### PR TITLE
Stop the install hint reading as a parameter of the command

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -215,8 +215,15 @@ try {
     Write-Host "  Scope    : $Scope"
     Write-Host "  Commands : $((Get-Command -Module UpdateEverything -CommandType Function).Name -join ', ')"
     Write-Host ''
-    Write-Host '  Try it without changing anything:'
-    Write-Host '    Get-Help Update-Everything -Full'
+    # -Full goes before the name. Written as "Get-Help Update-Everything -Full"
+    # it is still a correct Get-Help call, but it reads as though -Full were a
+    # mode of Update-Everything, and it was tried as one. Nothing trails the
+    # command name now, so there is nothing to misattribute to it.
+    Write-Host '  Read what it does, without running it:'
+    Write-Host '    Get-Help -Full -Name Update-Everything'
+    Write-Host ''
+    Write-Host '  Run everything:'
+    Write-Host '    Update-Everything'
     Write-Host ''
     Write-Host '  A cautious first run:'
     Write-Host '    Update-Everything -IncludeWindowsUpdate $false -IncludePowerShell7 $false -SetPwshTerminalDefault $false'

--- a/src/en-us/about_UpdateEverything.help.txt
+++ b/src/en-us/about_UpdateEverything.help.txt
@@ -76,4 +76,4 @@ EXAMPLES
 
 SEE ALSO
     https://github.com/briankronberg/UpdateEverything
-    Get-Help Update-Everything -Full
+    Get-Help -Full -Name Update-Everything

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -661,6 +661,71 @@ Describe 'Repository documentation' -Tag 'Docs' {
     }
 }
 
+Describe 'Nothing shows a parameter the command does not have' -Tag 'Docs' {
+
+    # The installer printed
+    #
+    #     Get-Help Update-Everything -Full
+    #
+    # which is a correct Get-Help call and reads as though -Full were a mode of
+    # Update-Everything. Someone typed "update-everything -full" and got "A
+    # parameter cannot be found that matches parameter name 'full'" from the
+    # first command they ran after installing.
+    #
+    # Anything that follows the command name in text will be read as belonging
+    # to it, whatever the parser thinks, so nothing that is not a real parameter
+    # may sit there.
+
+    BeforeAll {
+        # Comments are not shown to anyone; Write-Host arguments are. Taking the
+        # strings from the AST keeps an explanation of this very bug from
+        # tripping it.
+        $installPath = Join-Path $script:RepoRoot 'Install.ps1'
+        $installAst = [System.Management.Automation.Language.Parser]::ParseFile(
+            $installPath, [ref] $null, [ref] $null)
+
+        $printed = $installAst.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -in 'Write-Host', 'Write-Output'
+            }, $true) | ForEach-Object {
+            $_.CommandElements |
+                Where-Object { $_ -is [System.Management.Automation.Language.StringConstantExpressionAst] } |
+                ForEach-Object { $_.Value }
+        }
+
+        $aboutPath = Join-Path $script:ModuleRoot 'en-us\about_UpdateEverything.help.txt'
+
+        $script:UserFacingText = @(
+            ($printed -join "`n")
+            $script:Readme
+            (Get-Content $aboutPath -Raw)
+        ) -join "`n"
+
+        $script:RealParameters = (Get-Command Update-Everything).Parameters.Keys
+    }
+
+    It 'shows only real parameters after Update-Everything' {
+        $offenders = foreach ($match in [regex]::Matches($script:UserFacingText, 'Update-Everything((?:\s+-[A-Za-z]\w*)+)')) {
+            foreach ($p in [regex]::Matches($match.Groups[1].Value, '-([A-Za-z]\w*)')) {
+                $name = $p.Groups[1].Value
+                if ($name -notin $script:RealParameters) {
+                    "-$name (in: $($match.Value -replace '\s+', ' '))"
+                }
+            }
+        }
+
+        $offenders | Should-BeNull -Because "these read as parameters of Update-Everything and are not:`n$($offenders -join "`n")"
+    }
+
+    # The command needs no arguments to do its work, and the installer used to
+    # show only a help command and a cut-down run -- so the obvious question,
+    # "how do I just run it", had no answer on screen.
+    It 'tells a new user how to run everything' {
+        ($printed -join "`n") | Should-MatchString '(?m)^\s*Update-Everything\s*$'
+    }
+}
+
 Describe 'Variable hygiene' -Tag 'Static' {
 
     # Set-StrictMode would catch undefined variable reads at run time, but it


### PR DESCRIPTION
## What happened

The installer printed:

```
  Try it without changing anything:
    Get-Help Update-Everything -Full
```

That is a correct `Get-Help` call — `-Full` belongs to `Get-Help`. But it reads
as though `-Full` were a mode of `Update-Everything`, and it was typed as one.
The first command someone ran after installing answered:

```
Update-Everything: A parameter cannot be found that matches parameter name 'full'.
```

## The fix

Put `-Full` before the name, so nothing trails the command and there is nothing
to misattribute to it:

```
  Read what it does, without running it:
    Get-Help -Full -Name Update-Everything
```

The about-help `SEE ALSO` had the same line and gets the same fix.

## The question underneath it

"There should be a `-Full`." Fair — because the installer showed a help command
and a *cut-down* run, so **"how do I just run it" had no answer on screen.** It
does now:

```
  Run everything:
    Update-Everything
```

That already **is** the full run. Every switch that is off by default is off
because turning it on has a cost — a reboot, a prerelease, a moved pinned
toolchain — which the suite states as a rule.

And a `-Full` meaning "all of them" would not be coherent: two of the six are
not *more* work at all. `-SkipElevation` makes the run do **less** (admin steps
become `Skipped`), and `-PromptBeforeRun` **pauses and waits**, the opposite of
an unattended full run. So there is no `-Full`, and the bare command is what it
would have been.

## Guards

Two, both verified failing against the text that shipped:

- nothing shows a parameter after `Update-Everything` that the command does not
  have — caught `-Full` in both the installer and the about-help
- the installer tells a new user how to run everything

The first reads `Write-Host` arguments out of the AST rather than scanning the
file, so the comment that explains this bug does not trip it.

481 tests, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)