### PR TITLE
Fix a false reboot warning and step output that was returned, not shown

### DIFF
--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -56,11 +56,20 @@
         # line as interleaved nulls. Out-String also renders the Format* records
         # a table arrives as into the table itself, which writing the objects one
         # at a time would not.
+        # Out-Host on the end, for the same reason the summary table has one.
+        # Inside a function, unassigned pipeline output is the return value, so
+        # every line a step produced was being returned to the caller rather than
+        # displayed. $result = Update-Everything -- the form the README documents
+        # -- therefore captured 63 objects with the result buried among them, and
+        # the transcript recorded none of the run it was supposed to be a record
+        # of. Sending it to the host displays it live, the transcript picks it up
+        # from there, and only the result object comes back.
         $stepOutput = [System.Collections.Generic.List[object]]::new()
         & $Action *>&1 |
             ForEach-Object { $stepOutput.Add($_); $_ } |
             Out-String -Stream |
-            ForEach-Object { Write-StepLog -Path $stepLog -Raw $_; $_ }
+            ForEach-Object { Write-StepLog -Path $stepLog -Raw $_; $_ } |
+            Out-Host
 
         $code = $LASTEXITCODE
         if ($null -ne $code -and $code -ne 0) {

--- a/src/Public/Test-PendingReboot.ps1
+++ b/src/Public/Test-PendingReboot.ps1
@@ -8,9 +8,6 @@
     $pendingReboot  = $false
     $rebootReasons  = [System.Collections.Generic.List[string]]::new()
 
-$pendingReboot  = $false
-$rebootReasons  = [System.Collections.Generic.List[string]]::new()
-
 $rebootKeys = [ordered]@{
     'Component Based Servicing'  = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
     'CBS reboot in progress'     = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootInProgress'
@@ -35,10 +32,39 @@ $sessionManager = Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\
     -ErrorAction SilentlyContinue
 if ($sessionManager -and
     $sessionManager.PSObject.Properties.Name -contains 'PendingFileRenameOperations') {
-    $pendingRenames = @($sessionManager.PendingFileRenameOperations | Where-Object { $_ })
-    if ($pendingRenames.Count -gt 0) {
+    # The value is a REG_MULTI_SZ of [source, destination] pairs. A pair with a
+    # destination is a real rename: Windows is holding a replacement for a file
+    # that is in use, and the restart is what completes it. A pair with an empty
+    # destination is a scheduled *deletion*, which installers queue constantly
+    # for their own temp files and which needs no restart to be meaningful.
+    #
+    # Counting every entry made a single leftover
+    #   *1\??\C:\Users\...\AppData\Local\Temp\DEL396A.tmp
+    # announce "[!] A reboot is pending" on every run, while Component Based
+    # Servicing and Windows Update both reported nothing pending at all. A
+    # restart prompt nobody needs is one people learn to ignore.
+    $entries   = @($sessionManager.PendingFileRenameOperations)
+    $renames   = 0
+    $deletions = 0
+
+    for ($i = 0; $i -lt $entries.Count; $i += 2) {
+        $source = $entries[$i]
+        if (-not $source) { continue }
+
+        # A trailing source with no partner is malformed; treat it as a deletion
+        # rather than inventing a rename out of it.
+        $destination = if ($i + 1 -lt $entries.Count) { $entries[$i + 1] } else { '' }
+
+        if ($destination) { $renames++ } else { $deletions++ }
+    }
+
+    if ($renames -gt 0) {
         $pendingReboot = $true
-        $rebootReasons.Add("Pending file renames ($($pendingRenames.Count))")
+        $rebootReasons.Add("Pending file renames ($renames)")
+    }
+
+    if ($deletions -gt 0) {
+        Write-Verbose "$deletions scheduled file deletion(s) are queued; those do not require a restart."
     }
 }
 

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -762,6 +762,34 @@ Describe 'The summary is displayed, not returned' -Tag 'Static','Module' {
     }
 }
 
+Describe 'Step output is displayed, not returned' -Tag 'Static','Module' {
+
+    # Same defect as the summary table above, in the other half of the run.
+    # Inside a function, unassigned pipeline output is the return value, so every
+    # line a step produced was returned to the caller instead of displayed:
+    # `$result = Update-Everything` -- the form the README documents -- came back
+    # with 63 objects and the result buried among them, and the transcript
+    # recorded none of the run it exists to record.
+
+    It 'sends the captured step output to the host' {
+        $path = Join-Path $script:ModuleRoot 'Private\Invoke-Step.ps1'
+        $ast  = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref] $null, [ref] $null)
+
+        # The pipeline that runs the action, found by the action invocation
+        # inside it rather than by line number.
+        $pipeline = $ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.PipelineAst] -and
+                $node.Extent.Text -match '\$Action \*>&1'
+            }, $true) | Select-Object -First 1
+
+        $pipeline | Should-NotBeNull -Because 'the step action pipeline should still exist'
+
+        $last = $pipeline.PipelineElements[-1]
+        $last.GetCommandName() | Should-Be 'Out-Host'
+    }
+}
+
 Describe 'No step updates through a tool it has not verified' -Tag 'Static','Module' {
 
     # The rule: a step must not invoke a package manager it has not confirmed is

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -205,6 +205,62 @@ Describe 'Test-PendingReboot' -Tag 'Unit' {
         (Test-PendingReboot).IsPending | Should-BeFalse
     }
 
+    # The entries are [source, destination] pairs. An empty destination is a
+    # scheduled deletion, not a rename, and installers queue those for their own
+    # temp files constantly. This exact value was on a real machine and made
+    # every run print "[!] A reboot is pending" while Component Based Servicing
+    # and Windows Update both reported nothing.
+    It 'does not call a scheduled deletion a pending reboot' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(
+                '*1\??\C:\Users\someone\AppData\Local\Temp\DEL396A.tmp', '') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).IsPending | Should-BeFalse
+    }
+
+    It 'gives no reboot reason for a scheduled deletion' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @('\??\C:\Temp\DEL1.tmp', '') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).Reasons | Should-BeCollection -Count 0
+    }
+
+    # A rename means Windows is holding a replacement for a file in use, and the
+    # restart is what completes it. That still has to be reported.
+    It 'still reports a real rename alongside deletions' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(
+                '\??\C:\Temp\DEL1.tmp', '',
+                '\??\C:\Windows\System32\thing.dll', '!\??\C:\Windows\System32\thing.dll') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).IsPending | Should-BeTrue
+    }
+
+    It 'counts only the renames, not the deletions beside them' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(
+                '\??\C:\Temp\DEL1.tmp', '',
+                '\??\C:\Temp\DEL2.tmp', '',
+                '\??\C:\Windows\System32\thing.dll', '!\??\C:\Windows\System32\thing.dll') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).Reasons | Should-ContainCollection 'Pending file renames (1)'
+    }
+
+    # A trailing source with no partner is malformed. Inventing a rename out of
+    # it would resurrect the false positive on exactly the machines whose
+    # registry is already untidy.
+    It 'treats an unpaired trailing entry as a deletion' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @('\??\C:\Temp\DEL1.tmp') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).IsPending | Should-BeFalse
+    }
+
     # Asking for a value that is absent, with -ErrorAction Stop, throws -- and
     # Start-Transcript records the throw as "TerminatingError(Get-ItemProperty)"
     # in the run log even though it is caught. On a healthy machine that reads


### PR DESCRIPTION
Two defects found by running the module for real, neither in the original log.

## The reboot warning was a false positive

Two consecutive runs on a freshly updated machine both ended with

```
[!] A reboot is pending. Restart to finish applying updates.
    - Pending file renames (1)
```

while Component Based Servicing and Windows Update both reported nothing
pending, and `Get-WUHistory` showed the last install was two hours earlier. The
whole basis for the warning was one leftover value:

```
*1\??\C:\Users\...\AppData\Local\Temp\DEL396A.tmp
```

`PendingFileRenameOperations` is a REG_MULTI_SZ of `[source, destination]`
pairs. A pair **with** a destination is a real rename — Windows holding a
replacement for a file in use, which the restart completes. A pair with an
**empty** destination is a scheduled deletion, which installers queue constantly
for their own temp files. Counting every non-empty entry conflated the two.

Now the pairs are counted and only renames are reported. An unpaired trailing
source counts as a deletion rather than being promoted to a rename — inventing
one would resurrect the false positive on exactly the machines whose registry is
already untidy. Deletions stay visible under `-Verbose`.

Verified against the real value on the machine that produced it: `IsPending`
now `False`, with CBS and Windows Update agreeing.

## Step output was returned instead of displayed

The summary table was fixed for this once already — `Describe 'The summary is
displayed, not returned'` — but the other half of the run still had it. Inside a
function, unassigned pipeline output is the return value, so every line a step
produced was handed back to the caller rather than displayed.

The consequence is the form the README documents on line 128:

```powershell
$result = Update-Everything
```

That returned **63 objects** — 62 step-output strings with the result buried
among them — and the transcript recorded none of the run it exists to be a
record of. The documented `.OUTPUTS` is a single object, so the contract was
wrong in both directions at once: callers got what the log should have had, and
the log got nothing.

Sending the captured output to the host, exactly as the summary table does,
fixes both halves.

## Verification

A real run using the documented capturing form:

```
objects returned : 1          (was 63)
type             : PSCustomObject
FailedCount      : 0
OkCount          : 15
RebootPending    : False      (was True)
```

and the run itself is still fully recorded — 8,243-byte transcript, 15 steps,
summary present, 0 NUL bytes across all 22 logs.

447 tests, 0 failed. Each new guard was run against the unfixed code first; the
five behavioural ones fail there. The sixth (`still reports a real rename
alongside deletions`) passes both ways by design — it guards against the fix
over-correcting, not against the original bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)