### PR TITLE
Give an install command that can be run twice

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -10,13 +10,13 @@
     installs from the clone it sits in when there is one. So both of these work:
 
         # from a clone
-        powershell -NoProfile -ExecutionPolicy Bypass -File .\Install.ps1
+        powershell -NoProfile -ExecutionPolicy Bypass -File .\Install.ps1 -Force
 
         # from nothing but the URL
         $installer = Join-Path $env:TEMP 'Install-UpdateEverything.ps1'
         Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1 -OutFile $installer -UseBasicParsing
         Unblock-File $installer
-        powershell -NoProfile -ExecutionPolicy Bypass -File $installer
+        powershell -NoProfile -ExecutionPolicy Bypass -File $installer -Force
 
     Downloaded, then run, rather than piped through Invoke-Expression. The
     "irm ... | iex" idiom reads shorter but Defender blocks process creation on

--- a/README.md
+++ b/README.md
@@ -10,13 +10,20 @@ and tell you what happened with a toast notification.
 Nothing but the URL is needed. Paste this into PowerShell:
 
 ```powershell
-$i = Join-Path $env:TEMP 'Install-UpdateEverything.ps1'; Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1 -OutFile $i -UseBasicParsing; Unblock-File $i; powershell -NoProfile -ExecutionPolicy Bypass -File $i
+$i = Join-Path $env:TEMP 'Install-UpdateEverything.ps1'; Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1 -OutFile $i -UseBasicParsing; Unblock-File $i; powershell -NoProfile -ExecutionPolicy Bypass -File $i -Force
 ```
 
 It downloads the installer, which fetches the module from GitHub and installs it
 into your own module path. No elevation, and it prints what it exported. Add
-`-Force` to overwrite an existing install, or `-Scope AllUsers` to install
-machine-wide, which does need elevation.
+`-Scope AllUsers` to install machine-wide, which does need elevation.
+
+`-Force` is in the command because the module installs into a folder named for
+its version, and the installer refuses to overwrite one that is already there.
+The version does not change with every commit, so a second install from `main`
+is an overwrite of `1.0.0` by `1.0.0` and stops without it. On a first install
+it does nothing; on every one after, it is what makes the line safe to paste
+again. Nothing is lost if it is interrupted: the installer stages the new copy
+and validates it before it replaces the old one.
 
 Then:
 
@@ -54,7 +61,7 @@ git clone https://github.com/briankronberg/UpdateEverything.git
 ```
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\UpdateEverything\Install.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\UpdateEverything\Install.ps1 -Force
 ```
 
 Add `-FromGitHub` to install what is published rather than what is in the

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -610,6 +610,31 @@ Describe 'Repository documentation' -Tag 'Docs' {
         $offenders | Should-BeNull -Because "pwsh does not exist until this module installs it:`n$($offenders -join "`n")"
     }
 
+    # The module installs into a folder named for its version and the installer
+    # refuses to overwrite one that exists. The version does not move with every
+    # commit, so a second install from main is 1.0.0 over 1.0.0 and stops. A
+    # documented command that works exactly once is worse than one that asks for
+    # a flag, because it looks like the instructions are wrong.
+    It 'gives an install command that can be run more than once' {
+        $section = [regex]::Match($script:Readme, '(?s)\n## Install\r?\n(.*?)\r?\n## ').Groups[1].Value
+
+        $installs = $section -split "`r?`n" |
+            Where-Object { $_ -match 'powershell .*-File' }
+
+        $installs | Should-NotBeNull -Because 'the Install section should still show how to run the installer'
+
+        $unforced = $installs | Where-Object { $_ -notmatch '(?i)\s-Force\b' }
+        $unforced | Should-BeNull -Because "these stop on a reinstall from main:`n$($unforced -join "`n")"
+    }
+
+    # -Force has to be an argument to the script, not part of its name. Written
+    # as 'Install-UpdateEverything.ps1 -force' inside the quotes it becomes the
+    # file name, and PowerShell then refuses the path for not ending in .ps1 --
+    # after the download has already succeeded.
+    It 'passes -Force to the installer rather than naming a file after it' {
+        $script:Readme | Should-NotMatchString "Join-Path \`$env:TEMP '[^']*-[Ff]orce'"
+    }
+
     # Written with StartsWith rather than a regex on purpose. The regex form
     # needed a backslash escaped through several layers of tooling, lost one on
     # the way, and silently matched nothing.


### PR DESCRIPTION
## The problem

The module installs into a folder named for its version, and the installer
refuses to overwrite one that already exists:

```
UpdateEverything 1.0.0 is already installed at ... Use -Force to overwrite it.
```

The version does not move with every commit, and the module is distributed from
`main` rather than the Gallery — so a second install is `1.0.0` over `1.0.0` and
stops. **The documented command worked exactly once**, which reads as the
instructions being wrong rather than as a deliberate guard.

## The change

`-Force` goes in the command. On a first install it does nothing; on every one
after, it is what makes the line safe to paste again.

It is not as blunt as it sounds: the installer stages the new copy and validates
that it loads before it replaces the old one, so an interrupted install cannot
leave a broken module behind.

The `-FromGitHub` and `-Scope AllUsers` examples are left alone — each
demonstrates one parameter, and the prose above them covers `-Force`.

## Two guards

Both verified failing against the form they catch:

- every install invocation in the Install section carries `-Force`
- `-Force` is an argument, not part of the file name

The second is not hypothetical. Written inside the quotes:

```powershell
$i = Join-Path $env:TEMP 'Install-UpdateEverything.ps1 -force'
```

`-force` becomes part of the *file name*, and PowerShell then refuses it:

```
Processing -File '...\Install-UpdateEverything.ps1 -force' failed because the
file does not have a '.ps1' extension.
```

That fails later and less obviously than no `-Force` at all — the download
succeeds first, and the shell drops to an interactive banner, so it looks like
something ran.

479 tests, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)