### PR TITLE
Name the policy that refused an elevation

### DIFF
--- a/src/Private/Get-ElevationPolicyNote.ps1
+++ b/src/Private/Get-ElevationPolicyNote.ps1
@@ -1,0 +1,64 @@
+﻿function Get-ElevationPolicyNote {
+    <#
+        .SYNOPSIS
+        Explains, from policy, why an elevation attempt was refused.
+
+        .DESCRIPTION
+        Reporting rather than deciding, and deliberately so. Refusing a run over
+        these values would lock out the people most likely to be affected by
+        them: Test-AdministratorGroupMember already returns $null when a
+        filtered token hides the Administrators SID, and treating an unknown
+        answer plus a restrictive policy as "cannot elevate" would turn a real
+        administrator away. Nothing here changes what is attempted. It only
+        names what is set, once the attempt has already failed.
+
+        "Elevation was declined or failed" is true and useless on a managed
+        machine. Naming the value that did it turns the same failure into
+        something someone can take to whoever manages the policy.
+
+        The values that explain a failure:
+
+          ConsentPromptBehaviorUser = 0     a standard user's request is denied
+                                            outright; no prompt is ever shown
+          ValidateAdminCodeSignatures = 1   only executables with a validated
+                                            signature may elevate
+          EnableLUA = 0                     there is no consent prompt to answer
+
+        Returns nothing when none of them is set restrictively, so a caller can
+        append the result and say nothing extra on an ordinary machine.
+
+        .EXAMPLE
+        $note = Get-ElevationPolicyNote
+        if ($note) { Write-Warning $note }
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $policy = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+
+    # One read, then look for the values on the object. Asking for a named value
+    # that is absent throws, and Start-Transcript records the throw even when it
+    # is caught -- which reads as a fault in a log where nothing went wrong.
+    $values = Get-ItemProperty -LiteralPath $policy -ErrorAction SilentlyContinue
+    if (-not $values) { return }
+
+    $names = $values.PSObject.Properties.Name
+    $notes = [System.Collections.Generic.List[string]]::new()
+
+    if ($names -contains 'EnableLUA' -and $values.EnableLUA -eq 0) {
+        $notes.Add('UAC is switched off (EnableLUA is 0), so there is no consent prompt to answer.')
+    }
+
+    if ($names -contains 'ConsentPromptBehaviorUser' -and $values.ConsentPromptBehaviorUser -eq 0) {
+        $notes.Add('Policy denies elevation requests from standard users outright (ConsentPromptBehaviorUser is 0), so a standard user is never prompted.')
+    }
+
+    if ($names -contains 'ValidateAdminCodeSignatures' -and $values.ValidateAdminCodeSignatures -eq 1) {
+        $notes.Add('Policy allows only executables with a validated signature to elevate (ValidateAdminCodeSignatures is 1).')
+    }
+
+    if ($notes.Count -eq 0) { return }
+
+    'Policy on this machine may be the cause: ' + ($notes -join ' ')
+}

--- a/src/Private/Invoke-SelfElevation.ps1
+++ b/src/Private/Invoke-SelfElevation.ps1
@@ -113,7 +113,15 @@
         # console nobody is reading after an unattended run.
         return $child.ExitCode
     } catch {
-        # Declining the UAC prompt throws here.
-        throw "Elevation was declined or failed: $($_.Exception.Message). Re-run with -SkipElevation to proceed without admin."
+        # Declining the UAC prompt throws here, and so does a policy that
+        # refuses the request before anyone sees one. Those look identical from
+        # here, so the message says which values are set rather than guessing
+        # between them. Nothing is added on a machine where none of them is.
+        $message = "Elevation was declined or failed: $($_.Exception.Message)."
+
+        $policyNote = Get-ElevationPolicyNote
+        if ($policyNote) { $message += " $policyNote" }
+
+        throw "$message Re-run with -SkipElevation to proceed without admin."
     }
 }

--- a/tests/FreshMachine/Sandbox/Invoke-UnelevatedRun.ps1
+++ b/tests/FreshMachine/Sandbox/Invoke-UnelevatedRun.ps1
@@ -53,9 +53,23 @@ try {
     Import-Module UpdateEverything -Force
     $result.Imported = $true
 
-    # Bare, so the elevation handoff happens. The result object comes back from
-    # the parent; the child's own transcript is what the harness counts.
-    $run = Update-Everything -IncludeWindowsUpdate $false
+    # The elevation handoff happens, which is the point. -NonInteractive
+    # protects this process from a prompt it cannot answer, but not the elevated
+    # child: Invoke-SelfElevation builds its own command line, and that window
+    # gets a real console where Test-CanPrompt says yes.
+    #
+    # So the two questions a fresh machine actually asks are answered in
+    # advance. -AllowInstall is forwarded to the child along with everything
+    # else, and answering ahead of time is exactly what it is for -- it is what
+    # the module tells a scheduled task to do for the same reason.
+    #
+    #   NuGetProvider  Trust PSGallery asks for it; no machine has it new
+    #   PowerShellGet  1.0.0.1 is what Windows ships, so the upgrade is offered
+    #
+    # Windows Update is off because it is the one step that can run for hours,
+    # and it proves nothing here.
+    $run = Update-Everything -IncludeWindowsUpdate $false `
+        -AllowInstall 'NuGetProvider', 'PowerShellGet'
 
     $result.Ran          = $run.Ran
     $result.Elevated_Run = $run.Elevated

--- a/tests/FreshMachine/Sandbox/Start-Harness.ps1
+++ b/tests/FreshMachine/Sandbox/Start-Harness.ps1
@@ -103,10 +103,15 @@ try {
         Write-Output "-- install attempt $attempt --"
         $installLog = Join-Path $OutputPath "install-$attempt.log"
 
-        & powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $command *> $installLog
+        # Captured, then written with an explicit encoding. "*> file" is
+        # Out-File, which writes UTF-16LE on Windows PowerShell -- the same
+        # split that made the module's own step logs unreadable, reintroduced
+        # here on the first attempt.
+        $installOutput = & powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $command *>&1
         $code = $LASTEXITCODE
 
-        $text = Get-Content $installLog -Raw
+        $text = ($installOutput | Out-String)
+        [System.IO.File]::WriteAllText($installLog, $text, [System.Text.UTF8Encoding]::new($false))
         $ok = ($code -eq 0) -and ($text -match 'Installed UpdateEverything')
         Add-Check -Name "install succeeds (attempt $attempt)" -Passed $ok -Detail "exit $code"
         Write-Output ($text -split "`r?`n" | Select-Object -Last 12 | ForEach-Object { "    $_" })
@@ -122,12 +127,25 @@ try {
 
     # A scheduled task at RunLevel Limited is how an elevated session starts a
     # genuinely unelevated child of the same user.
+    #
+    # -NonInteractive is not decoration, and leaving it out hung the first run of
+    # this harness for as long as it was given. A fresh machine has no NuGet
+    # provider, so Trust PSGallery asks permission to install one -- and
+    # Test-CanPrompt says yes, because a task at RunLevel Limited reports
+    # UserInteractive with stdin not redirected. The prompt then waits on a
+    # window nobody is looking at.
+    #
+    # With -NonInteractive, PromptForChoice throws instead, which is the case
+    # Request-InstallConsent already catches and treats as declined. Measured:
+    #
+    #   without : CanPrompt=True  PromptForChoice blocks
+    #   with    : CanPrompt=True  PromptForChoice throws MethodInvocationException
     $runResult = Join-Path $OutputPath 'unelevated.json'
     $payload   = Join-Path $PSScriptRoot 'Invoke-UnelevatedRun.ps1'
 
     $taskName = 'UpdateEverything-SmokeTest'
     $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
-        -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$payload`" -ResultPath `"$runResult`""
+        -Argument "-NoProfile -NonInteractive -ExecutionPolicy Bypass -File `"$payload`" -ResultPath `"$runResult`""
     $taskPrincipal = New-ScheduledTaskPrincipal `
         -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) `
         -LogonType Interactive `

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -826,6 +826,73 @@ Describe 'The gallery steps never splat a parameter blindly' -Tag 'Static' {
     }
 }
 
+Describe 'Get-ElevationPolicyNote' -Tag 'Unit','Security' {
+
+    # "Elevation was declined or failed" is true and useless on a managed
+    # machine. This names the value that did it. It reports and never decides:
+    # refusing a run over these would lock out exactly the people they affect,
+    # because Test-AdministratorGroupMember already answers $null when a
+    # filtered token hides the Administrators SID.
+
+    It 'says nothing on a machine with no restrictive policy' {
+        Mock Get-ItemProperty { [pscustomobject]@{ EnableLUA = 1; ConsentPromptBehaviorAdmin = 2 } }
+        Get-ElevationPolicyNote | Should-BeNull
+    }
+
+    It 'says nothing when the policy key cannot be read' {
+        Mock Get-ItemProperty { }
+        Get-ElevationPolicyNote | Should-BeNull
+    }
+
+    It 'names a standard-user denial' {
+        Mock Get-ItemProperty { [pscustomobject]@{ ConsentPromptBehaviorUser = 0 } }
+        Get-ElevationPolicyNote | Should-MatchString 'ConsentPromptBehaviorUser is 0'
+    }
+
+    It 'names UAC being switched off' {
+        Mock Get-ItemProperty { [pscustomobject]@{ EnableLUA = 0 } }
+        Get-ElevationPolicyNote | Should-MatchString 'EnableLUA is 0'
+    }
+
+    It 'names a signature requirement' {
+        Mock Get-ItemProperty { [pscustomobject]@{ ValidateAdminCodeSignatures = 1 } }
+        Get-ElevationPolicyNote | Should-MatchString 'ValidateAdminCodeSignatures is 1'
+    }
+
+    # A machine can carry more than one, and hearing about only the first would
+    # send someone to change a value that was not the whole story.
+    It 'names every restrictive value, not just the first' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ EnableLUA = 0; ConsentPromptBehaviorUser = 0; ValidateAdminCodeSignatures = 1 }
+        }
+        $note = Get-ElevationPolicyNote
+        @('EnableLUA is 0', 'ConsentPromptBehaviorUser is 0', 'ValidateAdminCodeSignatures is 1') |
+            Should-All { $note -match $_ }
+    }
+
+    # The permissive settings are the common case. Reporting them would make the
+    # note appear on every machine and mean nothing on any of them.
+    It 'stays quiet when the same values are set permissively' {
+        Mock Get-ItemProperty {
+            [pscustomobject]@{ EnableLUA = 1; ConsentPromptBehaviorUser = 3; ValidateAdminCodeSignatures = 0 }
+        }
+        Get-ElevationPolicyNote | Should-BeNull
+    }
+}
+
+Describe 'A failed elevation names the policy' -Tag 'Static','Security' {
+
+    It 'appends the policy note to the failure it throws' {
+        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Invoke-SelfElevation.ps1') -Raw |
+            Should-MatchString '\$policyNote = Get-ElevationPolicyNote'
+    }
+
+    It 'still points at -SkipElevation' {
+        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Invoke-SelfElevation.ps1') -Raw |
+            Should-MatchString 'Re-run with -SkipElevation'
+    }
+}
+
 Describe 'Test-PackagedProcess' -Tag 'Unit','Security' {
 
     It 'recognises the package binary under WindowsApps' {


### PR DESCRIPTION
## The problem

`Elevation was declined or failed` is true and useless on a managed machine. It
reads as though someone clicked No — and where policy refused the request before
any prompt appeared, nobody clicked anything.

## The change

The failure now names the values that are set:

```
Elevation was declined or failed: <reason>. Policy on this machine may be the
cause: Policy denies elevation requests from standard users outright
(ConsentPromptBehaviorUser is 0), so a standard user is never prompted. Re-run
with -SkipElevation to proceed without admin.
```

Three values explain a refusal:

- `ConsentPromptBehaviorUser = 0` — a standard user's request is denied outright; no prompt is shown
- `ValidateAdminCodeSignatures = 1` — only executables with a validated signature may elevate
- `EnableLUA = 0` — there is no consent prompt to answer

**All** of them are reported, not just the first — a machine can carry more than
one, and fixing only the one you were told about leaves the run still broken.

## It reports, it never decides

This is the whole design, and it is why this is not the pre-flight check it
could have been. Refusing a run over these values would lock out exactly the
people they affect: `Test-AdministratorGroupMember` already answers `$null` when
a filtered token hides the Administrators SID, and treating *"unknown, plus a
restrictive policy"* as *"cannot elevate"* would turn away a real administrator.

Nothing here changes what is attempted.

## Quiet on an ordinary machine

Nothing is added where none of the values is set restrictively, so the common
case reads exactly as before. The permissive settings are deliberately **not**
reported: a note that appears everywhere means nothing anywhere.

The key is read once and the values looked for on the object, rather than asked
for by name. `Get-ItemProperty -Name` on an absent value throws, and
`Start-Transcript` records the throw even when caught — which reads as a fault in
a log where nothing went wrong. Same reason `Test-PendingReboot` reads its key
that way.

## Testing

Found by looking for a policy on a real managed machine, which turned out to
have `ConsentPromptBehaviorUser = 0`. Verified against that machine's actual
registry, not only against mocks.

498 tests, 0 failed. Eight of the nine new tests fail without this change; the
ninth guards that `-SkipElevation` is still offered and passes either way by
design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
