### PR TITLE
Add a fresh-machine smoke test

### DIFF
--- a/tests/FreshMachine/Invoke-FreshMachineTest.ps1
+++ b/tests/FreshMachine/Invoke-FreshMachineTest.ps1
@@ -1,0 +1,227 @@
+#Requires -Version 5.1
+
+<#
+    .SYNOPSIS
+    Installs UpdateEverything on an empty Windows and runs it without
+    administrator rights, in a throwaway Windows Sandbox.
+
+    .DESCRIPTION
+    The only test that exercises the module the way a new user meets it. Three
+    defects shipped in one day that nothing else could have caught, because each
+    is invisible on a machine where the module already works:
+
+      - the elevated relaunch command did not parse, so the child exited 1
+        before running a line. Self-elevation only happens when the session is
+        not already an administrator, and development sessions were
+      - the documented install required pwsh, which does not exist until this
+        module installs it
+      - the documented install worked exactly once, because the second run found
+        the version folder already there
+
+    A hosted CI runner cannot replace this. The windows-latest image runs as an
+    administrator, so the self-elevation path is never reached, and it ships
+    PowerShell 7, so the missing-pwsh case cannot arise. Both of the bugs this
+    is for are unreachable there.
+
+    Windows Sandbox is the right shape instead: genuinely empty, Windows
+    PowerShell only, discarded afterwards. Nothing this test does touches the
+    host, including the UAC change, which happens inside the sandbox.
+
+    .PARAMETER OutputPath
+    Where results are collected. Defaults to a timestamped folder under the
+    user's temp directory. Mapped into the sandbox read-write.
+
+    .PARAMETER TimeoutMinutes
+    How long to wait for the sandbox to report. Default 45.
+
+    .PARAMETER KeepSandboxOpen
+    Leave the sandbox running after the test finishes, to look around. Without
+    it the sandbox closes itself, which discards everything inside.
+
+    .EXAMPLE
+    .\Invoke-FreshMachineTest.ps1
+
+    .EXAMPLE
+    .\Invoke-FreshMachineTest.ps1 -KeepSandboxOpen -TimeoutMinutes 60
+
+    .OUTPUTS
+    An object with Passed, the individual checks, and where the logs were left.
+#>
+[CmdletBinding()]
+[OutputType([pscustomobject])]
+param(
+    [ValidateNotNullOrEmpty()]
+    [string] $OutputPath = (Join-Path ([System.IO.Path]::GetTempPath()) ('UE-FreshMachine-' + (Get-Date -Format 'yyyyMMdd-HHmmss'))),
+
+    [ValidateRange(5, 240)]
+    [int] $TimeoutMinutes = 45,
+
+    [switch] $KeepSandboxOpen
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot   = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$sandboxSrc = Join-Path $PSScriptRoot 'Sandbox'
+
+Write-Host ''
+Write-Host 'Fresh-machine smoke test' -ForegroundColor Cyan
+Write-Host "  repository : $repoRoot"
+Write-Host "  results    : $OutputPath"
+
+# --------------------------------------------------------------------------
+# Prerequisites, checked before anything is created. Each failure says what to
+# do about it, because "sandbox unavailable" on its own sends people hunting.
+# --------------------------------------------------------------------------
+$problems = [System.Collections.Generic.List[string]]::new()
+
+$edition = (Get-CimInstance Win32_OperatingSystem).Caption
+if ($edition -notmatch 'Pro|Enterprise|Education') {
+    $problems.Add("Windows Sandbox needs Pro, Enterprise or Education. This is '$edition'.")
+}
+
+if (-not (Get-CimInstance Win32_ComputerSystem).HypervisorPresent) {
+    $problems.Add('No hypervisor is present. Virtualization has to be enabled in firmware.')
+}
+
+$feature = Get-WindowsOptionalFeature -Online -FeatureName 'Containers-DisposableClientVM' -ErrorAction SilentlyContinue
+if (-not $feature -or $feature.State -ne 'Enabled') {
+    $problems.Add(
+        'Windows Sandbox is not enabled. From an elevated session: ' +
+        'Enable-WindowsOptionalFeature -Online -FeatureName Containers-DisposableClientVM -All')
+}
+
+$sandboxExe = Join-Path $env:WINDIR 'System32\WindowsSandbox.exe'
+if (-not (Test-Path -LiteralPath $sandboxExe)) {
+    $problems.Add("WindowsSandbox.exe was not found at $sandboxExe.")
+}
+
+if ($problems.Count -gt 0) {
+    Write-Host ''
+    Write-Warning 'Cannot run the fresh-machine test here:'
+    foreach ($problem in $problems) { Write-Warning "  $problem" }
+    return [pscustomobject]@{
+        PSTypeName = 'UpdateEverything.SmokeResult'
+        Passed     = $false
+        Ran        = $false
+        Reason     = ($problems -join ' ')
+        Checks     = @()
+        OutputPath = $null
+    }
+}
+
+$null = New-Item -ItemType Directory -Path $OutputPath -Force
+
+# --------------------------------------------------------------------------
+# The sandbox configuration. Written per run, because the mapped paths depend
+# on where the repository was cloned.
+# --------------------------------------------------------------------------
+$logon = '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass ' +
+    '-File "C:\smoke\Start-Harness.ps1" -RepoPath "C:\repo" -OutputPath "C:\out"'
+
+# Escaped, not interpolated raw. '&' is legal in a Windows path and fatal in
+# XML: a clone under C:\dev\R&D produces a .wsb the sandbox rejects, and it
+# reports that as a malformed file rather than as the ampersand it is.
+$escapedRepo    = [System.Security.SecurityElement]::Escape($repoRoot)
+$escapedSandbox = [System.Security.SecurityElement]::Escape($sandboxSrc)
+$escapedOutput  = [System.Security.SecurityElement]::Escape($OutputPath)
+$escapedLogon   = [System.Security.SecurityElement]::Escape($logon)
+
+$wsb = @"
+<Configuration>
+  <MappedFolders>
+    <MappedFolder>
+      <HostFolder>$escapedRepo</HostFolder>
+      <SandboxFolder>C:\repo</SandboxFolder>
+      <ReadOnly>true</ReadOnly>
+    </MappedFolder>
+    <MappedFolder>
+      <HostFolder>$escapedSandbox</HostFolder>
+      <SandboxFolder>C:\smoke</SandboxFolder>
+      <ReadOnly>true</ReadOnly>
+    </MappedFolder>
+    <MappedFolder>
+      <HostFolder>$escapedOutput</HostFolder>
+      <SandboxFolder>C:\out</SandboxFolder>
+      <ReadOnly>false</ReadOnly>
+    </MappedFolder>
+  </MappedFolders>
+  <LogonCommand>
+    <Command>$escapedLogon</Command>
+  </LogonCommand>
+  <Networking>Enable</Networking>
+  <MemoryInMB>8192</MemoryInMB>
+</Configuration>
+"@
+
+$wsbPath = Join-Path $OutputPath 'FreshMachine.wsb'
+[System.IO.File]::WriteAllText($wsbPath, $wsb, [System.Text.UTF8Encoding]::new($false))
+
+# The XML is generated from paths that may contain anything, so prove it parses
+# before handing it to the sandbox, which reports a malformed file unhelpfully.
+try {
+    $null = [xml] $wsb
+} catch {
+    throw "The generated sandbox configuration is not valid XML: $($_.Exception.Message)"
+}
+
+Write-Host ''
+Write-Host 'Starting Windows Sandbox. It installs from GitHub, so it needs a network.' -ForegroundColor Yellow
+Write-Host 'Leave it alone; it drives itself and closes when it is done.'
+
+Start-Process -FilePath $sandboxExe -ArgumentList "`"$wsbPath`""
+
+$resultFile = Join-Path $OutputPath 'result.json'
+$deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+$spin = 0
+
+while (-not (Test-Path -LiteralPath $resultFile) -and (Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 10
+    $spin += 10
+    if ($spin % 60 -eq 0) {
+        Write-Host "  still running, $([int]((Get-Date) - $deadline).TotalMinutes * -1) minute(s) left"
+    }
+}
+
+if (-not (Test-Path -LiteralPath $resultFile)) {
+    Write-Warning "No result after $TimeoutMinutes minutes. Anything the sandbox wrote is in $OutputPath."
+    return [pscustomobject]@{
+        PSTypeName = 'UpdateEverything.SmokeResult'
+        Passed     = $false
+        Ran        = $true
+        Reason     = "Timed out after $TimeoutMinutes minutes."
+        Checks     = @()
+        OutputPath = $OutputPath
+    }
+}
+
+$result = Get-Content -LiteralPath $resultFile -Raw | ConvertFrom-Json
+
+Write-Host ''
+foreach ($check in $result.Checks) {
+    $colour = if ($check.Passed) { 'Green' } else { 'Red' }
+    $mark   = if ($check.Passed) { 'PASS' } else { 'FAIL' }
+    Write-Host ("  [{0}] {1}" -f $mark, $check.Name) -ForegroundColor $colour
+    if ($check.Detail) { Write-Host "         $($check.Detail)" -ForegroundColor DarkGray }
+}
+
+Write-Host ''
+if ($result.Passed) {
+    Write-Host 'Fresh-machine test passed.' -ForegroundColor Green
+} else {
+    Write-Host 'Fresh-machine test FAILED.' -ForegroundColor Red
+}
+Write-Host "Logs and transcripts: $OutputPath"
+
+if (-not $KeepSandboxOpen) {
+    Write-Host 'The sandbox closes itself; everything inside it is discarded.' -ForegroundColor DarkGray
+}
+
+[pscustomobject]@{
+    PSTypeName = 'UpdateEverything.SmokeResult'
+    Passed     = [bool] $result.Passed
+    Ran        = $true
+    Reason     = ''
+    Checks     = $result.Checks
+    OutputPath = $OutputPath
+}

--- a/tests/FreshMachine/README.md
+++ b/tests/FreshMachine/README.md
@@ -1,0 +1,91 @@
+# Fresh-machine smoke test
+
+Installs the module on an empty Windows and runs it **without administrator
+rights**, in a throwaway Windows Sandbox.
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\FreshMachine\Invoke-FreshMachineTest.ps1
+```
+
+It is not part of `test.ps1`. Pester discovers `*.Tests.ps1` only, so nothing
+here runs with the suite; it needs a hypervisor and several minutes, and it
+belongs before a release rather than before a commit.
+
+## Why it exists
+
+Three defects shipped in one day that nothing else could have caught, because
+each is invisible on a machine where the module already works.
+
+| Defect | Why the suite missed it |
+|---|---|
+| The elevated relaunch command did not parse, so the child exited 1 before running a line | Self-elevation only happens when the session is **not** already an administrator, and development sessions were |
+| The documented install required `pwsh` | Which does not exist until this module installs it |
+| The documented install worked exactly once | The second run found the version folder already there |
+
+Each was found by a person on a new laptop, twice within twenty seconds.
+
+## Why not CI
+
+The obvious answer does not work. The `windows-latest` runner executes as an
+administrator, so `Test-IsAdministrator` returns true and the self-elevation
+path is never reached — the exact code that broke stays untested. It also ships
+PowerShell 7, so the missing-`pwsh` case cannot arise. Both of the bugs this is
+for are unreachable on a hosted runner.
+
+Windows Sandbox is the right shape instead: genuinely empty, Windows PowerShell
+only, discarded afterwards.
+
+## What it checks
+
+- The machine really is fresh — `pwsh` is absent before anything runs
+- The install command **from README.md**, run twice. The second run is what
+  `-Force` exists for
+- The payload ran with no administrator rights, so self-elevation was exercised
+- **Two** transcripts appeared: the parent's, recording the handoff, and the
+  elevated child's own. One means the child died before it could log, which is
+  precisely how the relaunch parse error presented
+- A transcript reached the summary, and `FailedCount` came back a number
+
+The install command is read out of `README.md` rather than copied here. A smoke
+test carrying its own copy tests the copy, and two of the three defects above
+were *in* the documented command.
+
+## The UAC part
+
+Self-elevation raises a prompt, and an unattended test cannot click it. Turning
+UAC off is not the workaround: `Test-ElevationCapability` reads `EnableLUA` and
+refuses the run outright when it is `0`, so the harness would measure the
+refusal rather than the handoff.
+
+The harness leaves `EnableLUA` at `1` and sets `ConsentPromptBehaviorAdmin` to
+`0` — elevate without prompting. UAC stays enabled, the capability check still
+passes, and the child starts with nobody at the keyboard. This happens inside
+the sandbox and is discarded with it; the host is untouched.
+
+## Prerequisites
+
+Checked before anything is created, each with what to do about it:
+
+- Windows Pro, Enterprise or Education
+- Virtualization enabled in firmware
+- Windows Sandbox turned on:
+
+```powershell
+Enable-WindowsOptionalFeature -Online -FeatureName Containers-DisposableClientVM -All
+```
+
+The sandbox needs a network, because the install command fetches the module from
+GitHub — so it tests `main`, not the working copy. That is deliberate: it is the
+path a new user takes.
+
+## Files
+
+| File | Runs |
+|---|---|
+| `Invoke-FreshMachineTest.ps1` | On the host. Checks prerequisites, writes the `.wsb`, starts the sandbox, waits, reports |
+| `Sandbox\Start-Harness.ps1` | Inside, elevated, from the logon command |
+| `Sandbox\Invoke-UnelevatedRun.ps1` | Inside, **unelevated**, via a scheduled task at `RunLevel Limited` |
+
+That last hop is the one that matters. A scheduled task at `RunLevel Limited` is
+how an elevated session starts a genuinely unelevated child of the same user;
+without it the harness would run as an administrator and test nothing.

--- a/tests/FreshMachine/Sandbox/Invoke-UnelevatedRun.ps1
+++ b/tests/FreshMachine/Sandbox/Invoke-UnelevatedRun.ps1
@@ -1,0 +1,74 @@
+#Requires -Version 5.1
+
+<#
+    .SYNOPSIS
+    Runs Update-Everything without administrator rights, inside the sandbox.
+
+    .DESCRIPTION
+    This is the payload the whole smoke test exists to execute. It must run
+    unelevated, because self-elevation is the code under test: when the session
+    is already an administrator that path is never reached, which is exactly why
+    a parse error in the relaunch command survived development and shipped.
+
+    The harness starts it through a scheduled task at RunLevel Limited, which is
+    how an elevated session gets a genuinely unelevated child of the same user.
+
+    Windows Update is turned off. It is the one step that can run for hours, and
+    it proves nothing here -- the question is whether the elevated relaunch
+    happens at all, not whether Windows has patches.
+
+    .PARAMETER ResultPath
+    Where to write what happened, as JSON, for the harness to collect.
+
+    .EXAMPLE
+    Invoke-UnelevatedRun.ps1 -ResultPath C:\smoke-out\unelevated.json
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $ResultPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal] $identity
+
+$result = [ordered]@{
+    Started      = (Get-Date).ToString('o')
+    User         = $identity.Name
+    Elevated     = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    PSVersion    = $PSVersionTable.PSVersion.ToString()
+    PSEdition    = $PSVersionTable.PSEdition
+    Imported     = $false
+    Ran          = $null
+    Elevated_Run = $null
+    FailedCount  = $null
+    Reason       = $null
+    Error        = $null
+}
+
+try {
+    Import-Module UpdateEverything -Force
+    $result.Imported = $true
+
+    # Bare, so the elevation handoff happens. The result object comes back from
+    # the parent; the child's own transcript is what the harness counts.
+    $run = Update-Everything -IncludeWindowsUpdate $false
+
+    $result.Ran          = $run.Ran
+    $result.Elevated_Run = $run.Elevated
+    $result.FailedCount  = $run.FailedCount
+    $result.Reason       = $run.Reason
+} catch {
+    $result.Error = $_.Exception.Message
+}
+
+$result.Finished = (Get-Date).ToString('o')
+
+# Written last and in one go, so the harness never reads a half-finished file.
+[System.IO.File]::WriteAllText(
+    $ResultPath,
+    ([pscustomobject] $result | ConvertTo-Json -Depth 4),
+    [System.Text.UTF8Encoding]::new($false))

--- a/tests/FreshMachine/Sandbox/Start-Harness.ps1
+++ b/tests/FreshMachine/Sandbox/Start-Harness.ps1
@@ -1,0 +1,209 @@
+#Requires -Version 5.1
+
+<#
+    .SYNOPSIS
+    Drives the fresh-machine smoke test from inside Windows Sandbox.
+
+    .DESCRIPTION
+    Started by the sandbox logon command, which runs elevated. Everything that
+    needs administrator rights happens here; the part under test is handed to an
+    unelevated child.
+
+    The install command is read out of README.md rather than copied into this
+    file. A smoke test with its own copy of the command tests the copy, and the
+    three defects this exists to catch were all in the documented command or on
+    the path it leads to.
+
+    UAC is left enabled and only the consent behaviour is changed. Turning UAC
+    off would be the obvious way to get an unattended elevation, and it would
+    test the wrong thing: Test-ElevationCapability reads EnableLUA and refuses
+    the run outright when it is 0, so the harness would be measuring the refusal
+    rather than the handoff.
+
+    .PARAMETER RepoPath
+    The repository, mapped into the sandbox read-only. README.md is read from
+    here.
+
+    .PARAMETER OutputPath
+    A folder mapped read-write, where results are left for the host.
+
+    .EXAMPLE
+    Start-Harness.ps1 -RepoPath C:\repo -OutputPath C:\smoke-out
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $RepoPath,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$transcript = Join-Path $OutputPath 'harness.log'
+Start-Transcript -Path $transcript -Force | Out-Null
+
+$checks = [System.Collections.Generic.List[object]]::new()
+function Add-Check {
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][bool]   $Passed,
+        [string] $Detail
+    )
+    $checks.Add([pscustomobject]@{ Name = $Name; Passed = $Passed; Detail = $Detail })
+    $mark = if ($Passed) { 'PASS' } else { 'FAIL' }
+    Write-Output ("  [{0}] {1}{2}" -f $mark, $Name, $(if ($Detail) { " -- $Detail" } else { '' }))
+}
+
+try {
+    Write-Output '== Environment =='
+    $os = Get-CimInstance Win32_OperatingSystem
+    Write-Output "  $($os.Caption) build $($os.BuildNumber)"
+    Write-Output "  PowerShell $($PSVersionTable.PSVersion) ($($PSVersionTable.PSEdition))"
+
+    # The premise of the whole exercise. If pwsh is already here, this is not a
+    # fresh machine and the missing-pwsh case cannot be observed.
+    $pwshPresent = [bool] (Get-Command pwsh -CommandType Application -ErrorAction SilentlyContinue)
+    Add-Check -Name 'machine has no PowerShell 7 to start with' -Passed (-not $pwshPresent) `
+        -Detail $(if ($pwshPresent) { 'pwsh resolved; this is not a fresh machine' } else { 'pwsh absent, as expected' })
+
+    Write-Output ''
+    Write-Output '== UAC =='
+    # EnableLUA stays 1 so Test-ElevationCapability still allows the run.
+    # ConsentPromptBehaviorAdmin 0 means "elevate without prompting", which is
+    # what lets the child start with nobody at the keyboard.
+    $policy = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+    Set-ItemProperty -Path $policy -Name 'ConsentPromptBehaviorAdmin' -Value 0 -Type DWord
+    $enableLua = (Get-ItemProperty -Path $policy -Name 'EnableLUA').EnableLUA
+    $consent   = (Get-ItemProperty -Path $policy -Name 'ConsentPromptBehaviorAdmin').ConsentPromptBehaviorAdmin
+    Write-Output "  EnableLUA=$enableLua ConsentPromptBehaviorAdmin=$consent"
+    Add-Check -Name 'UAC still enabled' -Passed ($enableLua -eq 1) -Detail "EnableLUA=$enableLua"
+
+    Write-Output ''
+    Write-Output '== Install command, taken from README =='
+    $readme = Get-Content (Join-Path $RepoPath 'README.md') -Raw
+
+    # The first fenced powershell block in the Install section is the command a
+    # new user pastes.
+    $section = [regex]::Match($readme, '(?s)\n## Install\r?\n(.*?)\r?\n## ').Groups[1].Value
+    $command = [regex]::Match($section, '(?s)```powershell\r?\n(.*?)```').Groups[1].Value.Trim()
+
+    $found = -not [string]::IsNullOrWhiteSpace($command)
+    Add-Check -Name 'install command found in README' -Passed $found
+    if (-not $found) { throw 'Could not extract the install command from README.md.' }
+    Write-Output "  $command"
+
+    # Twice. The second run is what -Force exists for: the module installs into
+    # a folder named for its version, and the version does not move per commit.
+    foreach ($attempt in 1, 2) {
+        Write-Output ''
+        Write-Output "-- install attempt $attempt --"
+        $installLog = Join-Path $OutputPath "install-$attempt.log"
+
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $command *> $installLog
+        $code = $LASTEXITCODE
+
+        $text = Get-Content $installLog -Raw
+        $ok = ($code -eq 0) -and ($text -match 'Installed UpdateEverything')
+        Add-Check -Name "install succeeds (attempt $attempt)" -Passed $ok -Detail "exit $code"
+        Write-Output ($text -split "`r?`n" | Select-Object -Last 12 | ForEach-Object { "    $_" })
+    }
+
+    Write-Output ''
+    Write-Output '== Unelevated run =='
+    $logDir = Join-Path $env:USERPROFILE 'UpdateLogs'
+    $before = @()
+    if (Test-Path $logDir) {
+        $before = @((Get-ChildItem $logDir -Filter 'Update-Everything-*.log').Name)
+    }
+
+    # A scheduled task at RunLevel Limited is how an elevated session starts a
+    # genuinely unelevated child of the same user.
+    $runResult = Join-Path $OutputPath 'unelevated.json'
+    $payload   = Join-Path $PSScriptRoot 'Invoke-UnelevatedRun.ps1'
+
+    $taskName = 'UpdateEverything-SmokeTest'
+    $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$payload`" -ResultPath `"$runResult`""
+    $taskPrincipal = New-ScheduledTaskPrincipal `
+        -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) `
+        -LogonType Interactive `
+        -RunLevel Limited
+
+    $register = @{
+        TaskName  = $taskName
+        Action    = $action
+        Principal = $taskPrincipal
+        Force     = $true
+    }
+    Register-ScheduledTask @register | Out-Null
+    Start-ScheduledTask -TaskName $taskName
+
+    Write-Output '  waiting for the unelevated run to finish...'
+    $deadline = (Get-Date).AddMinutes(30)
+    while (-not (Test-Path $runResult) -and (Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 5
+    }
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+
+    $produced = Test-Path $runResult
+    Add-Check -Name 'unelevated run produced a result' -Passed $produced `
+        -Detail $(if ($produced) { '' } else { 'timed out after 30 minutes' })
+    if (-not $produced) { throw 'The unelevated run never wrote its result.' }
+
+    $run = Get-Content $runResult -Raw | ConvertFrom-Json
+    Write-Output "  ran as $($run.User), elevated=$($run.Elevated)"
+
+    Add-Check -Name 'payload ran without administrator rights' -Passed (-not $run.Elevated) `
+        -Detail "elevated=$($run.Elevated)"
+    Add-Check -Name 'module imported after install' -Passed ([bool] $run.Imported)
+    Add-Check -Name 'run reported no error' -Passed ([string]::IsNullOrEmpty($run.Error)) -Detail $run.Error
+
+    Write-Output ''
+    Write-Output '== Transcripts =='
+    $after = @((Get-ChildItem $logDir -Filter 'Update-Everything-*.log' -ErrorAction SilentlyContinue).Name)
+    $new = @($after | Where-Object { $_ -notin $before })
+    Write-Output "  new transcripts: $($new.Count)"
+    $new | ForEach-Object { Write-Output "    $_" }
+
+    # Two: the parent's, which records the handoff, and the elevated child's own.
+    # One means the child died before it could log -- which is exactly how the
+    # relaunch parse error presented, and why counting them is the assertion.
+    Add-Check -Name 'both parent and elevated child left a transcript' -Passed ($new.Count -ge 2) `
+        -Detail "$($new.Count) found"
+
+    $childReachedSummary = $false
+    foreach ($name in $new) {
+        $body = Get-Content (Join-Path $logDir $name) -Raw
+        if ($body -match 'Maintenance run started' -and $body -match '=+ SUMMARY =+') {
+            $childReachedSummary = $true
+        }
+        Copy-Item (Join-Path $logDir $name) (Join-Path $OutputPath $name) -Force
+    }
+    Add-Check -Name 'a transcript reached the summary' -Passed $childReachedSummary
+
+    Add-Check -Name 'FailedCount came back as a number' -Passed ($null -ne $run.FailedCount) `
+        -Detail "FailedCount=$($run.FailedCount)"
+} catch {
+    Add-Check -Name 'harness completed' -Passed $false -Detail $_.Exception.Message
+    Write-Output "HARNESS ERROR: $($_.Exception.Message)"
+}
+
+$summary = [pscustomobject]@{
+    Finished = (Get-Date).ToString('o')
+    Passed   = @($checks | Where-Object { -not $_.Passed }).Count -eq 0
+    Checks   = $checks.ToArray()
+}
+
+Write-Output ''
+Write-Output "== $(if ($summary.Passed) { 'ALL CHECKS PASSED' } else { 'FAILURES PRESENT' }) =="
+
+[System.IO.File]::WriteAllText(
+    (Join-Path $OutputPath 'result.json'),
+    ($summary | ConvertTo-Json -Depth 5),
+    [System.Text.UTF8Encoding]::new($false))
+
+Stop-Transcript | Out-Null

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -57,6 +57,12 @@ BeforeDiscovery {
     $LintTargets += (Join-Path $ModuleRoot 'UpdateEverything.psm1')
     $LintTargets += (Join-Path $RepoRoot 'test.ps1')
     $LintTargets += (Join-Path $RepoRoot 'Install.ps1')
+
+    # The fresh-machine harness. Pester never runs these -- it discovers
+    # *.Tests.ps1 only -- but they are the house style's problem like anything
+    # else, and nothing else in the suite would look at them.
+    $LintTargets += @(Get-ChildItem -Path (Join-Path $RepoRoot 'tests\FreshMachine') -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.FullName })
 }
 
 BeforeAll {


### PR DESCRIPTION
Installs from the README command on an empty Windows and completes one
**unelevated** run, in a throwaway Windows Sandbox.

## Why

Three defects shipped in a single day that nothing in the suite could have
caught, because each is invisible on a machine where the module already works:

| Defect | Why the suite missed it |
|---|---|
| The elevated relaunch command did not parse — child exited 1 before running a line | Self-elevation only happens when the session is **not** already an administrator |
| The documented install required `pwsh` | Which does not exist until this module installs it |
| The documented install worked exactly once | The second run found the version folder already there |

All three were found by a person on a new laptop, two of them within twenty
seconds of each other.

## Why not CI

`windows-latest` executes as an administrator, so `Test-IsAdministrator` returns
true and the self-elevation path is never reached. It also ships PowerShell 7,
so the missing-`pwsh` case cannot arise. **Both bugs are unreachable on a hosted
runner.** Windows Sandbox is empty, has Windows PowerShell only, and is
discarded afterwards.

## Three things this had to get right

**Getting an unelevated child out of an elevated session.** A scheduled task at
`RunLevel Limited` does it — measured on a real machine, the child reported
`elevated=False` as the same user. Without that hop the harness runs as an
administrator and tests nothing.

**UAC.** Turning it off is the obvious way to elevate unattended and the wrong
one: `Test-ElevationCapability` reads `EnableLUA` and refuses outright at `0`, so
the harness would measure the refusal rather than the handoff. `EnableLUA` stays
`1` and `ConsentPromptBehaviorAdmin` goes to `0` — elevate without prompting —
inside the sandbox, which is discarded.

**The install command is read out of `README.md`, not copied.** A smoke test
carrying its own copy tests the copy, and two of the three defects were *in* the
documented command.

## The assertion that matters

A working run leaves **two** transcripts: the parent's, recording the handoff,
and the elevated child's own. One means the child died before it could log —
which is exactly how the relaunch parse error presented.

## Also

Mapped paths are XML-escaped. `&` is legal in a Windows path and fatal in a
`.wsb`; a clone under `C:\dev\R&D` would otherwise produce a file the sandbox
rejects as malformed without saying why.

## Verified here, as far as it goes

- All three scripts parse and lint clean under the repository settings, the same
  bar `Install.ps1` meets — they are added to `$LintTargets`
- The README extraction returns the command (265 chars)
- The prerequisite check correctly refuses on this machine and names the command
  that enables the feature
- The de-elevation and XML-escaping mechanisms were each measured separately

**Not yet run end to end** — this machine has `Containers-DisposableClientVM`
disabled. That is the one step remaining, and it needs the feature enabled.

Not part of `test.ps1`: Pester discovers `*.Tests.ps1` only, and this needs a
hypervisor and several minutes. It is a pre-release gate.

482 tests, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)