### PR TITLE
Let the module update itself from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ thing that crosses a process boundary.
 | `-Notify` | off | Show a toast when the run finishes, plus an urgent one if a restart is needed. Intended for scheduled runs. |
 | `-AllowInstall` | *(none)* | Which missing components may be installed: `All`, or any of `PowerShell7`, `PSWindowsUpdate`, `NuGetProvider`, `BurntToast`, `PowerShellGet`. |
 | `-LogRetentionDays` | `30` | Prune logs and settings.json backups older than this. `0` keeps everything. |
+| `-UpdateSelf` | off | Reinstall this module from GitHub first, whether or not the version differs. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. Off by default because it fetches and runs an installer from a branch. |
 
 ## What it updates
 

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -139,6 +139,25 @@
         The reason is repeated in the closing summary, because by then the original
         warning has scrolled well out of sight.
 
+    .PARAMETER UpdateSelf
+        Reinstall this module from GitHub before doing anything else, whether or
+        not the installed version differs. Default: $false.
+
+        The version does not move with every commit and the module is
+        distributed from a branch rather than the PowerShell Gallery, so
+        "already 1.0.0" is the normal state of an out-of-date copy. This is what
+        makes tracking main practical.
+
+        It takes effect on the *next* run. Unlike winget, which is a fresh
+        process every step, this module is already loaded by the time it runs:
+        the files on disk are replaced, and the functions executing now stay on
+        the code already in memory.
+
+        Off by default, and deliberately. It fetches and runs an installer from
+        a branch, which is a supply-chain decision rather than a routine update,
+        and a scheduled task that quietly followed main would be making that
+        decision every week on its own.
+
     .PARAMETER LogRetentionDays
         Delete logs and settings.json backups in the log directory older than this
         many days. Default: 30. Set to 0 to keep everything.
@@ -191,7 +210,8 @@
         [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet')]
         [string[]] $AllowInstall = @(),
         [ValidateRange(0, 3650)]
-        [int]    $LogRetentionDays       = 30
+        [int]    $LogRetentionDays       = 30,
+        [switch] $UpdateSelf
     )
 
     # $script:, not a plain local. As a script these lived at script scope and
@@ -353,6 +373,46 @@
     $WingetNothingToDo = @(-1978335189, -1978335212)
 
     Write-Host "Maintenance run started $(Get-Date)  |  Admin: $isAdmin  |  Main Log: $mainLog" -ForegroundColor Green
+
+    # ---------------------------------------------------------------------------
+    # 1b. The module itself
+    # ---------------------------------------------------------------------------
+    if ($UpdateSelf) {
+        Invoke-Step -Name 'UpdateEverything (self)' -Action {
+            # Reinstalls whether or not the version differs. The version does not
+            # move with every commit and the module is distributed from a branch
+            # rather than the gallery, so "already 1.0.0" is the normal state of
+            # an out-of-date copy and is no reason to skip.
+            $uri = 'https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1'
+            $installer = Join-Path ([System.IO.Path]::GetTempPath()) "Install-UpdateEverything-$script:runStamp.ps1"
+
+            try {
+                Write-Output "Fetching the installer from $uri"
+                Invoke-WebRequest -Uri $uri -OutFile $installer -UseBasicParsing -ErrorAction Stop
+                Unblock-File -LiteralPath $installer -ErrorAction SilentlyContinue
+
+                # In a child process, and powershell rather than the current
+                # host: the installer imports the module when it finishes, and
+                # doing that inside the session currently running a function
+                # from that module is asking for trouble. powershell.exe is also
+                # always present, which pwsh is not.
+                & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer -Force
+                if ($LASTEXITCODE -ne 0) {
+                    throw "The installer exited with code $LASTEXITCODE."
+                }
+
+                # Said plainly, because the obvious assumption is wrong. Unlike
+                # winget, which is a fresh process every step, this module is
+                # already loaded: the functions running now stay on the old code
+                # however new the files on disk are.
+                Write-Output 'Updated. The new version loads on the next run; this one continues on the code already in memory.'
+            } finally {
+                Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
+            }
+        }
+    } else {
+        Add-SkippedStep -Name 'UpdateEverything (self)' -Reason 'not requested (-UpdateSelf)'
+    }
 
     # ---------------------------------------------------------------------------
     # 2. winget (apps from winget + Microsoft Store sources)

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -30,13 +30,14 @@ BeforeDiscovery {
         @{ Name = 'PromptTimeoutSeconds';      TypeName = 'int';      Type = [int];      Default = '60' }
         @{ Name = 'DelayMinutes';              TypeName = 'int';      Type = [int];      Default = '60' }
         @{ Name = 'LogRetentionDays';          TypeName = 'int';      Type = [int];      Default = '30' }
+        @{ Name = 'UpdateSelf';                TypeName = 'switch';   Type = [switch];   Default = $null }
     )
 
     # Each of these either reboots the machine, moves pinned toolchains, or
     # reaches out to the gallery, so turning one on has to be deliberate.
     $DefaultOffSwitches = @(
         'AutoReboot', 'IncludePrerelease', 'UpdateGlobalNpm', 'SkipElevation',
-        'Notify', 'PromptBeforeRun'
+        'Notify', 'PromptBeforeRun', 'UpdateSelf'
     )
 
     # Steps that cannot work unelevated, and so must carry -RequiresAdmin.
@@ -453,7 +454,7 @@ Describe 'Update-Everything' -Tag 'Static' {
 
         It 'declares no parameters beyond the documented contract' {
             $script:DeclaredParameters.Name.VariablePath.UserPath |
-                Should-BeCollection -Count 13 -Because 'a new parameter needs docs and a test'
+                Should-BeCollection -Count 14 -Because 'a new parameter needs docs and a test'
         }
 
         It 'bounds -LogRetentionDays with ValidateRange' {
@@ -988,7 +989,9 @@ Describe 'No step updates through a tool it has not verified' -Tag 'Static','Mod
         # Windows Update is gated by -RequiresAdmin and the install consent.
         $builtIn = @(
             'Trust PSGallery', 'PowerShell modules', 'PowerShell help',
-            'Windows Update', 'Windows Terminal default = PowerShell 7'
+            'Windows Update', 'Windows Terminal default = PowerShell 7',
+            # Invoke-WebRequest is built in and powershell.exe is always there.
+            'UpdateEverything (self)'
         )
 
         $offenders = foreach ($call in $ast.FindAll({


### PR DESCRIPTION
It updates winget, uv, npm, pipx, rustup and Windows — and never itself.
`-UpdateSelf` reinstalls it from the repository before anything else runs.

```powershell
Update-Everything -UpdateSelf
```

## Force, always

The version does not move with every commit and the module is distributed from a
branch rather than the Gallery, so **"already 1.0.0" is the normal state of an
out-of-date copy** and is no reason to skip. That is the whole point while
tracking `main`.

## It takes effect on the *next* run

The step says so, because the obvious assumption is wrong. `winget self-update`
works within the run because winget is a fresh process every step. This module is
already loaded by the time the step executes. Measured:

```
before replacing files : OLD
after replacing files  : OLD
after Import -Force    : NEW
```

That is also what makes the step safe to run first — it cannot change behaviour
underneath the run that started it.

## Off by default, deliberately

Fetching and running an installer from a branch is a supply-chain decision rather
than a routine update, and a scheduled task quietly following `main` would be
making that decision every week on its own. `-UpdateSelf` is the consent.

The installer goes to a **child process** rather than this session: it imports
the module when it finishes, and doing that inside a session currently executing
a function from that module is asking for trouble. `powershell.exe` rather than
the current host, because it is always present.

## Verified on a real machine

With this branch's build installed, running the step's logic replaced it with
`main` from GitHub:

```
installed copy has -UpdateSelf : False    <- pulled main, replaced the branch build
both edition paths refreshed   : same timestamp
```

## Two guards caught the new parameter

Satisfied rather than worked around:

- the documented-contract count (`a new parameter needs docs and a test`)
- the rule that every step either names a tool or skips itself explicitly

The step joins the built-in list beside `Trust PSGallery`, because
`Invoke-WebRequest` ships with PowerShell and `powershell.exe` is always there.
`-UpdateSelf` also joins the default-off switch list, which asserts it stays
opt-in.

488 tests, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)