### PR TITLE
Do not hold the transcript open across the elevation handoff

### DIFF
--- a/src/Private/Invoke-SelfElevation.ps1
+++ b/src/Private/Invoke-SelfElevation.ps1
@@ -96,7 +96,9 @@
         $child = Start-Process -FilePath $hostPath -Verb RunAs -ArgumentList $argList `
             -PassThru -Wait -ErrorAction Stop
 
-        Write-Host "Elevated run finished with exit code $($child.ExitCode)." -ForegroundColor Green
+        # The caller reports the outcome, not this function. It reopens its
+        # transcript first, so the line lands in the log rather than only on a
+        # console nobody is reading after an unattended run.
         return $child.ExitCode
     } catch {
         # Declining the UAC prompt throws here.

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -253,9 +253,40 @@
                 -LogDirectory $logDir -MainLog $mainLog)
         }
 
+        # Close the transcript before handing off, and reopen it afterwards to
+        # record the outcome.
+        #
+        # The child computes its own run stamp and starts its own transcript. The
+        # stamps have one-second resolution, so if the two land in the same second
+        # they resolve to the same file -- and two processes with it open at once
+        # is not benign: -Append reports success and then the child's content is
+        # silently lost. Measured here, a child needs ~1.7s to start and import
+        # before it stamps, so today the stamps always differ. That is a timing
+        # margin under 2x on one machine, it narrows on faster hardware, and the
+        # failure it guards is the loss of the elevated transcript -- the one that
+        # did the work. Not overlapping costs nothing and does not depend on it.
+        # Said before the close, not after: if the elevated child hangs or the
+        # machine dies mid-run, this transcript is all there is, and it should
+        # name the log the real work went to.
+        $childNote = "Handing off to an elevated run. Its transcript is a separate Update-Everything-*.log in $logDir, stamped when it starts."
+        Write-Host $childNote -ForegroundColor Yellow
+
+        if ($transcriptRunning) {
+            try { Stop-Transcript | Out-Null } catch { Write-Verbose "Transcript already stopped." }
+            $transcriptRunning = $false
+        }
+
         # A module function must not kill the session it was called from, so the
         # elevated child's outcome comes back as a result rather than an exit.
         $child = Invoke-SelfElevation -BoundParameters $PSBoundParameters
+
+        try {
+            Start-Transcript -Path $mainLog -Append -ErrorAction Stop | Out-Null
+            $transcriptRunning = $true
+        } catch {
+            Write-Verbose "Could not reopen the transcript to record the elevated run's outcome."
+        }
+        Write-Host "Elevated run finished with exit code $child." -ForegroundColor Green
 
         if ($transcriptRunning) { try { Stop-Transcript | Out-Null } catch { Write-Verbose "Transcript already stopped." } }
         try { [Console]::OutputEncoding = $originalOutputEncoding } catch { Write-Verbose "Could not restore the console encoding." }

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -326,6 +326,26 @@ Describe 'Logging starts before the run can decline to start' -Tag 'Static','Mod
             ($script:Source -split "`r?`n" | Select-String -Pattern $pattern |
                 Select-Object -First 1).LineNumber
         }
+
+        # The handoff assertions are bounded structurally rather than by
+        # proximity. Taking the first Stop-Transcript in the file would find the
+        # one in the "cannot elevate" return, which sits earlier and is before
+        # the handoff for reasons that have nothing to do with this rule --
+        # green for the wrong reason.
+        $lines = $script:Source -split "`r?`n"
+        $hand  = ($lines | Select-String -Pattern 'Invoke-SelfElevation -BoundParameters' |
+            Select-Object -First 1).LineNumber
+
+        # Starts after the "cannot elevate" return, not at the elevation test.
+        # That branch has a Stop-Transcript of its own, and including it made the
+        # close assertion pass against code that never closed anything before the
+        # handoff -- verified by running it against the previous implementation.
+        $open  = ($lines | Select-String -Pattern '-Ran \$false -Reason \$elevation\.Reason' |
+            Select-Object -First 1).LineNumber
+        $close = ($lines | Select-String -Pattern '-Ran \$false -Elevated' | Select-Object -First 1).LineNumber
+
+        $script:BeforeHandoff = ($lines[($open - 1)..($hand - 1)]) -join "`n"
+        $script:AfterHandoff  = ($lines[($hand - 1)..($close - 1)]) -join "`n"
     }
 
     It 'starts the transcript before testing whether it can elevate' {
@@ -356,6 +376,38 @@ Describe 'Logging starts before the run can decline to start' -Tag 'Static','Mod
         $stops  = ([regex]::Matches($script:Source, 'Stop-Transcript')).Count
 
         $stops | Should-BeGreaterThanOrEqual 3 -Because "one per early return plus the normal end; found $starts start(s) and $stops stop(s)"
+    }
+
+    # Two processes with the same transcript open at once is not benign, and it
+    # fails silently: the child's Start-Transcript -Append reports success and
+    # its content is then lost. Measured, a child needs ~1.7s to start and import
+    # before it stamps, so the one-second stamps differ today -- but that is a
+    # timing margin that narrows on faster hardware, and it guards the loss of
+    # the elevated run's transcript. So the parent does not overlap it at all.
+    It 'closes the transcript before handing off to the child' {
+        $script:BeforeHandoff |
+            Should-MatchString 'Stop-Transcript' -Because 'the child opens its own transcript on a path that can collide with this one'
+    }
+
+    It 'reopens the transcript after the child returns' {
+        $script:AfterHandoff |
+            Should-MatchString 'Start-Transcript' -Because 'the outcome still has to be recorded'
+    }
+
+    # Losing this would leave a hung child with no explanation anywhere.
+    It 'names where the real work will be logged before closing' {
+        $script:BeforeHandoff | Should-MatchString 'Handing off to an elevated run'
+    }
+
+    # Reporting it from inside Invoke-SelfElevation would put the line on the
+    # console while the transcript is closed, so an unattended run would lose it.
+    It 'reports the elevated outcome from the caller' {
+        $script:AfterHandoff | Should-MatchString 'Elevated run finished with exit code'
+    }
+
+    It 'does not also report it from inside Invoke-SelfElevation' {
+        Get-Content (Join-Path $script:ModuleRoot 'Private\Invoke-SelfElevation.ps1') -Raw |
+            Should-NotMatchString 'Write-Host "Elevated run finished'
     }
 
     It 'reports the log location even when nothing ran' {


### PR DESCRIPTION
Follow-up to #1, which merged while this was being verified.

#1 moved logging above the elevation decision so a run that declines to start
still leaves a log. That left the parent transcript open while the elevated
child ran, and I justified it in that PR by saying `-Append` covers a stamp
collision. **That justification was wrong**, and this corrects it.

## What the measurement showed

Forcing the collision — parent and child holding the same transcript path:

```
Child reported : CHILD-LINE CHILD-OK
  PARENT-LINE-BEFORE-CHILD   present 1x
  CHILD-LINE                 present 0x
  PARENT-LINE-AFTER-CHILD    present 1x
```

The child's `Start-Transcript -Append` **succeeds and reports success**, then its
content is silently lost. The transcript that disappears is the elevated one —
the run that did the work.

It cannot happen today: a child needs ~1.7s to start and import before it stamps,
and stamps have one-second resolution, so they always differ. But that is a margin
under 2x measured on one machine, it *narrows* on faster hardware, and nothing
would report it if it ever closed.

## The change

Close the parent transcript across the handoff and reopen it after. No overlap,
no dependence on timing. Also:

- The outcome line moves from `Invoke-SelfElevation` to the caller, which reopens
  the transcript first — previously it would have printed to a console while the
  transcript was closed, so an unattended run lost it.
- The handoff is announced *before* the close, naming where the real work will be
  logged, so a child that hangs still leaves an explanation behind.

## On the tests

The new assertions bound the handoff region structurally, per the rule
`CONTRIBUTING.md` added in 20232e2. My first attempt bounded it from the
elevation test, which let `closes the transcript before handing off` pass against
code that never closed anything — that region contains the "cannot elevate"
return, which has a `Stop-Transcript` of its own. Running all five against the
previous implementation caught it; they now fail there and pass here.

A second self-inflicted one worth noting: a duplicate `BeforeAll` in the same
`Describe` failed discovery for the whole file, and the filtered run still showed
a passing count. Worth knowing that a discovery failure can look like a pass if
you are grepping the tail.

## Verification

Real `Start-Process -Verb RunAs` handoff on a machine with the MSI build
installed (installed this session, since the MSIX build cannot elevate at all):

```
New transcripts: 2
  Update-Everything-20260830-131814.log  1876 bytes, 0 NUL   Elevated run finished: True
  Update-Everything-20260830-131816.log  3966 bytes, 0 NUL   SUMMARY: True
```

Two transcripts, stamps 2s apart, both closed cleanly, no NUL bytes, nothing lost.

441 tests, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)