### PR TITLE
Fix the six defects the first clean-machine run exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ thing that crosses a process boundary.
 | `-PromptTimeoutSeconds` | `60` | How long that prompt waits before starting anyway. |
 | `-DelayMinutes` | `60` | How long the "wait, then run" answer waits. |
 | `-Notify` | off | Show a toast when the run finishes, plus an urgent one if a restart is needed. Intended for scheduled runs. |
-| `-AllowInstall` | *(none)* | Which missing components may be installed: `All`, or any of `PowerShell7`, `PSWindowsUpdate`, `NuGetProvider`, `BurntToast`. |
+| `-AllowInstall` | *(none)* | Which missing components may be installed: `All`, or any of `PowerShell7`, `PSWindowsUpdate`, `NuGetProvider`, `BurntToast`, `PowerShellGet`. |
 | `-LogRetentionDays` | `30` | Prune logs and settings.json backups older than this. `0` keeps everything. |
 
 ## Channels covered
@@ -199,6 +199,7 @@ that was never there does, and the module will not do it silently.
 | `PSWindowsUpdate` | The PSWindowsUpdate module | **all users** | `-IncludeWindowsUpdate` |
 | `NuGetProvider` | The NuGet package provider | current user | reaching the PowerShell Gallery |
 | `BurntToast` | The BurntToast module | current user | `-Notify` |
+| `PowerShellGet` | PowerShellGet 2.x, replacing the 1.0.0.1 Windows ships | **all users** when elevated, else current user | module updates that see everything installed |
 
 Without `-AllowInstall`, an interactive run asks before each one and defaults to
 *No*. A non-interactive run never prompts and never installs. There is nobody to

--- a/src/Private/Get-PowerShellHostPath.ps1
+++ b/src/Private/Get-PowerShellHostPath.ps1
@@ -1,16 +1,37 @@
 ﻿function Get-PowerShellHostPath {
-    # Prefer PowerShell 7 when it is installed: the script runs on either, but
-    # pwsh is the host the rest of the toolchain assumes.
+    <#
+        .SYNOPSIS
+        The pwsh to bake into a scheduled task.
+
+        .DESCRIPTION
+        Prefer the MSI install. Resolving pwsh from PATH inside a packaged
+        session returns
+
+            ...\WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__8wekyb3d8bbwe\pwsh.exe
+
+        which carries the version, so it stops existing at the next PowerShell
+        update and takes the task with it. The app execution alias that also
+        resolves is no better: Task Scheduler cannot launch a zero-byte reparse
+        point.
+
+        Windows PowerShell remains the last resort, at a path that has not moved
+        in twenty years.
+    #>
     [CmdletBinding()]
     [OutputType([string])]
     param()
 
+    $msi = Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'
+    if (Test-Path -LiteralPath $msi) { return $msi }
+
     foreach ($candidate in 'pwsh', 'powershell') {
         $resolved = Get-Command $candidate -CommandType Application -ErrorAction SilentlyContinue |
+            Where-Object { -not (Test-PackagedProcess -Path $_.Source) } |
             Select-Object -First 1
         if ($resolved) { return $resolved.Source }
     }
 
-    # Last resort: the host running this script.
-    return (Get-Process -Id $PID).Path
+    # Last resort: the host running this script. Packaged or not, a task that
+    # names something is better than one that names nothing.
+    (Get-Process -Id $PID).Path
 }

--- a/src/Private/Invoke-SelfElevation.ps1
+++ b/src/Private/Invoke-SelfElevation.ps1
@@ -30,10 +30,29 @@
     # Prefer the current host executable. Some hosts report no path, so fall back
     # to whatever PowerShell can be resolved.
     $hostPath = (Get-Process -Id $PID).Path
+
+    # ...unless this host is the MSIX package, which Windows will not run
+    # elevated. The MSI build sits alongside it and can, so prefer that over
+    # failing. Test-ElevationCapability refuses the run outright when neither is
+    # available, so reaching here with no MSI means it was called directly.
+    if (Test-PackagedProcess -Path $hostPath) {
+        $msi = Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'
+        if (Test-Path -LiteralPath $msi) {
+            Write-Warning 'This PowerShell is the MSIX package, which Windows will not run elevated. Relaunching with the MSI build.'
+            $hostPath = $msi
+        } else {
+            throw 'Cannot self-elevate: this PowerShell is the MSIX build (the Store and winget default), and Windows does not run packaged apps elevated. Install the MSI build with "winget install --id Microsoft.PowerShell --exact --source winget --installer-type wix", or re-run with -SkipElevation.'
+        }
+    }
+
     if (-not $hostPath -or -not (Test-Path -LiteralPath $hostPath)) {
         $hostPath = $null
         foreach ($candidate in 'pwsh', 'powershell') {
+            # A packaged candidate is no better than a packaged host, and the
+            # alias in WindowsApps is a zero-byte reparse point Start-Process
+            # cannot launch at all.
             $resolved = Get-Command $candidate -CommandType Application -ErrorAction SilentlyContinue |
+                Where-Object { -not (Test-PackagedProcess -Path $_.Source) } |
                 Select-Object -First 1
             if ($resolved) { $hostPath = $resolved.Source; break }
         }

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -50,10 +50,17 @@
         # almost nothing in the step log. The ForEach-Object both accumulates the
         # output for inspection and passes it through, so the console and the
         # transcript still see it live during long-running steps.
+        # Out-String -Stream, then a single writer. Tee-Object -FilePath writes
+        # UTF-16LE in Windows PowerShell and has no -Encoding there, so it fought
+        # with Write-StepLog's ANSI over the same file and left every captured
+        # line as interleaved nulls. Out-String also renders the Format* records
+        # a table arrives as into the table itself, which writing the objects one
+        # at a time would not.
         $stepOutput = [System.Collections.Generic.List[object]]::new()
         & $Action *>&1 |
             ForEach-Object { $stepOutput.Add($_); $_ } |
-            Tee-Object -FilePath $stepLog -Append
+            Out-String -Stream |
+            ForEach-Object { Write-StepLog -Path $stepLog -Raw $_; $_ }
 
         $code = $LASTEXITCODE
         if ($null -ne $code -and $code -ne 0) {

--- a/src/Private/Set-PwshAsWindowsTerminalDefault.ps1
+++ b/src/Private/Set-PwshAsWindowsTerminalDefault.ps1
@@ -1,7 +1,13 @@
 ﻿function Set-PwshAsWindowsTerminalDefault {
     # Points Windows Terminal's defaultProfile at the PowerShell 7 (PowershellCore)
     # profile. Only the defaultProfile value is rewritten; nothing else is touched.
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of a console maintenance tool. Its output is progress a person watches, not data a caller consumes, and the summary uses colour to separate failures from noise.')]
+    #
+    # Write-Output, not Write-Host. This runs inside an Invoke-Step action, where
+    # *>&1 merges the information stream into the pipeline: Write-Host wrote to
+    # the console and emitted an InformationRecord that Out-Default then rendered
+    # again, so every line here appeared twice in the transcript -- once wrapped
+    # to console width, once not. Write-Host stays the right call in
+    # Update-Everything's own summary, which is not inside a step.
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Called from one step, which reports what it did and backs the file up before writing. The step, not this helper, is where a caller decides whether to proceed.')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'The parameter belongs to a MatchEvaluator delegate signature and must be declared whether or not the body reads it.')]
     param([Parameter(Mandatory)][string] $LogDir)
@@ -15,10 +21,10 @@
     $present = @($candidates | Where-Object { Test-Path -LiteralPath $_ })
     $settingsPath = if ($present.Count) { $present[0] } else { $null }
     if (-not $settingsPath) {
-        Write-Host 'Windows Terminal settings.json not found; Terminal not installed for this user. Skipping.'
+        Write-Output 'Windows Terminal settings.json not found; Terminal not installed for this user. Skipping.'
         return
     }
-    Write-Host "Windows Terminal settings: $settingsPath"
+    Write-Output "Windows Terminal settings: $settingsPath"
 
     # Terminal rewrites settings.json from memory when it exits, which silently
     # reverts an edit made while it is running.
@@ -49,9 +55,9 @@
     }
     if (-not $ps7Guid) {
         $ps7Guid = $wellKnownPwsh
-        Write-Host "No PowerShell Core profile present yet; using well-known GUID $ps7Guid (Terminal generates it on next launch)."
+        Write-Output "No PowerShell Core profile present yet; using well-known GUID $ps7Guid (Terminal generates it on next launch)."
     } else {
-        Write-Host "PowerShell 7 profile GUID: $ps7Guid"
+        Write-Output "PowerShell 7 profile GUID: $ps7Guid"
     }
 
     # Read the current value from the parsed object when possible, and from the
@@ -64,10 +70,10 @@
     }
 
     if ($current -eq $ps7Guid) {
-        Write-Host "Default profile is already PowerShell 7 ($ps7Guid). No change needed."
+        Write-Output "Default profile is already PowerShell 7 ($ps7Guid). No change needed."
         return
     }
-    Write-Host "Current default profile: $current"
+    Write-Output "Current default profile: $current"
 
     $backup = Join-Path $LogDir ("WindowsTerminal-settings-{0:yyyyMMdd-HHmmss}.json.bak" -f (Get-Date))
     try {
@@ -75,7 +81,7 @@
     } catch {
         throw "Could not back up settings.json to $backup; refusing to edit without a backup. $($_.Exception.Message)"
     }
-    Write-Host "Backed up settings.json -> $backup"
+    Write-Output "Backed up settings.json -> $backup"
 
     $newKv = '"defaultProfile": "' + $ps7Guid + '"'
     # Match any string value, not just a GUID. Terminal also accepts a profile
@@ -107,5 +113,5 @@
     } catch {
         throw "Could not write settings.json (is Windows Terminal holding the file?): $($_.Exception.Message)"
     }
-    Write-Host "Set Windows Terminal default profile to PowerShell 7 ($ps7Guid). Restart Windows Terminal to apply."
+    Write-Output "Set Windows Terminal default profile to PowerShell 7 ($ps7Guid). Restart Windows Terminal to apply."
 }

--- a/src/Private/Test-ElevationCapability.ps1
+++ b/src/Private/Test-ElevationCapability.ps1
@@ -31,6 +31,21 @@
         }
     }
 
+    # An MSIX PowerShell cannot be elevated at all: Windows does not run packaged
+    # apps elevated, and the app execution alias that also reaches it is a
+    # zero-byte reparse point rather than a program. Saying so here is this
+    # function's whole purpose -- otherwise the run raises a UAC prompt that
+    # cannot succeed and reports the failure as though the user had declined it.
+    # The MSI build, if it is installed alongside, can elevate, and
+    # Invoke-SelfElevation relaunches through it.
+    if ((Test-PackagedProcess) -and -not (Test-Path -LiteralPath (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'))) {
+        return [pscustomobject]@{
+            IsElevated = $false
+            CanElevate = $false
+            Reason     = 'This session is the MSIX build of PowerShell (the Store and winget default), and Windows does not run packaged apps elevated. Install the MSI build with "winget install --id Microsoft.PowerShell --exact --source winget --installer-type wix", start an elevated session yourself, or use -SkipElevation.'
+        }
+    }
+
     [pscustomobject]@{
         IsElevated = $false
         CanElevate = $true

--- a/src/Private/Test-PackagedProcess.ps1
+++ b/src/Private/Test-PackagedProcess.ps1
@@ -1,0 +1,41 @@
+﻿function Test-PackagedProcess {
+    <#
+        .SYNOPSIS
+        Whether an executable is MSIX-packaged, which Windows will not run
+        elevated.
+
+        .DESCRIPTION
+        winget has defaulted Microsoft.PowerShell to the MSIX installer since
+        7.6, so a machine can have a perfectly current pwsh that cannot
+        self-elevate at all. Two paths reach it and neither survives the RunAs
+        verb:
+
+          - the package binary under %ProgramFiles%\WindowsApps\Microsoft.PowerShell_<version>_...
+          - the app execution alias in %LOCALAPPDATA%\Microsoft\WindowsApps,
+            which is a zero-byte reparse point rather than a program
+
+        The package path also carries the version, so it stops existing at the
+        next PowerShell update. That makes it the wrong thing to bake into a
+        scheduled task as well, which is why Get-PowerShellHostPath asks too.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        # Defaults to the current host. Passed explicitly when testing a
+        # candidate that is not this process.
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $Path = (Get-Process -Id $PID).Path
+    )
+
+    if (-not $Path) { return $false }
+
+    # Compared as path segments, not as a substring: a folder merely named
+    # "WindowsApps" somewhere else on disk is not a packaged install.
+    foreach ($root in @("$env:ProgramFiles\WindowsApps", "$env:LOCALAPPDATA\Microsoft\WindowsApps")) {
+        if (-not $root) { continue }
+        if ($Path -like (Join-Path $root '*')) { return $true }
+    }
+
+    $false
+}

--- a/src/Private/Test-ParameterSupport.ps1
+++ b/src/Private/Test-ParameterSupport.ps1
@@ -1,0 +1,30 @@
+﻿function Test-ParameterSupport {
+    <#
+        .SYNOPSIS
+        Whether the command that resolves in this session has the named parameter.
+
+        .DESCRIPTION
+        Windows PowerShell ships PowerShellGet 1.0.0.1, which predates
+        -AcceptLicense on Install-Module and Update-Module. Splatting it there is
+        a terminating error, and it took out both the "PowerShell modules" and
+        "Windows Update" steps on a 5.1 run.
+
+        Comparing module versions would be the wrong test. What matters is the
+        command that actually binds in this session, and that follows
+        PSModulePath order rather than the highest version installed.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Command,
+
+        [Parameter(Mandatory)]
+        [string] $Parameter
+    )
+
+    $resolved = Get-Command $Command -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $resolved) { return $false }
+
+    $resolved.Parameters.ContainsKey($Parameter)
+}

--- a/src/Private/Write-StepLog.ps1
+++ b/src/Private/Write-StepLog.ps1
@@ -1,12 +1,50 @@
 ﻿function Write-StepLog {
-    # Logging must never be the thing that kills a run, so failures here degrade
-    # to a warning rather than propagating.
+    <#
+        .SYNOPSIS
+        Appends a line to a step log, in one explicit encoding.
+
+        .DESCRIPTION
+        The encoding is explicit because it has to be. Add-Content defaults to
+        ANSI in Windows PowerShell, and Tee-Object -FilePath writes UTF-16LE
+        there with no -Encoding parameter to override it. A step log written by
+        both came out half readable text and half interleaved nulls:
+
+            2026-08-29 21:15:14 | STARTING Trust PSGallery
+            P S G a l l e r y   ( P o w e r S h e l l G e t   v 2 )   s e t ...
+
+        Logging must never be the thing that kills a run, so failures here
+        degrade to a warning rather than propagating.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Stamped')]
     param(
-        [Parameter(Mandatory)][string] $Path,
-        [Parameter(Mandatory)][string] $Message
+        [Parameter(Mandatory)]
+        [string] $Path,
+
+        # A status line. Timestamped, because these are the lines someone greps.
+        [Parameter(Mandatory, ParameterSetName = 'Stamped')]
+        [string] $Message,
+
+        # Captured step output, already rendered to text. Written verbatim: a
+        # timestamp per line would wreck the layout of anything drawing a table.
+        [Parameter(Mandatory, ParameterSetName = 'Raw')]
+        [AllowEmptyString()]
+        [string] $Raw
     )
+
+    $text = if ($PSCmdlet.ParameterSetName -eq 'Raw') {
+        $Raw
+    } else {
+        '{0:yyyy-MM-dd HH:mm:ss} | {1}' -f (Get-Date), $Message
+    }
+
     try {
-        Add-Content -LiteralPath $Path -Value ('{0:yyyy-MM-dd HH:mm:ss} | {1}' -f (Get-Date), $Message) -ErrorAction Stop
+        # AppendAllText rather than Add-Content: it takes the encoding as an
+        # argument on both editions, where Add-Content -Encoding utf8 means
+        # "with BOM" on 5.1 and "without" on 7.
+        [System.IO.File]::AppendAllText(
+            $Path,
+            $text + [Environment]::NewLine,
+            [System.Text.UTF8Encoding]::new($false))
     } catch {
         Write-Warning "Could not write to step log '$Path': $($_.Exception.Message)"
     }

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -64,7 +64,7 @@
         Approvals to pass through for first-time installs. A scheduled run cannot
         prompt, so anything not approved here is declined and its step reported
         as skipped. Accepts All, PowerShell7, PSWindowsUpdate, NuGetProvider,
-        BurntToast.
+        BurntToast, PowerShellGet.
 
     .PARAMETER WindowStyle
         How the run's console window appears: Normal (default), Minimized or
@@ -129,7 +129,7 @@
 
         [bool] $Notify = $true,
 
-        [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast')]
+        [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet')]
         [string[]] $AllowInstall = @(),
 
         [ValidateSet('Normal', 'Minimized', 'Hidden')]

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -408,7 +408,13 @@
                 if ($LASTEXITCODE -ne 0) { $global:LASTEXITCODE = 0 }
                 Write-Output "Installed pwsh version: $reported"
             } else {
-                Write-Output "Note: $exe not found after the winget step (an MSIX install lands elsewhere)."
+                # The install branch forces --installer-type wix, but the upgrade
+                # branch cannot convert a PowerShell that is already packaged, so
+                # say what it costs and how to switch. An MSIX pwsh works fine for
+                # everything except elevating and being named in a scheduled task,
+                # which are two things this module needs.
+                Write-Output "Note: $exe not found, so PowerShell 7 here is the MSIX package. It runs normally, but Windows will not elevate it and its path changes at every update, so scheduled tasks cannot rely on it."
+                Write-Output 'To switch: winget install --id Microsoft.PowerShell --exact --source winget --installer-type wix'
             }
         }
     } else {

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -952,6 +952,13 @@
         Write-Host '[!] Notifications were requested but could not be sent.' -ForegroundColor Yellow
         Write-Host "    Reason: $($notificationStatus.Reason)" -ForegroundColor Yellow
         Write-Host '    The update run itself was unaffected.' -ForegroundColor Yellow
+    } elseif (-not $Notify) {
+        # Say that nothing was asked for. Without this the run is simply silent
+        # about notifications, which reads as a broken feature rather than an
+        # unrequested one -- and sends people looking for a BurntToast prompt
+        # that was never going to appear.
+        Write-Host ''
+        Write-Host 'Notifications: not requested. Pass -Notify for a toast when the run finishes.' -ForegroundColor DarkGray
     }
 
     Write-Host "Finished $(Get-Date). Detailed logs saved to: $logDir" -ForegroundColor Green

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -491,11 +491,20 @@
             Update-PSResource @p
         } elseif (Get-Command Update-Module -ErrorAction SilentlyContinue) {
             $p = @{
-                Force         = $true
-                AcceptLicense = $true
-                Confirm       = $false
-                ErrorAction   = 'SilentlyContinue'
+                Force       = $true
+                Confirm     = $false
+                ErrorAction = 'SilentlyContinue'
             }
+
+            # PowerShellGet 1.0.0.1 -- the version Windows PowerShell ships -- has
+            # no -AcceptLicense, and splatting a parameter that does not exist is a
+            # terminating error, so this step used to fail outright on 5.1.
+            if (Test-ParameterSupport -Command 'Update-Module' -Parameter 'AcceptLicense') {
+                $p.AcceptLicense = $true
+            } else {
+                Write-Output 'PowerShellGet on this host predates -AcceptLicense; continuing without it. A module that requires accepting a license will be skipped rather than prompt.'
+            }
+
             if ($IncludePrerelease) { $p.AllowPrerelease = $true }
             Update-Module @p
         } else {
@@ -776,8 +785,22 @@
                 }
 
                 try {
-                    Install-Module PSWindowsUpdate -Force -Scope AllUsers -AcceptLicense `
-                        -AllowClobber -Confirm:$false -ErrorAction Stop
+                    $install = @{
+                        Name         = 'PSWindowsUpdate'
+                        Force        = $true
+                        Scope        = 'AllUsers'
+                        AllowClobber = $true
+                        Confirm      = $false
+                        ErrorAction  = 'Stop'
+                    }
+
+                    # Same reason as the module-update step: the PowerShellGet
+                    # Windows ships has no -AcceptLicense to splat.
+                    if (Test-ParameterSupport -Command 'Install-Module' -Parameter 'AcceptLicense') {
+                        $install.AcceptLicense = $true
+                    }
+
+                    Install-Module @install
                 } catch {
                     throw "Failed to install PSWindowsUpdate module: $_"
                 }

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -99,6 +99,10 @@
           PSWindowsUpdate  install the PSWindowsUpdate module (AllUsers scope)
           NuGetProvider    install the NuGet package provider (CurrentUser)
           BurntToast       install the BurntToast module for -Notify (CurrentUser)
+          PowerShellGet    replace the PowerShellGet 1.0.0.1 Windows ships with
+                           2.x, which can accept module licenses and can see
+                           modules installed by newer versions (AllUsers when
+                           elevated, otherwise CurrentUser)
 
         A scheduled task cannot prompt, so pass the approvals it should have:
             -AllowInstall PSWindowsUpdate,BurntToast
@@ -184,7 +188,7 @@
         [ValidateRange(1, 1440)]
         [int]    $DelayMinutes            = 60,
         [switch] $Notify,
-        [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast')]
+        [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet')]
         [string[]] $AllowInstall = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30
@@ -494,6 +498,37 @@
                 Write-Output 'PSGallery (PowerShellGet v2) set to Trusted.'
             } else {
                 Write-Output 'PSGallery (PowerShellGet v2) already Trusted.'
+            }
+        }
+
+        # Windows PowerShell ships PowerShellGet 1.0.0.1 and never updates it.
+        # Test-ParameterSupport keeps that version from failing the module step
+        # outright, but it cannot fix the deeper problem: v1 does not see modules
+        # installed by v2, so Update-Module on 5.1 quietly skips most of what is
+        # actually installed. Offer the upgrade rather than assuming it.
+        #
+        # Declining is not fatal here, unlike the NuGet provider above: trust has
+        # already been set, and the module step still runs on v1.
+        # Indexed rather than "| Select-Object -First 1": that halts the upstream
+        # pipeline, and inside a step action the transcript records the stop as a
+        # TerminatingError.
+        $psgetAll = @(Get-Module PowerShellGet -ListAvailable | Sort-Object Version -Descending)
+        $psget    = if ($psgetAll.Count) { $psgetAll[0] } else { $null }
+
+        if ($psget -and $psget.Version -lt [version]'2.0.0') {
+            Write-Output "PowerShellGet $($psget.Version) is the version Windows ships."
+
+            # This step is not admin-gated, and -Scope AllUsers fails without
+            # elevation, so the scope follows what the run actually has.
+            $scope = if ($isAdmin) { 'AllUsers' } else { 'CurrentUser' }
+            $where = if ($isAdmin) { 'for all users on this machine' } else { 'for the current user only' }
+
+            if (Approve-Install -Component 'PowerShellGet' -Approved $AllowInstall `
+                    -Description "PowerShellGet $($psget.Version) cannot accept module licenses and does not see modules installed by newer versions, so module updates on this host will miss most of what is installed. This would install PowerShellGet 2.x from the PowerShell Gallery $where.") {
+
+                Install-Module PowerShellGet -Force -AllowClobber -Scope $scope `
+                    -Confirm:$false -ErrorAction Stop
+                Write-Output "Installed PowerShellGet 2.x ($scope). It takes effect in the next session; this run continues on the version already loaded."
             }
         }
     }

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -194,35 +194,17 @@
     # the private helpers read them as $script:. Inside a module a plain
     # assignment is function-scoped, so Invoke-Step would read an unset
     # $script:logDir and fail on every single step.
-    $script:isAdmin = Test-IsAdministrator
-    if (-not $isAdmin -and -not $SkipElevation) {
-        # Ask whether elevation is possible before asking for it. Without this the
-        # script raises a UAC prompt a standard user can never satisfy, and reports
-        # the refusal as though the user had declined it.
-        $elevation = Test-ElevationCapability
-        if (-not $elevation.CanElevate) {
-            Write-Warning "Cannot run elevated: $($elevation.Reason)"
-            Write-Warning 'Nothing has been changed. Re-run with -SkipElevation to run the steps that do not need administrator rights.'
-            return (New-UpdateEverythingResult -Ran $false -Reason $elevation.Reason)
-        }
-
-        # A module function must not kill the session it was called from, so the
-        # elevated child's outcome comes back as a result rather than an exit.
-        $child = Invoke-SelfElevation -BoundParameters $PSBoundParameters
-        return (New-UpdateEverythingResult -Ran $false -Elevated `
-            -Reason "Re-ran elevated in a separate window, which finished with exit code $child." `
-            -FailedCount ([int] $child))
-    }
-
-    if (-not $isAdmin) {
-        Write-Warning 'Running without administrator rights. Steps that require admin will be skipped and listed in the summary.'
-    }
-
     # TLS: no hardcoded override. Modern Windows/PowerShell negotiates TLS 1.2/1.3 automatically.
     $originalOutputEncoding = Initialize-ConsoleEncoding
 
     # ---------------------------------------------------------------------------
     # 1. Logging
+    #
+    # Before the elevation decision, not after it. Logging used to start once
+    # elevation had already succeeded, so every way this run could decline to
+    # start -- a standard user, UAC switched off, a host that cannot be elevated
+    # at all -- produced no log whatsoever. A PowerShell 7 run that could not
+    # elevate left nothing behind to read, and never would have.
     # ---------------------------------------------------------------------------
     $script:logDir = Get-UpdateLogDirectory
 
@@ -248,6 +230,40 @@
         $transcriptRunning = $true
     } catch {
         Write-Warning "Transcript unavailable ($($_.Exception.Message)); per-step logs are unaffected."
+    }
+
+    $script:isAdmin = Test-IsAdministrator
+    if (-not $isAdmin -and -not $SkipElevation) {
+        # Ask whether elevation is possible before asking for it. Without this the
+        # script raises a UAC prompt a standard user can never satisfy, and reports
+        # the refusal as though the user had declined it.
+        $elevation = Test-ElevationCapability
+        if (-not $elevation.CanElevate) {
+            Write-Warning "Cannot run elevated: $($elevation.Reason)"
+            Write-Warning 'Nothing has been changed. Re-run with -SkipElevation to run the steps that do not need administrator rights.'
+
+            if ($transcriptRunning) { try { Stop-Transcript | Out-Null } catch { Write-Verbose "Transcript already stopped." } }
+            try { [Console]::OutputEncoding = $originalOutputEncoding } catch { Write-Verbose "Could not restore the console encoding." }
+
+            return (New-UpdateEverythingResult -Ran $false -Reason $elevation.Reason `
+                -LogDirectory $logDir -MainLog $mainLog)
+        }
+
+        # A module function must not kill the session it was called from, so the
+        # elevated child's outcome comes back as a result rather than an exit.
+        $child = Invoke-SelfElevation -BoundParameters $PSBoundParameters
+
+        if ($transcriptRunning) { try { Stop-Transcript | Out-Null } catch { Write-Verbose "Transcript already stopped." } }
+        try { [Console]::OutputEncoding = $originalOutputEncoding } catch { Write-Verbose "Could not restore the console encoding." }
+
+        return (New-UpdateEverythingResult -Ran $false -Elevated `
+            -Reason "Re-ran elevated in a separate window, which finished with exit code $child." `
+            -FailedCount ([int] $child) `
+            -LogDirectory $logDir -MainLog $mainLog)
+    }
+
+    if (-not $isAdmin) {
+        Write-Warning 'Running without administrator rights. Steps that require admin will be skipped and listed in the summary.'
     }
 
     # Notifications are resolved before any work starts, not after it. A warning

--- a/tests/InstallConsent.Tests.ps1
+++ b/tests/InstallConsent.Tests.ps1
@@ -223,13 +223,25 @@ Describe 'Every install site is gated' -Tag 'Static','Consent' {
     }
 
     It 'guards the winget install of PowerShell 7' {
-        # winget is a native command, so it is matched as text rather than AST.
+        # The AST, not a text search. winget is a native command but still parses
+        # as a CommandAst, and matching text instead would also hit the string
+        # literal that prints the command as advice -- which installs nothing.
+        $installs = @($script:Ast.FindAll({
+                    param($node)
+                    $node -is [System.Management.Automation.Language.CommandAst] -and
+                    $node.GetCommandName() -eq 'winget' -and
+                    @($node.CommandElements | ForEach-Object { $_.Extent.Text }) -contains 'install'
+                }, $true))
+
+        $installs | Should-NotBeNull -Because 'the PowerShell 7 install should still exist'
+
         $lines = $script:Source -split "`r?`n"
-        $index = ($lines | Select-String -Pattern 'winget install --id' -SimpleMatch:$false).LineNumber
+        $ungated = foreach ($call in $installs) {
+            $line   = $call.Extent.StartLineNumber
+            $window = ($lines[[Math]::Max(0, $line - 13)..($line - 1)]) -join "`n"
+            if ($window -notmatch 'Approve-Install') { "line ${line}: $($call.Extent.Text)" }
+        }
 
-        $index | Should-NotBeNull -Because 'the PowerShell 7 install should still exist'
-
-        $window = ($lines[[Math]::Max(0, $index - 12)..($index - 1)]) -join "`n"
-        $window | Should-MatchString 'Approve-Install'
+        $ungated | Should-BeNull -Because "these install without asking:`n$($ungated -join "`n")"
     }
 }

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -267,6 +267,60 @@ Describe 'Shared run state' -Tag 'Static','Module' {
     }
 }
 
+Describe 'Logging starts before the run can decline to start' -Tag 'Static','Module' {
+
+    # Logging used to be set up after elevation succeeded, so every path that
+    # ended the run early produced no log at all. A PowerShell 7 run that could
+    # not elevate left nothing behind to read, which is exactly the case someone
+    # would go looking for a log to explain.
+
+    BeforeAll {
+        $script:Source = Get-Content $script:MainPath -Raw
+
+        $script:LineOf = {
+            param($pattern)
+            ($script:Source -split "`r?`n" | Select-String -Pattern $pattern |
+                Select-Object -First 1).LineNumber
+        }
+    }
+
+    It 'starts the transcript before testing whether it can elevate' {
+        $transcript = & $script:LineOf 'Start-Transcript'
+        $elevation  = & $script:LineOf 'Test-ElevationCapability'
+
+        $transcript | Should-BeLessThan $elevation
+    }
+
+    It 'resolves the log directory before testing whether it can elevate' {
+        $logDir    = & $script:LineOf '\$script:logDir\s*=\s*Get-UpdateLogDirectory'
+        $elevation = & $script:LineOf 'Test-ElevationCapability'
+
+        $logDir | Should-BeLessThan $elevation
+    }
+
+    It 'starts the transcript before handing off to an elevated child' {
+        $transcript = & $script:LineOf 'Start-Transcript'
+        $elevate    = & $script:LineOf 'Invoke-SelfElevation'
+
+        $transcript | Should-BeLessThan $elevate
+    }
+
+    # Opening a transcript and returning without closing it leaves it running in
+    # the caller's session, where it silently records everything they do next.
+    It 'stops the transcript on every early return' {
+        $starts = ([regex]::Matches($script:Source, 'Start-Transcript')).Count
+        $stops  = ([regex]::Matches($script:Source, 'Stop-Transcript')).Count
+
+        $stops | Should-BeGreaterThanOrEqual 3 -Because "one per early return plus the normal end; found $starts start(s) and $stops stop(s)"
+    }
+
+    It 'reports the log location even when nothing ran' {
+        # Both early returns take -LogDirectory now, so the caller can find the
+        # transcript that explains the refusal.
+        $script:Source | Should-MatchString '-Ran \$false -Reason \$elevation\.Reason `\r?\n\s*-LogDirectory \$logDir -MainLog \$mainLog'
+    }
+}
+
 Describe 'Update-Everything' -Tag 'Static' {
 
     Context 'Parameter contract' {

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -387,15 +387,59 @@ Describe 'Format-LastRunResult' -Tag 'Unit' {
 
 Describe 'Get-PowerShellHostPath' -Tag 'Unit' {
 
+    # This path is baked into a scheduled task, so it has to still exist months
+    # later. A packaged pwsh resolves to
+    # ...\WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__8wekyb3d8bbwe\pwsh.exe,
+    # which carries the version and disappears at the next update, and the app
+    # execution alias beside it is a zero-byte reparse point Task Scheduler
+    # cannot launch. Neither is a thing to write into a task definition.
+
     It 'returns a path that exists' {
         Test-Path -LiteralPath (Get-PowerShellHostPath) | Should-BeTrue
     }
 
-    It 'prefers pwsh when it is installed' -Skip:(-not (Get-Command pwsh -CommandType Application -ErrorAction SilentlyContinue)) {
-        Get-PowerShellHostPath | Should-MatchString 'pwsh\.exe$'
+    It 'prefers the MSI install, whose path does not move' {
+        Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+
+        Get-PowerShellHostPath | Should-Be (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe')
+    }
+
+    It 'prefers an unpackaged pwsh on PATH when there is no MSI install' {
+        Mock Test-Path { $false } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+        Mock Get-Command { [pscustomobject]@{ Source = 'D:\tools\pwsh.exe' } } `
+            -ParameterFilter { $Name -eq 'pwsh' }
+
+        Get-PowerShellHostPath | Should-Be 'D:\tools\pwsh.exe'
+    }
+
+    # The regression: a task registered on an MSIX-only machine used to name a
+    # version-stamped WindowsApps path and die at the next PowerShell update.
+    # Windows PowerShell at a path that has not moved in twenty years is the
+    # better answer, and the module supports 5.1 anyway.
+    It 'skips a packaged pwsh in favour of Windows PowerShell' {
+        Mock Test-Path { $false } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+        Mock Get-Command {
+            [pscustomobject]@{ Source = "$env:ProgramFiles\WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__8wekyb3d8bbwe\pwsh.exe" }
+        } -ParameterFilter { $Name -eq 'pwsh' }
+        Mock Get-Command { [pscustomobject]@{ Source = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' } } `
+            -ParameterFilter { $Name -eq 'powershell' }
+
+        Get-PowerShellHostPath | Should-MatchString 'powershell\.exe$'
+    }
+
+    It 'never returns an app execution alias' {
+        Mock Test-Path { $false } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+        Mock Get-Command {
+            [pscustomobject]@{ Source = "$env:LOCALAPPDATA\Microsoft\WindowsApps\pwsh.exe" }
+        } -ParameterFilter { $Name -eq 'pwsh' }
+        Mock Get-Command { [pscustomobject]@{ Source = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' } } `
+            -ParameterFilter { $Name -eq 'powershell' }
+
+        Get-PowerShellHostPath | Should-NotMatchString 'WindowsApps'
     }
 
     It 'falls back to Windows PowerShell when pwsh is absent' {
+        Mock Test-Path { $false } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
         Mock Get-Command { } -ParameterFilter { $Name -eq 'pwsh' }
         Mock Get-Command { [pscustomobject]@{ Source = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' } } `
             -ParameterFilter { $Name -eq 'powershell' }

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -571,6 +571,49 @@ Describe 'The gallery steps never splat a parameter blindly' -Tag 'Static' {
     }
 }
 
+Describe 'Test-PackagedProcess' -Tag 'Unit','Security' {
+
+    It 'recognises the package binary under WindowsApps' {
+        Test-PackagedProcess -Path "$env:ProgramFiles\WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__8wekyb3d8bbwe\pwsh.exe" |
+            Should-BeTrue
+    }
+
+    # The alias is a zero-byte reparse point, not a program. Start-Process
+    # cannot launch it and Task Scheduler cannot either.
+    It 'recognises the app execution alias' {
+        Test-PackagedProcess -Path "$env:LOCALAPPDATA\Microsoft\WindowsApps\pwsh.exe" |
+            Should-BeTrue
+    }
+
+    It 'accepts the MSI install as unpackaged' {
+        Test-PackagedProcess -Path "$env:ProgramFiles\PowerShell\7\pwsh.exe" |
+            Should-BeFalse
+    }
+
+    It 'accepts Windows PowerShell as unpackaged' {
+        Test-PackagedProcess -Path "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe" |
+            Should-BeFalse
+    }
+
+    # A substring test would call this packaged. It is an ordinary folder that
+    # happens to share a name, and refusing to elevate over it would be wrong.
+    It 'does not match a folder merely named WindowsApps elsewhere' {
+        Test-PackagedProcess -Path 'D:\Backup\WindowsApps\pwsh.exe' | Should-BeFalse
+    }
+
+    It 'treats an empty path as unpackaged rather than throwing' {
+        Test-PackagedProcess -Path '' | Should-BeFalse
+    }
+
+    It 'treats a null path as unpackaged rather than throwing' {
+        Test-PackagedProcess -Path $null | Should-BeFalse
+    }
+
+    It 'returns a real boolean' {
+        Test-PackagedProcess -Path 'C:\nowhere\pwsh.exe' | Should-HaveType ([bool])
+    }
+}
+
 Describe 'Test-UacEnabled' -Tag 'Unit','Security' {
 
     It 'reports enabled when EnableLUA is 1' {
@@ -651,6 +694,10 @@ Describe 'Test-ElevationCapability' -Tag 'Unit','Security' {
             Mock Test-IsAdministrator { $false }
             Mock Test-AdministratorGroupMember { $true }
             Mock Test-UacEnabled { $true }
+            # Mocked rather than left to the real host: whether the developer's
+            # own PowerShell came from the Store decides this answer otherwise,
+            # and a test that passes or fails on that is not testing anything.
+            Mock Test-PackagedProcess { $false }
         }
 
         It 'allows elevation to be attempted' {
@@ -659,6 +706,56 @@ Describe 'Test-ElevationCapability' -Tag 'Unit','Security' {
 
         It 'does not claim the session is already elevated' {
             (Test-ElevationCapability).IsElevated | Should-BeFalse
+        }
+    }
+
+    # winget has defaulted Microsoft.PowerShell to the MSIX installer since 7.6,
+    # so this is the ordinary state of a machine that installed pwsh the obvious
+    # way. Windows does not run packaged apps elevated, and the run used to
+    # discover that by raising a UAC prompt that could not succeed and then
+    # reporting the failure as though the user had declined it.
+    Context 'An MSIX PowerShell with no MSI build installed' {
+
+        BeforeEach {
+            Mock Test-IsAdministrator { $false }
+            Mock Test-AdministratorGroupMember { $true }
+            Mock Test-UacEnabled { $true }
+            Mock Test-PackagedProcess { $true }
+            Mock Test-Path { $false } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+        }
+
+        It 'refuses rather than raising a prompt that cannot succeed' {
+            (Test-ElevationCapability).CanElevate | Should-BeFalse
+        }
+
+        It 'names the packaged build as the reason' {
+            (Test-ElevationCapability).Reason | Should-MatchString 'MSIX'
+        }
+
+        It 'gives the command that installs a build which can elevate' {
+            (Test-ElevationCapability).Reason | Should-MatchString 'installer-type wix'
+        }
+
+        It 'still offers -SkipElevation as the way forward' {
+            (Test-ElevationCapability).Reason | Should-MatchString 'SkipElevation'
+        }
+    }
+
+    # The MSI build sits at a fixed path and can elevate, so a packaged host is
+    # only a dead end when nothing else is installed. Invoke-SelfElevation
+    # relaunches through the MSI in this case.
+    Context 'An MSIX PowerShell with the MSI build alongside it' {
+
+        BeforeEach {
+            Mock Test-IsAdministrator { $false }
+            Mock Test-AdministratorGroupMember { $true }
+            Mock Test-UacEnabled { $true }
+            Mock Test-PackagedProcess { $true }
+            Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*PowerShell\7\pwsh.exe' }
+        }
+
+        It 'allows elevation to be attempted' {
+            (Test-ElevationCapability).CanElevate | Should-BeTrue
         }
     }
 
@@ -673,6 +770,7 @@ Describe 'Test-ElevationCapability' -Tag 'Unit','Security' {
             Mock Test-IsAdministrator { $false }
             Mock Test-AdministratorGroupMember { $null }
             Mock Test-UacEnabled { $true }
+            Mock Test-PackagedProcess { $false }
         }
 
         It 'attempts elevation rather than refusing' {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -643,6 +643,48 @@ Describe 'Test-PackagedProcess' -Tag 'Unit','Security' {
     }
 }
 
+Describe 'The PowerShellGet upgrade offer' -Tag 'Static' {
+
+    # PowerShellGet 1.0.0.1 is what Windows ships and it never updates itself.
+    # Test-ParameterSupport stops it failing the module step, but it cannot fix
+    # the deeper problem: v1 does not see modules installed by v2, so
+    # Update-Module on 5.1 quietly skips most of what is actually installed.
+
+    BeforeAll {
+        $script:MainSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    It 'is gated behind the same consent prompt as every other install' {
+        $script:MainSource | Should-MatchString "Approve-Install -Component 'PowerShellGet'"
+    }
+
+    It 'only fires when the installed version predates 2.0' {
+        $script:MainSource | Should-MatchString "\`$psget\.Version -lt \[version\]'2\.0\.0'"
+    }
+
+    # The Trust PSGallery step carries no -RequiresAdmin, and -Scope AllUsers
+    # fails without elevation, so an unelevated run has to fall back rather than
+    # throw in a step that was working fine before.
+    It 'installs to AllUsers only when the run is elevated' {
+        $script:MainSource | Should-MatchString "if \(\`$isAdmin\) \{ 'AllUsers' \} else \{ 'CurrentUser' \}"
+    }
+
+    # Declining is not fatal here: trust is already set and the module step still
+    # runs on v1, unlike the NuGet provider which the step cannot work without.
+    It 'does not abort the step when the offer is declined' {
+        $script:MainSource | Should-NotMatchString "PowerShellGet'[\s\S]{0,400}Stop-StepAsSkipped"
+    }
+
+    It 'is accepted by -AllowInstall on both entry points' -ForEach @(
+        'src\Public\Update-Everything.ps1'
+        'src\Public\Register-UpdateEverythingTask.ps1'
+    ) {
+        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) $_) -Raw |
+            Should-MatchString "ValidateSet\('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet'\)"
+    }
+}
+
 Describe 'Test-UacEnabled' -Tag 'Unit','Security' {
 
     It 'reports enabled when EnableLUA is 1' {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -685,6 +685,32 @@ Describe 'The PowerShellGet upgrade offer' -Tag 'Static' {
     }
 }
 
+Describe 'The summary says notifications were not requested' -Tag 'Static' {
+
+    # -Notify defaults to off, so a run that does not pass it never reaches
+    # Initialize-NotificationSupport and never offers to install BurntToast.
+    # That is correct, but the run said nothing at all about it, which reads as
+    # a broken feature rather than an unrequested one, and sends people looking
+    # for a consent prompt that was never going to appear.
+
+    It 'reports the unrequested case rather than staying silent' {
+        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw |
+            Should-MatchString 'Notifications: not requested'
+    }
+
+    It 'names the switch that turns them on' {
+        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw |
+            Should-MatchString 'Notifications: not requested[^\r\n]*-Notify'
+    }
+
+    # The existing branch reports notifications that were asked for and could not
+    # be sent. This must not swallow it.
+    It 'still reports notifications that were requested but unavailable' {
+        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw |
+            Should-MatchString 'Notifications were requested but could not be sent'
+    }
+}
+
 Describe 'Test-UacEnabled' -Tag 'Unit','Security' {
 
     It 'reports enabled when EnableLUA is 1' {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -405,6 +405,113 @@ Describe 'Write-StepLog' -Tag 'Unit' {
 
         $warnings | Should-NotBeNull
     }
+
+    It 'writes -Raw text through without a timestamp' {
+        $log = Join-Path $TestDrive 'raw.log'
+        Write-StepLog -Path $log -Raw '    Name      Id'
+
+        Get-Content $log -Raw | Should-MatchString '^ {4}Name {6}Id'
+    }
+
+    It 'accepts an empty -Raw line, which output is full of' {
+        $log = Join-Path $TestDrive 'rawempty.log'
+        Write-StepLog -Path $log -Raw ''
+        Write-StepLog -Path $log -Raw 'after'
+
+        (Get-Content $log) | Should-BeCollection -Count 2
+    }
+}
+
+Describe 'Step logs are written in one encoding' -Tag 'Unit' {
+
+    # The bug: Tee-Object -FilePath writes UTF-16LE on Windows PowerShell and has
+    # no -Encoding there, while Write-StepLog's Add-Content wrote ANSI. Both hit
+    # the same file, so every captured line arrived as interleaved nulls --
+    # "P S G a l l e r y   ( P o w e r S h e l l G e t   v 2 )". A NUL byte is
+    # the tell, and it is what this asserts on.
+
+    BeforeEach {
+        $script:logDir   = Join-Path $TestDrive ('enc-' + [guid]::NewGuid().ToString('N'))
+        $null            = New-Item -ItemType Directory -Path $script:logDir -Force
+        $script:runStamp = 'encstamp'
+        $script:Results  = [System.Collections.Generic.List[object]]::new()
+    }
+
+    It 'keeps the captured text readable end to end' {
+        Invoke-Step -Name 'enc' -Action { 'PSGallery set to Trusted.' } 6>$null
+
+        Get-Content (Join-Path $script:logDir 'enc-encstamp.log') -Raw |
+            Should-MatchString 'PSGallery set to Trusted\.'
+    }
+
+    # Objects reach a step log as the Format* records that render a table, not as
+    # text. Writing them one at a time would log nothing useful.
+    It 'renders a table rather than its format records' {
+        Invoke-Step -Name 'enc' -Action {
+            [pscustomobject]@{ Alpha = 1; Beta = 'two' } | Format-Table -AutoSize
+        } 6>$null
+
+        $text = Get-Content (Join-Path $script:logDir 'enc-encstamp.log') -Raw
+        $text | Should-MatchString 'Alpha Beta'
+        $text | Should-MatchString '1 two'
+    }
+
+    # The status lines and the captured output are written by the same function
+    # now, so the two halves of the file have to agree.
+    It 'writes the status lines in the same encoding as the output' {
+        Invoke-Step -Name 'enc' -Action { 'work' } 6>$null
+
+        $text = Get-Content (Join-Path $script:logDir 'enc-encstamp.log') -Raw
+        $text | Should-MatchString 'STARTING enc'
+        $text | Should-MatchString 'COMPLETED \| Duration:'
+    }
+
+    # This is the one that would have caught the bug, and it only can from 5.1.
+    # Tee-Object -FilePath defaults to UTF-16LE there and takes no -Encoding to
+    # say otherwise; on 7 it writes UTF-8 and the same code looks fine. The suite
+    # runs on 7, so without shelling out nothing here would ever notice.
+    It 'leaves no NUL bytes in a step log written by Windows PowerShell' -Skip:(-not (Get-Command powershell.exe -ErrorAction SilentlyContinue)) {
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) ('ue-enc-' + [guid]::NewGuid().ToString('N'))
+        $null = New-Item -ItemType Directory -Path $dir -Force
+
+        try {
+            $child = @"
+Get-ChildItem '$script:ModuleRoot\Private\*.ps1' | ForEach-Object { . `$_.FullName }
+`$script:logDir   = '$dir'
+`$script:runStamp = 'enc'
+`$script:Results  = [System.Collections.Generic.List[object]]::new()
+Invoke-Step -Name 'step' -Action { 'PSGallery set to Trusted.' } 6>`$null | Out-Null
+`$bytes = [System.IO.File]::ReadAllBytes((Join-Path '$dir' 'step-enc.log'))
+'NULS=' + @(`$bytes | Where-Object { `$_ -eq 0 }).Count
+"@
+            $output = & powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $child
+
+            ($output -join ' ') | Should-MatchString 'NULS=0'
+        } finally {
+            Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'Invoke-Step does not use the writer that caused the encoding split' -Tag 'Static' {
+
+    # A behavioural guard cannot see this from PowerShell 7, where Tee-Object
+    # writes UTF-8 and the bug is invisible. Naming the construct is what keeps
+    # it from coming back on the edition where it does damage.
+    # The AST, not a text search: the comment explaining why Tee-Object is gone
+    # names it, and a regex over the source cannot tell a comment from a call.
+    It 'never writes the step log with Tee-Object' {
+        $path = Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Invoke-Step.ps1'
+        $ast  = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref] $null, [ref] $null)
+
+        $calls = $ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -eq 'Tee-Object'
+            }, $true)
+
+        $calls | Should-BeNull -Because 'Tee-Object writes UTF-16LE on 5.1 and takes no -Encoding there'
+    }
 }
 
 Describe 'Test-ParameterSupport' -Tag 'Unit' {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -514,6 +514,35 @@ Describe 'Invoke-Step does not use the writer that caused the encoding split' -T
     }
 }
 
+Describe 'Helpers called from inside a step do not use Write-Host' -Tag 'Static' {
+
+    # Windows PowerShell routes Write-Host through the information stream. Inside
+    # an Invoke-Step action, *>&1 merges that into the pipeline, so the line was
+    # written to the console once by Write-Host and rendered again by
+    # Out-Default. The transcript recorded both, one wrapped to console width and
+    # one not:
+    #
+    #   Windows Terminal settings:
+    #   C:\Users\...\LocalState\settings.json
+    #   Windows Terminal settings: C:\Users\...\LocalState\settings.json
+    #
+    # Update-Everything's own summary is not inside a step, so Write-Host is
+    # still correct there and this only covers the helpers a step calls.
+
+    It 'Set-PwshAsWindowsTerminalDefault writes to the pipeline, not the host' {
+        $path = Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Set-PwshAsWindowsTerminalDefault.ps1'
+        $ast  = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref] $null, [ref] $null)
+
+        $calls = $ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -eq 'Write-Host'
+            }, $true)
+
+        $calls | Should-BeNull -Because 'inside a step, Write-Host is logged twice on Windows PowerShell'
+    }
+}
+
 Describe 'Test-ParameterSupport' -Tag 'Unit' {
 
     # Windows PowerShell ships PowerShellGet 1.0.0.1, whose Update-Module has no

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -407,6 +407,63 @@ Describe 'Write-StepLog' -Tag 'Unit' {
     }
 }
 
+Describe 'Test-ParameterSupport' -Tag 'Unit' {
+
+    # Windows PowerShell ships PowerShellGet 1.0.0.1, whose Update-Module has no
+    # -AcceptLicense. Splatting it there is a terminating error, and it failed
+    # both the "PowerShell modules" and "Windows Update" steps on a 5.1 run.
+
+    It 'reports true for a parameter the resolved command really has' {
+        Test-ParameterSupport -Command 'Get-ChildItem' -Parameter 'Recurse' |
+            Should-BeTrue
+    }
+
+    It 'reports false for a parameter the resolved command does not have' {
+        Test-ParameterSupport -Command 'Get-ChildItem' -Parameter 'AcceptLicense' |
+            Should-BeFalse
+    }
+
+    # A missing command is the ordinary case on a host without PowerShellGet, so
+    # it has to answer rather than throw.
+    It 'reports false for a command that does not exist' {
+        Test-ParameterSupport -Command 'No-SuchCommandExists' -Parameter 'Whatever' |
+            Should-BeFalse
+    }
+
+    It 'returns a real boolean rather than a truthy object' {
+        Test-ParameterSupport -Command 'Get-ChildItem' -Parameter 'Recurse' |
+            Should-HaveType ([bool])
+    }
+}
+
+Describe 'The gallery steps never splat a parameter blindly' -Tag 'Static' {
+
+    # The regression these guard is subtle: -AcceptLicense is correct on
+    # PSResourceGet and on PowerShellGet v2, so it looks right everywhere until
+    # it runs on the version Windows actually ships.
+
+    BeforeAll {
+        $script:MainSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    It 'guards the Update-Module call' {
+        $script:MainSource |
+            Should-MatchString "Test-ParameterSupport -Command 'Update-Module' -Parameter 'AcceptLicense'"
+    }
+
+    It 'guards the Install-Module call' {
+        $script:MainSource |
+            Should-MatchString "Test-ParameterSupport -Command 'Install-Module' -Parameter 'AcceptLicense'"
+    }
+
+    # Update-PSResource is a different command with a different history, and it
+    # has always had the parameter, so it needs no guard.
+    It 'leaves the PSResourceGet branch alone' {
+        $script:MainSource | Should-MatchString 'Update-PSResource @p'
+    }
+}
+
 Describe 'Test-UacEnabled' -Tag 'Unit','Security' {
 
     It 'reports enabled when EnableLUA is 1' {


### PR DESCRIPTION
Fixes found by the 2026-08-29 test run on a fresh machine
(`Update-Everything-20260829-210625.log`): 2 steps failed, and four further
defects the summary did not surface at all.

Three of the six exist only because of how that machine is set up, and none of
it is exotic — winget has defaulted `Microsoft.PowerShell` to the MSIX installer
since 7.6, and every Windows box ships PowerShellGet 1.0.0.1. Any machine that
installed pwsh through winget and then ran the module from a `runas` window
reproduces both reported failures.

| | Host that produced the log | `powershell.exe` 5.1.26100.8875 |
|---|---|---|
| | PowerShellGet on 5.1 | **1.0.0.1** (inbox) — no `-AcceptLicense` |
| | PowerShell 7 install type | **MSIX**, `...\WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__...` |
| | `C:\Program Files\PowerShell\7\pwsh.exe` | absent |

## The two reported failures

**`-AcceptLicense` was splatted unconditionally.** PowerShellGet 1.0.0.1 predates
it, and splatting a parameter that does not exist is a terminating error, so both
`PowerShell modules` and `Windows Update` failed outright on 5.1. New
`Test-ParameterSupport` asks the *resolved* command instead of comparing module
versions — which `Update-Module` binds depends on `PSModulePath` order, not on the
highest version installed. The PSResourceGet branch is untouched; it has always
had the parameter.

## Four the summary never showed

**An MSIX PowerShell cannot self-elevate, and the error said otherwise.** Windows
does not run packaged apps elevated. `Test-ElevationCapability` never asked, so it
reported `CanElevate = $true` and the user was told *"Elevation was declined or
failed"* on a machine where elevation from that host is impossible by design — the
exact case its own docstring says it exists to prevent. It now refuses up front
and gives the `--installer-type wix` command; where the MSI build is installed
alongside, `Invoke-SelfElevation` relaunches through it instead of giving up.

**Step logs were written in two encodings at once.** `Tee-Object -FilePath` writes
UTF-16LE on Windows PowerShell and has no `-Encoding` there; `Write-StepLog` wrote
ANSI. Same file, both — a probe measured 145 NUL bytes in a log of 361, and every
captured line read `P S G a l l e r y   ( P o w e r S h e l l G e t   v 2 )`.
That included both logs the summary pointed at under "Steps needing attention".

**The elevation failure left no trace anywhere.** Logging was set up *after*
elevation succeeded, so every path that declined to start produced no log at all.
The PowerShell 7 run that could not elevate left nothing to read, and never would
have. Logging now starts first, and both early returns stop the transcript rather
than leaving it recording the caller's session.

**Scheduled tasks were registered against a path that expires.**
`Get-PowerShellHostPath` resolved `pwsh` from PATH, which inside a packaged session
returns a version-stamped `WindowsApps` path that stops existing at the next
PowerShell update. The alias beside it is a zero-byte reparse point Task Scheduler
cannot launch either.

Plus: every Windows Terminal line was logged twice, because `Write-Host` inside an
`Invoke-Step` action is both written to the console and re-rendered by
`Out-Default` once `*>&1` merges the information stream. Measured on 5.1: two
occurrences before, one after.

## Also included

Two items that were judgment calls rather than defects, both requested:

- **PowerShellGet 2.x offered through the existing consent gate.** Probing for
  `-AcceptLicense` stops v1 failing the step, but v1 also cannot see modules
  installed by v2, so `Update-Module` on 5.1 quietly skips most of what is
  installed and reports success. Declining is not fatal.
- **The summary now says when notifications were not requested**, instead of being
  silent about `-Notify` and sending people looking for a BurntToast prompt that
  was never going to appear.

## Not a bug

No BurntToast prompt appeared because `-Notify` defaults to off and the test run
did not pass it. No scheduled task is needed to get one — `Update-Everything
-Notify` asks.

## Testing

`./test.ps1` — **434 passing, 0 failing** (from 387 on `main`).

The regression tests for the encoding split shell out to `powershell.exe`,
following the pattern already used for the module import test. They have to: on
PowerShell 7 `Tee-Object` writes UTF-8, so the old code looks correct from the
host the suite runs on. Each new guard was verified failing against the previous
implementation before the fix landed.

Verified on the MSIX host itself: the run now refuses with the `wix` command and
writes that refusal to a log, and `Get-PowerShellHostPath` returns
`C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe` in place of the
version-stamped `WindowsApps` path.

Both analyzer passes clean, including the default gallery rules; module imports on
5.1 and 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
