### PR TITLE
Name the file a pending restart is waiting on

### DIFF
--- a/src/Public/Test-PendingReboot.ps1
+++ b/src/Public/Test-PendingReboot.ps1
@@ -43,9 +43,9 @@ if ($sessionManager -and
     # announce "[!] A reboot is pending" on every run, while Component Based
     # Servicing and Windows Update both reported nothing pending at all. A
     # restart prompt nobody needs is one people learn to ignore.
-    $entries   = @($sessionManager.PendingFileRenameOperations)
-    $renames   = 0
-    $deletions = 0
+    $entries     = @($sessionManager.PendingFileRenameOperations)
+    $renamePaths = [System.Collections.Generic.List[string]]::new()
+    $deletions   = 0
 
     for ($i = 0; $i -lt $entries.Count; $i += 2) {
         $source = $entries[$i]
@@ -55,12 +55,51 @@ if ($sessionManager -and
         # rather than inventing a rename out of it.
         $destination = if ($i + 1 -lt $entries.Count) { $entries[$i + 1] } else { '' }
 
-        if ($destination) { $renames++ } else { $deletions++ }
+        if (-not $destination) {
+            $deletions++
+            continue
+        }
+
+        # Report which file, not just how many. "Pending file renames (1)" sent
+        # someone through the event log, the servicing keys and the Office
+        # update state to work out what a restart was actually for, and the
+        # answer was unrecoverable by then: the queue is consumed at boot and
+        # nothing else records it. The path is the whole answer, so log it.
+        #
+        # Sources carry NT object-manager syntax and MoveFileEx markers --
+        # "\??\C:\x", "*1\??\C:\x" and "!\??\C:\x" all mean C:\x. Trim them so
+        # the reason reads as a path someone recognises.
+        $path = $source
+        foreach ($prefix in '*1\??\', '*\??\', '!\??\', '\??\') {
+            if ($path.StartsWith($prefix)) {
+                $path = $path.Substring($prefix.Length)
+                break
+            }
+        }
+
+        $renamePaths.Add($path)
     }
 
-    if ($renames -gt 0) {
+    if ($renamePaths.Count -gt 0) {
         $pendingReboot = $true
-        $rebootReasons.Add("Pending file renames ($renames)")
+
+        # The summary prints one line per reason and the toast joins the first
+        # two, so a long queue must not turn either into a wall of text. Three
+        # paths is enough to recognise what is happening; the count still says
+        # how many there are.
+        $shown = [System.Collections.Generic.List[string]]::new()
+        for ($j = 0; $j -lt [Math]::Min(3, $renamePaths.Count); $j++) {
+            $p = $renamePaths[$j]
+            if ($p.Length -gt 70) { $p = '...' + $p.Substring($p.Length - 67) }
+            $shown.Add($p)
+        }
+
+        $detail = $shown -join '; '
+        if ($renamePaths.Count -gt 3) {
+            $detail = "$detail; and $($renamePaths.Count - 3) more"
+        }
+
+        $rebootReasons.Add("Pending file renames ($($renamePaths.Count)): $detail")
     }
 
     if ($deletions -gt 0) {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -247,7 +247,88 @@ Describe 'Test-PendingReboot' -Tag 'Unit' {
                 '\??\C:\Windows\System32\thing.dll', '!\??\C:\Windows\System32\thing.dll') }
         } -ParameterFilter { $LiteralPath -like '*Session Manager' }
 
-        (Test-PendingReboot).Reasons | Should-ContainCollection 'Pending file renames (1)'
+        (Test-PendingReboot).Reasons | Should-ContainCollection 'Pending file renames (1): C:\Windows\System32\thing.dll'
+    }
+
+    # "Pending file renames (1)" on its own sent someone through the event log,
+    # the servicing keys and the Office update state to work out what a restart
+    # was for, and by then the answer was gone: the queue is consumed at boot
+    # and nothing else records it. The path is the answer.
+    It 'names the file a restart is waiting on' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(
+                '\??\C:\Windows\System32\drivers\thing.sys', '!\??\C:\Windows\System32\drivers\thing.sys') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).Reasons |
+            Should-ContainCollection 'Pending file renames (1): C:\Windows\System32\drivers\thing.sys'
+    }
+
+    # The sources carry NT object-manager syntax and MoveFileEx markers. Left in,
+    # the reason reads as machine noise rather than a path.
+    It 'strips the <_> prefix from the reported path' -ForEach @('\??\', '*1\??\', '!\??\') {
+        $prefix = $_
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(
+                ($prefix + 'C:\dir\file.dll'), '!\??\C:\dir\file.dll') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).Reasons | Should-ContainCollection 'Pending file renames (1): C:\dir\file.dll'
+    }
+
+    # The summary prints a line per reason and the toast joins the first two, so
+    # a machine mid-servicing must not turn either into a wall of text.
+    It 'lists at most three paths' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(
+                '\??\C:\a.dll', '!\??\C:\a.dll',
+                '\??\C:\b.dll', '!\??\C:\b.dll',
+                '\??\C:\c.dll', '!\??\C:\c.dll',
+                '\??\C:\d.dll', '!\??\C:\d.dll',
+                '\??\C:\e.dll', '!\??\C:\e.dll') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).Reasons |
+            Should-ContainCollection 'Pending file renames (5): C:\a.dll; C:\b.dll; C:\c.dll; and 2 more'
+    }
+
+    # The count is the total, not the number of paths shown. Asserting only
+    # "renames (4)" would pass against the version that reported a bare count
+    # and no paths at all, so this pins the whole reason.
+    It 'counts every rename even though it shows three' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(
+                '\??\C:\a.dll', '!\??\C:\a.dll',
+                '\??\C:\b.dll', '!\??\C:\b.dll',
+                '\??\C:\c.dll', '!\??\C:\c.dll',
+                '\??\C:\d.dll', '!\??\C:\d.dll') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).Reasons |
+            Should-ContainCollection 'Pending file renames (4): C:\a.dll; C:\b.dll; C:\c.dll; and 1 more'
+    }
+
+    # A path long enough to wrap the summary is trimmed from the left, because
+    # the file name is the end and that is the part that identifies it.
+    It 'trims a long path from the left, keeping the file name' {
+        $long = 'C:\Program Files\Some Vendor\A Very Long Product Name Indeed\subfolder\deeper\thing.dll'
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(('\??\' + $long), '!\??\x') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).Reasons | Should-MatchString 'thing\.dll$'
+    }
+
+    # Measuring the trimmed length is not enough on its own: with no path in the
+    # reason at all, the measurement lands on "Pending file renames (1)" and
+    # passes. The ellipsis is what proves a path was there and was trimmed.
+    It 'marks a trimmed path with a leading ellipsis' {
+        $long = 'C:\Program Files\Some Vendor\A Very Long Product Name Indeed\subfolder\deeper\thing.dll'
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ PendingFileRenameOperations = @(('\??\' + $long), '!\??\x') }
+        } -ParameterFilter { $LiteralPath -like '*Session Manager' }
+
+        (Test-PendingReboot).Reasons | Should-MatchString 'renames \(1\): \.\.\.'
     }
 
     # A trailing source with no partner is malformed. Inventing a rename out of


### PR DESCRIPTION
## The problem

A run reported:

```
[!] A reboot is pending. Restart to finish applying updates.
    - Pending file renames (1)
```

Answering *"required for what?"* afterwards meant walking the event log, the
servicing keys, Windows Update history and the Office update state — and still
coming up empty. `PendingFileRenameOperations` is consumed at boot and nothing
else records it, so by the time anyone asks, the answer no longer exists.

Everything else could be ruled out — Component Based Servicing absent, Windows
Update had installed nothing for two hours, no `MsiInstaller` events in the
window, Office version unchanged with nothing staged — but the one fact that
would have settled it, the file name, was never written down.

The count was never the useful part.

## The change

Report the path alongside the count.

Sources carry NT object-manager syntax and MoveFileEx markers — `\??\C:\x`,
`*1\??\C:\x` and `!\??\C:\x` all mean `C:\x` — so those are trimmed, or the
reason reads as machine noise rather than a file someone recognises.

The summary prints one line per reason and the toast joins the first two, so at
most three paths are listed with `and N more` carrying the rest, and a path over
70 characters is trimmed from the left — the file name is the end, and the end
is the part that identifies it.

```
Pending file renames (1): C:\Windows\System32\drivers\vendor.sys
Pending file renames (5): C:\a.dll; C:\b.dll; C:\c.dll; and 2 more
Pending file renames (1): ...ndor\A Very Long Product Name\deeper\thing.dll
```

Deletions still report nothing at all, so the machine that prompted the earlier
fix continues to read as no reboot pending.

## Testing

455 tests, 0 failed, lint included.

Two of the nine new tests passed against the unfixed code on the first attempt
and were rewritten — both are variants of failure modes `CONTRIBUTING.md`
already documents:

- asserting `renames \(4\)` matched the old bare count, so it proved nothing
- measuring the trimmed path length landed on `Pending file renames (1)` itself
  when no path was present, and 24 characters is comfortably under the cap

The replacements pin the whole reason string and assert the ellipsis that proves
a path was there and was trimmed. All nine now fail without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)