### PR TITLE
Build an elevated relaunch command that parses

### DIFF
--- a/src/Private/Invoke-SelfElevation.ps1
+++ b/src/Private/Invoke-SelfElevation.ps1
@@ -67,27 +67,39 @@
     # manifest named after it, which a versioned path like \1.0.0 never has.
     $manifest = Join-Path $script:ModuleRoot 'UpdateEverything.psd1'
     $escModule = "'" + ($manifest -replace "'", "''") + "'"
-    $invoke = "Import-Module $escModule -Force; Update-Everything"
+
+    # The call is built on its own, separately from the import. Parentheses in
+    # PowerShell hold an expression, not a statement list, so wrapping both
+    # together --
+    #
+    #     exit (Import-Module '...' -Force; Update-Everything).FailedCount
+    #
+    # -- is a parse error: "Missing closing ')' in expression". The elevated
+    # window opened, pwsh exited 1 before running a line of it, and it closed
+    # again too fast to read, leaving no transcript and no clue. Import first,
+    # then exit on the call alone, which is what Get-UpdateTaskArgument has
+    # always done for the scheduled task.
+    $call = 'Update-Everything'
 
     foreach ($entry in $BoundParameters.GetEnumerator()) {
         $key = $entry.Key
         $val = $entry.Value
 
         if ($val -is [switch]) {
-            if ($val.IsPresent) { $invoke += " -$key" }
+            if ($val.IsPresent) { $call += " -$key" }
         } elseif ($val -is [bool]) {
-            $invoke += " -${key}:`$$($val.ToString().ToLowerInvariant())"
+            $call += " -${key}:`$$($val.ToString().ToLowerInvariant())"
         } elseif ($val -is [array]) {
             $quoted = ($val | ForEach-Object { "'" + ("$_" -replace "'", "''") + "'" }) -join ','
-            $invoke += " -$key $quoted"
+            $call += " -$key $quoted"
         } else {
-            $invoke += " -$key '" + ("$val" -replace "'", "''") + "'"
+            $call += " -$key '" + ("$val" -replace "'", "''") + "'"
         }
     }
 
     # The child turns the result into an exit code, which is the only thing that
     # can cross a process boundary.
-    $invoke = "exit ($invoke).FailedCount"
+    $invoke = "Import-Module $escModule -Force; exit ($call).FailedCount"
     $argList = "-NoProfile -ExecutionPolicy Bypass -Command `"$invoke`""
 
     try {

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -717,6 +717,73 @@ Describe 'The relaunch imports a manifest, not a folder' -Tag 'Static','Module' 
     }
 }
 
+Describe 'The elevated relaunch runs a command that parses' -Tag 'Static','Module' {
+
+    # It did not. The command was built as
+    #
+    #     exit (Import-Module '...' -Force; Update-Everything).FailedCount
+    #
+    # and parentheses in PowerShell hold an expression, not a statement list, so
+    # that is "Missing closing ')' in expression". The elevated window opened,
+    # pwsh exited 1 without running a line, and closed again before anyone could
+    # read it -- no transcript, no error, nothing but an exit code. Every
+    # non-elevated run hit it, which is to say every ordinary first run.
+    #
+    # Neither existing relaunch test noticed, because both check what the string
+    # contains and neither asks whether it is valid PowerShell.
+
+    BeforeAll {
+        # The real function, with the launch mocked out. Building the string is
+        # the part under test; starting a process is not.
+        $script:Captured = & (Get-Module UpdateEverything) {
+            $captured = $null
+            $script:ModuleRoot = 'C:\Modules\UpdateEverything\1.0.0'
+
+            function Start-Process {
+                param(
+                    $FilePath, $Verb, $ArgumentList, [switch] $PassThru, [switch] $Wait, $ErrorAction
+                )
+                $script:seen = $ArgumentList
+                [pscustomobject]@{ ExitCode = 0 }
+            }
+
+            $null = Invoke-SelfElevation -BoundParameters ([ordered]@{
+                Notify               = [switch]::Present
+                IncludeWindowsUpdate = $false
+                AllowInstall         = @('PSWindowsUpdate', 'BurntToast')
+                PromptTimeoutSeconds = 90
+            }) 6>$null 3>$null
+
+            $script:seen
+        }
+
+        # The command line is not PowerShell; the string inside -Command is.
+        $script:Command = if ($script:Captured -match '-Command\s+"(.*)"\s*$') { $Matches[1] } else { $null }
+    }
+
+    It 'passes a -Command string to the elevated host' {
+        $script:Command | Should-NotBeNull
+    }
+
+    It 'builds a command with no parse errors' {
+        $errors = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseInput(
+            $script:Command, [ref] $null, [ref] $errors)
+
+        $errors | Should-BeNull -Because "the elevated child exits 1 without running anything:`n$($errors.Message -join "`n")"
+    }
+
+    # The shape that parses: import as its own statement, then exit on the call
+    # alone. Get-UpdateTaskArgument has always built the task command this way.
+    It 'imports the module before the exit rather than inside it' {
+        $script:Command | Should-MatchString "^Import-Module '[^']+\.psd1' -Force; exit \("
+    }
+
+    It 'still hands the caller parameters to the elevated run' {
+        $script:Command | Should-MatchString ([regex]::Escape("-AllowInstall 'PSWindowsUpdate','BurntToast'"))
+    }
+}
+
 Describe 'Enter takes the default' -Tag 'Unit','Prompt' {
 
     BeforeAll {


### PR DESCRIPTION
## The symptom

On a new machine, an ordinary (non-elevated) run failed twice. The elevated
window opened, closed within seconds, and left nothing behind — no transcript,
no error, only the parent reporting:

```
Handing off to an elevated run. Its transcript is a separate Update-Everything-*.log ...
Elevated run finished with exit code 1.
```

Running `Update-Everything` from an already-elevated prompt worked fine.

## The cause

The command handed to the child was:

```powershell
exit (Import-Module '...\UpdateEverything.psd1' -Force; Update-Everything).FailedCount
```

Parentheses in PowerShell hold an expression, not a statement list, so that is
`Missing closing ')' in expression`. **pwsh exits 1 before running a line of
it** — which is exactly why the child never reached `Start-Transcript` and had
nothing to say for itself.

Measured on the string the function actually generates:

| form | exit | |
|---|---|---|
| `exit (Import; Cmd).Prop` | 1 | parse error |
| `Import; exit (Cmd).Prop` | 0 | parses and runs |

## The fix

Build the call separately from the import, and put the `exit` on the call
alone:

```powershell
Import-Module '...' -Force; exit (Update-Everything -Notify).FailedCount
```

That is the shape `Get-UpdateTaskArgument` has always used for the scheduled
task. The same idea existed correctly in one place and incorrectly in the
other.

Verified end to end: the command the function now generates is accepted by a
real `pwsh` and exits 0.

## Why it stayed hidden

Self-elevation only runs when the session is *not* already elevated. Every run
during development was launched from an admin prompt, and the MSIX check
refuses before starting a child, so this path was never exercised. The first
machine to run it as an ordinary user hit it twice in twenty seconds.

The two relaunch tests that existed both check what the string *contains*;
neither asked whether it is valid PowerShell. The new test parses it with
`[Parser]::ParseInput` and asserts no errors — verified failing against the
previous implementation.

476 tests, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)