### PR TITLE
Drop progress repaints from what a step shows and logs

### DIFF
--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -64,10 +64,20 @@
         # the transcript recorded none of the run it was supposed to be a record
         # of. Sending it to the host displays it live, the transcript picks it up
         # from there, and only the result object comes back.
+        # The Where-Object drops progress repaints. PowerShell splits captured
+        # native output on carriage returns, so a tool that redraws a progress
+        # bar in place -- winget above all -- arrives as one line per repaint
+        # and a single download becomes a column of percentages and spinner
+        # ticks, on the console and in the log alike. Nothing upstream prevents
+        # it: --disable-interactivity governs prompts, not rendering.
+        #
+        # $stepOutput is filled before the filter, so the error-record check
+        # below still sees everything the step produced.
         $stepOutput = [System.Collections.Generic.List[object]]::new()
         & $Action *>&1 |
             ForEach-Object { $stepOutput.Add($_); $_ } |
             Out-String -Stream |
+            Where-Object { -not (Test-ProgressRepaint -Line $_) } |
             ForEach-Object { Write-StepLog -Path $stepLog -Raw $_; $_ } |
             Out-Host
 

--- a/src/Private/Test-ProgressRepaint.ps1
+++ b/src/Private/Test-ProgressRepaint.ps1
@@ -1,0 +1,65 @@
+﻿function Test-ProgressRepaint {
+    <#
+        .SYNOPSIS
+        Whether a captured line is a leftover frame from a redrawing progress
+        bar rather than something worth reading.
+
+        .DESCRIPTION
+        winget draws progress by writing a bar and repainting it with carriage
+        returns. PowerShell splits captured native output on those carriage
+        returns, so every repaint arrives as its own line and a single download
+        turns into a column of percentages and spinner characters:
+
+            (3/7) Found App Installer [Microsoft.AppInstaller] Version 1.29.290
+            Starting package install...
+              -
+              \
+              |
+              /
+            ################          86%
+            #################         87%
+            ...
+
+        Nothing suppresses it upstream: --disable-interactivity governs prompts,
+        not rendering, and the bar is not written through the PowerShell
+        progress stream where $ProgressPreference would reach it.
+
+        The patterns are deliberately narrow -- a bar, a bare percentage, a
+        spinner tick -- because this runs over every line of every step, and
+        dropping real output to tidy a log would be the worse bug.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $Line
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Line)) { return $false }
+
+    # A spinner tick, alone on its line. Compared as a string rather than with
+    # a character class, because "[-\\|/]" needs the backslash doubled to mean a
+    # backslash and one written as "[-\|/]" silently becomes an escaped pipe --
+    # which matches every tick except the one that looks like an escape.
+    $trimmed = $Line.Trim()
+    if ($trimmed.Length -eq 1 -and '-\|/'.Contains($trimmed)) { return $true }
+
+    # A bare percentage, which is what the bar's label becomes once the bar
+    # itself has been drawn with box characters this console cannot show.
+    if ($Line -match '^\s*\d{1,3}\s*%\s*$') { return $true }
+
+    # A bar: the box-drawing and block characters winget draws it with,
+    # optionally labelled with a percentage. Stripping those leaves nothing a
+    # person would want to read.
+    #
+    # '#' and '=' are deliberately not in this set. Plenty of real output rules
+    # a line off with them, and a table underline of '-' has to survive too --
+    # which it does, because the spinner pattern above matches a single
+    # character, not a run of them.
+    $stripped = $Line -replace '[\u2500-\u259F\u25A0-\u25FF\s]', ''
+    if (-not $stripped) { return $true }
+    if ($stripped -match '^\d{1,3}%$') { return $true }
+
+    $false
+}

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -680,6 +680,95 @@ Describe 'Helpers called from inside a step do not use Write-Host' -Tag 'Static'
     }
 }
 
+Describe 'Test-ProgressRepaint' -Tag 'Unit' {
+
+    # winget repaints its progress bar with carriage returns, and PowerShell
+    # splits captured native output on those, so one download arrives as a
+    # column of spinner ticks and percentages -- on the console and in the log.
+    # Nothing upstream prevents it: --disable-interactivity governs prompts.
+
+    It 'drops the <_> spinner tick' -ForEach @('-', '\', '|', '/') {
+        $tick = $_
+        Test-ProgressRepaint -Line "  $tick" | Should-BeTrue
+    }
+
+    It 'drops a bare percentage' {
+        Test-ProgressRepaint -Line '   86%' | Should-BeTrue
+    }
+
+    It 'drops a block bar carrying a percentage' {
+        $bar = [string]([char]0x2588) * 12
+        Test-ProgressRepaint -Line "$bar  48%" | Should-BeTrue
+    }
+
+    It 'drops a block bar with no label' {
+        Test-ProgressRepaint -Line ([string]([char]0x2588) * 20) | Should-BeTrue
+    }
+
+    It 'keeps a line of real output' {
+        Test-ProgressRepaint -Line 'Successfully installed' | Should-BeFalse
+    }
+
+    It 'keeps a line that merely mentions a percentage' {
+        Test-ProgressRepaint -Line 'Disk is 86% full' | Should-BeFalse
+    }
+
+    # winget underlines its upgrade table with runs of hyphens. Reading that as
+    # a spinner would eat the header of the one table people actually read.
+    It 'keeps a table underline made of hyphens' {
+        Test-ProgressRepaint -Line '------- ------ -------- ---------- -------' | Should-BeFalse
+    }
+
+    It 'keeps a rule made of equals signs' {
+        Test-ProgressRepaint -Line '================' | Should-BeFalse
+    }
+
+    # Blank lines are structure, not repaint noise, and the caller already
+    # collapses nothing -- so removing them here would reflow real output.
+    It 'keeps a blank line' {
+        Test-ProgressRepaint -Line '' | Should-BeFalse
+    }
+
+    It 'accepts a null line rather than throwing' {
+        Test-ProgressRepaint -Line $null | Should-BeFalse
+    }
+
+    It 'returns a real boolean' {
+        Test-ProgressRepaint -Line 'text' | Should-HaveType ([bool])
+    }
+}
+
+Describe 'A step strips progress repaints from what it shows and logs' -Tag 'Unit' {
+
+    BeforeEach {
+        $script:logDir   = Join-Path $TestDrive ('rp-' + [guid]::NewGuid().ToString('N'))
+        $null            = New-Item -ItemType Directory -Path $script:logDir -Force
+        $script:runStamp = 'rp'
+        $script:Results  = [System.Collections.Generic.List[object]]::new()
+    }
+
+    It 'keeps the real lines and drops the repaints' {
+        Invoke-Step -Name 'prog' -Action {
+            'Starting package install...'
+            '  -'
+            '  \'
+            ([string]([char]0x2588) * 8) + '  48%'
+            '95%'
+            'Successfully installed'
+        } 6>$null
+
+        $body = @(Get-Content (Join-Path $script:logDir 'prog-rp.log') |
+            Where-Object { $_ -notmatch '^\d{4}-\d{2}-\d{2} ' })
+
+        $body | Should-BeCollection -Count 2
+    }
+
+    It 'still records the step as OK' {
+        Invoke-Step -Name 'prog' -Action { '  /'; '50%'; 'done' } 6>$null
+        $script:Results[0].Status | Should-Be 'OK'
+    }
+}
+
 Describe 'Test-ParameterSupport' -Tag 'Unit' {
 
     # Windows PowerShell ships PowerShellGet 1.0.0.1, whose Update-Module has no


### PR DESCRIPTION
## What was happening

On a new machine, every winget download turned into a column of spinner ticks
and percentages — on the console and in the step log:

```
(3/7) Found App Installer [Microsoft.AppInstaller] Version 1.29.290
Starting package install...
  -
  \
  |
  /
########            2%
##################  48%
Successfully installed. Restart the application to complete the upgrade.
```

winget draws progress by repainting a bar with carriage returns, and **PowerShell
splits captured native output on carriage returns**, so every repaint arrives as
its own pipeline object.

Nothing upstream prevents it. `--disable-interactivity` governs prompts, not
rendering; the bar does not go through the PowerShell progress stream where
`$ProgressPreference` would reach it; and winget has no flag to disable it
(confirmed against `winget upgrade --help` on v1.29.290).

**This is not a regression.** Measured on the same input, `Tee-Object` produced
the identical lines before `Out-String -Stream` replaced it. It only became
visible once a machine had seven packages to upgrade instead of three — an
earlier run with three emitted no progress frames at all.

## The change

Filter the repaints out after the split, in `Invoke-Step`, so both the console
and the log benefit.

The patterns are deliberately narrow, because this runs over every line of every
step and eating real output to tidy a log would be the worse bug:

- a bar of block characters, with or without a percentage label
- a bare percentage alone on its line
- a lone spinner tick

A run of hyphens survives — that is how winget underlines the upgrade table —
and so does a rule of `=` or `#`. `$stepOutput` is filled *before* the filter, so
the error-record check that decides `Warning` vs `OK` still sees everything.

## One bug worth naming

The spinner test compares a string rather than using a character class. Written
as `[-\|/]` the class silently means *an escaped pipe*, so it matched every tick
except the backslash. The first version did exactly that, and it passed casual
inspection — a codepoint dump of the surviving lines is what caught it:

```
  3   True      U+0020 U+0020 U+002D
  4   False     U+0020 U+0020 U+005C     <- the backslash, not matched
  5   True      U+0020 U+0020 U+007C
```

`CONTRIBUTING.md` already says to prefer a plain string operation where one will
do, and this is why.

## Verification

Measured on a reproduction of the reported output: **20 captured lines, 8 kept**,
and the step log reads like the clean run it should have been.

472 tests, 0 failed, lint included. With the helper removed and `Invoke-Step`
reverted, 15 of the new tests fail — the first attempt at that check silently
verified nothing, because `git stash push` on an untracked file errors out and
leaves the tree alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)