### PR TITLE
Give an install command that runs without PowerShell 7

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -10,13 +10,13 @@
     installs from the clone it sits in when there is one. So both of these work:
 
         # from a clone
-        pwsh -NoProfile -ExecutionPolicy Bypass -File .\Install.ps1
+        powershell -NoProfile -ExecutionPolicy Bypass -File .\Install.ps1
 
         # from nothing but the URL
         $installer = Join-Path $env:TEMP 'Install-UpdateEverything.ps1'
         Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1 -OutFile $installer -UseBasicParsing
         Unblock-File $installer
-        pwsh -NoProfile -ExecutionPolicy Bypass -File $installer
+        powershell -NoProfile -ExecutionPolicy Bypass -File $installer
 
     Downloaded, then run, rather than piped through Invoke-Expression. The
     "irm ... | iex" idiom reads shorter but Defender blocks process creation on
@@ -55,10 +55,10 @@
     Return the installed module rather than only printing a summary.
 
 .EXAMPLE
-    pwsh -NoProfile -ExecutionPolicy Bypass -File .\Install.ps1 -FromGitHub
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\Install.ps1 -FromGitHub
 
 .EXAMPLE
-    pwsh -NoProfile -ExecutionPolicy Bypass -File .\Install.ps1 -Scope AllUsers
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\Install.ps1 -Scope AllUsers
 
 .NOTES
     Uninstall by deleting the folder this reports.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and tell you what happened with a toast notification.
 Nothing but the URL is needed. Paste this into PowerShell:
 
 ```powershell
-$i = Join-Path $env:TEMP 'Install-UpdateEverything.ps1'; Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1 -OutFile $i -UseBasicParsing; Unblock-File $i; pwsh -NoProfile -ExecutionPolicy Bypass -File $i
+$i = Join-Path $env:TEMP 'Install-UpdateEverything.ps1'; Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1 -OutFile $i -UseBasicParsing; Unblock-File $i; powershell -NoProfile -ExecutionPolicy Bypass -File $i
 ```
 
 It downloads the installer, which fetches the module from GitHub and installs it
@@ -54,7 +54,7 @@ git clone https://github.com/briankronberg/UpdateEverything.git
 ```
 
 ```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File .\UpdateEverything\Install.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\UpdateEverything\Install.ps1
 ```
 
 Add `-FromGitHub` to install what is published rather than what is in the

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -589,6 +589,27 @@ Describe 'Repository documentation' -Tag 'Docs' {
         $script:Readme | Should-MatchString 'ExecutionPolicy Bypass'
     }
 
+    # PowerShell 7 is one of the things this module installs, so the install
+    # instructions cannot require it to already be there. The documented command
+    # ended in "pwsh -NoProfile ... -File $i", and on a machine with only
+    # Windows PowerShell that is "The term 'pwsh' is not recognized" -- the
+    # download succeeds and the install never happens, on exactly the machine
+    # the instructions are written for.
+    #
+    # Scoped to the Install section and to lines that run a host against a
+    # -File, so the Defender demonstration further down (which says pwsh to make
+    # a point about process creation) and the developer test commands are left
+    # alone.
+    It 'gives an install command that runs on Windows PowerShell' {
+        $section = [regex]::Match($script:Readme, '(?s)\n## Install\r?\n(.*?)\r?\n## ').Groups[1].Value
+        $section | Should-NotBeEmptyString -Because 'the Install section should still be findable'
+
+        $offenders = $section -split "`r?`n" |
+            Where-Object { $_ -match '-File' -and $_ -match '\bpwsh\b' }
+
+        $offenders | Should-BeNull -Because "pwsh does not exist until this module installs it:`n$($offenders -join "`n")"
+    }
+
     # Written with StartsWith rather than a regex on purpose. The regex form
     # needed a backslash escaped through several layers of tooling, lost one on
     # the way, and silently matched nothing.


### PR DESCRIPTION
## The problem

The documented install command ends in:

```powershell
pwsh -NoProfile -ExecutionPolicy Bypass -File $i
```

`pwsh` only exists once PowerShell 7 is installed — **which is one of the things
this module installs**. On a machine with only Windows PowerShell, the download
succeeds and then:

```
The term 'pwsh' is not recognized as the name of a cmdlet, function,
script file, or operable program.
```

So the instructions cannot be followed on exactly the machine they are written
for, and they fail at the *last* step, after appearing to work.

## Install.ps1 never needed it

It declares `#Requires -Version 5.1`, uses no PowerShell 7 syntax, and installs
into both edition folders whichever host runs it.

Verified by running it under Windows PowerShell with `pwsh` removed from `PATH`:

```
pwsh available? False
UpdateEverything 1.0.0 is already installed at
  ...\Documents\PowerShell\Modules\UpdateEverything\1.0.0,
  ...\Documents\WindowsPowerShell\Modules\UpdateEverything\1.0.0
```

It reaches its own guard having resolved both destinations — so nothing is lost
by running it from 5.1.

## Scope

Changed only the lines that run a host against a `-File`:

- the install one-liner
- the from-a-clone command
- the four matching examples in `Install.ps1`'s help

**Deliberately left alone:**

- The Defender ASR demonstration, which says `pwsh` to make a point about
  process creation rather than asking anyone to run it.
- The test-suite commands, because `CONTRIBUTING.md` tells contributors to run
  the suite the way CI does.

## Testing

473 tests, 0 failed. The new Docs guard is scoped to the Install section and to
lines invoking a host with `-File`, and fails against the previous README on
both offending lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)