### PR TITLE
Report what the smoke test cannot run, instead of failing it

### DIFF
--- a/tests/FreshMachine/Invoke-FreshMachineTest.ps1
+++ b/tests/FreshMachine/Invoke-FreshMachineTest.ps1
@@ -179,8 +179,40 @@ $null = New-Item -ItemType Directory -Path $OutputPath -Force
 # The sandbox configuration. Written per run, because the mapped paths depend
 # on where the repository was cloned.
 # --------------------------------------------------------------------------
-$logon = '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass ' +
-    '-File "C:\smoke\Start-Harness.ps1" -RepoPath "C:\repo" -OutputPath "C:\out"'
+# The logon command waits for its own script to appear before running it.
+#
+# Windows Sandbox starts the logon command without guaranteeing the mapped
+# folders are mounted, and -File against a path that is not there yet fails
+# instantly and silently: the sandbox sits at an empty desktop, nothing is
+# written, and the only evidence is a run that times out having produced
+# nothing at all. It is a race, so it looks intermittent -- the first run of
+# this harness worked, and two later ones did not.
+#
+# It also drops a breadcrumb the moment the folders appear, so a future failure
+# can be told apart from this one: no breadcrumb means the mapping never
+# arrived, a breadcrumb with no transcript means the harness itself died.
+# No ampersand anywhere in here, and that is not a style choice.
+#
+# Windows Sandbox mishandles "&" in a logon command even when it is correct XML.
+# SecurityElement::Escape turns it into "&amp;", which round-trips through
+# .NET's XML reader perfectly and still does not survive whatever the sandbox
+# does with it: the command never runs, the desktop sits empty, and nothing is
+# written anywhere. Measured -- the identical command with the call operator
+# removed runs, and with it restored does not.
+#
+# So the script is called by path rather than with "&". None of these paths
+# contains a space, so it needs no quoting either.
+#
+# The wait is for the mapped folders. The sandbox starts the logon command
+# without guaranteeing they are mounted, and a run that begins too early fails
+# silently. logon.txt is dropped the moment they appear, so a later failure can
+# be told apart from this one: no logon.txt means the mapping never arrived, a
+# logon.txt with no transcript means the harness itself died.
+$logon = '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command ' +
+    '"$d = (Get-Date).AddMinutes(5); ' +
+    'while (-not (Test-Path C:\smoke\Start-Harness.ps1) -and (Get-Date) -lt $d) { Start-Sleep -Seconds 2 }; ' +
+    '''reached the mapped folders at '' + (Get-Date -Format o) | Set-Content C:\out\logon.txt; ' +
+    'C:\smoke\Start-Harness.ps1 -RepoPath C:\repo -OutputPath C:\out"'
 
 # Escaped, not interpolated raw. '&' is legal in a Windows path and fatal in
 # XML: a clone under C:\dev\R&D produces a .wsb the sandbox rejects, and it

--- a/tests/FreshMachine/Invoke-FreshMachineTest.ps1
+++ b/tests/FreshMachine/Invoke-FreshMachineTest.ps1
@@ -35,8 +35,18 @@
     How long to wait for the sandbox to report. Default 45.
 
     .PARAMETER KeepSandboxOpen
-    Leave the sandbox running after the test finishes, to look around. Without
-    it the sandbox closes itself, which discards everything inside.
+    Leave the sandbox running after the test finishes, to look around.
+    Otherwise it is closed, which discards everything inside it.
+
+    A sandbox does not stop when its logon command finishes, and Windows runs
+    only one at a time -- so leaving one open means the next run starts nothing,
+    waits out its whole timeout, and reports a failure belonging to the run
+    before it. Close it before running again.
+
+    .PARAMETER CloseExistingSandbox
+    Close a sandbox that is already open, rather than refusing to start. Off by
+    default, because it may be one somebody is using for something else and
+    Windows gives no way to tell.
 
     .EXAMPLE
     .\Invoke-FreshMachineTest.ps1
@@ -56,10 +66,34 @@ param(
     [ValidateRange(5, 240)]
     [int] $TimeoutMinutes = 45,
 
-    [switch] $KeepSandboxOpen
+    [switch] $KeepSandboxOpen,
+
+    # Close a sandbox that is already open rather than refusing to start.
+    # Off by default: it may be one somebody is using for something else, and
+    # Windows gives no way to tell whose it is.
+    [switch] $CloseExistingSandbox
 )
 
 $ErrorActionPreference = 'Stop'
+
+function Close-Sandbox {
+    # The sandbox does not stop when its logon command finishes, and Windows
+    # runs only one at a time -- so leaving it open guarantees the next run
+    # starts nothing, waits out its whole timeout, and reports a failure that
+    # belongs to this run. That is exactly what happened once.
+    param([switch] $Keep)
+
+    if ($Keep) {
+        Write-Host 'Leaving the sandbox open, as asked. Close it before the next run.' -ForegroundColor DarkYellow
+        return
+    }
+
+    $running = @(Get-Process -Name $script:SandboxProcessNames -ErrorAction SilentlyContinue)
+    if ($running.Count -eq 0) { return }
+
+    $running | Stop-Process -Force -ErrorAction SilentlyContinue
+    Write-Host 'Sandbox closed.' -ForegroundColor DarkGray
+}
 
 $repoRoot   = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $sandboxSrc = Join-Path $PSScriptRoot 'Sandbox'
@@ -94,6 +128,35 @@ if (-not $feature -or $feature.State -ne 'Enabled') {
 $sandboxExe = Join-Path $env:WINDIR 'System32\WindowsSandbox.exe'
 if (-not (Test-Path -LiteralPath $sandboxExe)) {
     $problems.Add("WindowsSandbox.exe was not found at $sandboxExe.")
+}
+
+# Windows only runs one sandbox at a time, and starting a second does nothing
+# at all -- no window, no error, no clue. A run that hits this waits out its
+# whole timeout and reports a failure that belongs to the previous run.
+# The session processes, and deliberately not vmmemWindowsSandbox. That one is
+# the virtual machine's memory, reclaimed by the hypervisor on its own schedule
+# after the session is gone -- it cannot usefully be stopped, and it lingers for
+# minutes. Counting it meant "close the open sandbox" reported failure against a
+# sandbox that had already closed.
+$script:SandboxProcessNames = @(
+    'WindowsSandbox', 'WindowsSandboxClient', 'WindowsSandboxServer',
+    'WindowsSandboxRemoteSession'
+)
+$alreadyRunning = @(Get-Process -Name $script:SandboxProcessNames -ErrorAction SilentlyContinue)
+if ($alreadyRunning.Count -gt 0) {
+    if ($CloseExistingSandbox) {
+        Write-Host '  closing the sandbox that is already open...' -ForegroundColor DarkGray
+        $alreadyRunning | Stop-Process -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 5
+        $stillThere = @(Get-Process -Name $script:SandboxProcessNames -ErrorAction SilentlyContinue)
+        if ($stillThere.Count -gt 0) {
+            $problems.Add('A Windows Sandbox is still running after being asked to close.')
+        }
+    } else {
+        $problems.Add(
+            'A Windows Sandbox is already running, and Windows allows only one. ' +
+            'Close it and try again, or pass -CloseExistingSandbox.')
+    }
 }
 
 if ($problems.Count -gt 0) {
@@ -167,7 +230,7 @@ try {
 
 Write-Host ''
 Write-Host 'Starting Windows Sandbox. It installs from GitHub, so it needs a network.' -ForegroundColor Yellow
-Write-Host 'Leave it alone; it drives itself and closes when it is done.'
+Write-Host 'Leave it alone; it drives itself. This closes it afterwards.'
 
 Start-Process -FilePath $sandboxExe -ArgumentList "`"$wsbPath`""
 
@@ -185,6 +248,8 @@ while (-not (Test-Path -LiteralPath $resultFile) -and (Get-Date) -lt $deadline) 
 
 if (-not (Test-Path -LiteralPath $resultFile)) {
     Write-Warning "No result after $TimeoutMinutes minutes. Anything the sandbox wrote is in $OutputPath."
+    Close-Sandbox -Keep:$KeepSandboxOpen
+
     return [pscustomobject]@{
         PSTypeName = 'UpdateEverything.SmokeResult'
         Passed     = $false
@@ -224,9 +289,7 @@ if (-not $result.Passed) {
 }
 Write-Host "Logs and transcripts: $OutputPath"
 
-if (-not $KeepSandboxOpen) {
-    Write-Host 'The sandbox closes itself; everything inside it is discarded.' -ForegroundColor DarkGray
-}
+Close-Sandbox -Keep:$KeepSandboxOpen
 
 [pscustomobject]@{
     PSTypeName = 'UpdateEverything.SmokeResult'

--- a/tests/FreshMachine/Invoke-FreshMachineTest.ps1
+++ b/tests/FreshMachine/Invoke-FreshMachineTest.ps1
@@ -199,17 +199,28 @@ $result = Get-Content -LiteralPath $resultFile -Raw | ConvertFrom-Json
 
 Write-Host ''
 foreach ($check in $result.Checks) {
-    $colour = if ($check.Passed) { 'Green' } else { 'Red' }
-    $mark   = if ($check.Passed) { 'PASS' } else { 'FAIL' }
-    Write-Host ("  [{0}] {1}" -f $mark, $check.Name) -ForegroundColor $colour
+    # Three states, not two. A check the machine could not run is not a failure
+    # and must not be coloured like one.
+    $colour = switch ($check.Status) {
+        'PASS'  { 'Green' }
+        'FAIL'  { 'Red' }
+        default { 'DarkYellow' }
+    }
+    Write-Host ("  [{0}] {1}" -f $check.Status.PadRight(4), $check.Name) -ForegroundColor $colour
     if ($check.Detail) { Write-Host "         $($check.Detail)" -ForegroundColor DarkGray }
 }
 
 Write-Host ''
-if ($result.Passed) {
-    Write-Host 'Fresh-machine test passed.' -ForegroundColor Green
-} else {
+if (-not $result.Passed) {
     Write-Host 'Fresh-machine test FAILED.' -ForegroundColor Red
+} elseif ($result.NotCovered -gt 0) {
+    # Said plainly rather than buried. A green run that skipped the elevation
+    # checks proves less than a green run that made them, and the difference
+    # matters most to whoever is deciding whether it is safe to release.
+    Write-Host 'Fresh-machine test passed.' -ForegroundColor Green
+    Write-Host "$($result.NotCovered) check(s) could not run on this machine; see N/A above for why." -ForegroundColor DarkYellow
+} else {
+    Write-Host 'Fresh-machine test passed, with everything covered.' -ForegroundColor Green
 }
 Write-Host "Logs and transcripts: $OutputPath"
 

--- a/tests/FreshMachine/README.md
+++ b/tests/FreshMachine/README.md
@@ -40,15 +40,39 @@ only, discarded afterwards.
 - The machine really is fresh — `pwsh` is absent before anything runs
 - The install command **from README.md**, run twice. The second run is what
   `-Force` exists for
+- The module imported and the run reached its summary, with `FailedCount` a
+  number
 - The payload ran with no administrator rights, so self-elevation was exercised
 - **Two** transcripts appeared: the parent's, recording the handoff, and the
   elevated child's own. One means the child died before it could log, which is
   precisely how the relaunch parse error presented
-- A transcript reached the summary, and `FailedCount` came back a number
 
 The install command is read out of `README.md` rather than copied here. A smoke
 test carrying its own copy tests the copy, and two of the three defects above
 were *in* the documented command.
+
+## What it does not check, in Windows Sandbox
+
+**The last two are reported `N/A` here, and the elevation path is not covered.**
+
+Windows Sandbox ships with UAC off, and turning it back on needs a restart a
+disposable machine cannot perform. With `EnableLUA=0` there is no split token:
+everything runs elevated, `RunLevel Limited` cannot produce an unelevated child,
+and `Update-Everything` never reaches self-elevation at all.
+
+So of the three defects that motivated this, Sandbox covers two — the missing
+`pwsh` and the `-Force` reinstall — and **not** the relaunch parse error, which
+was the worst of them.
+
+The first version of this harness reported those checks as failures. That was
+wrong in a way worth naming: it showed red for something the module did not do,
+and a suite that cries wolf is one people stop reading. They now report `N/A`
+with the reason, the run still passes, and the summary says how many checks it
+could not make.
+
+Real elevation coverage needs a VM that can boot with UAC on — a Hyper-V
+checkpoint restored between runs. That is a heavier harness than this one and
+has not been built.
 
 ## The UAC part
 

--- a/tests/FreshMachine/Sandbox/Start-Harness.ps1
+++ b/tests/FreshMachine/Sandbox/Start-Harness.ps1
@@ -47,15 +47,32 @@ $transcript = Join-Path $OutputPath 'harness.log'
 Start-Transcript -Path $transcript -Force | Out-Null
 
 $checks = [System.Collections.Generic.List[object]]::new()
+
 function Add-Check {
     param(
         [Parameter(Mandatory)][string] $Name,
         [Parameter(Mandatory)][bool]   $Passed,
         [string] $Detail
     )
-    $checks.Add([pscustomobject]@{ Name = $Name; Passed = $Passed; Detail = $Detail })
-    $mark = if ($Passed) { 'PASS' } else { 'FAIL' }
-    Write-Output ("  [{0}] {1}{2}" -f $mark, $Name, $(if ($Detail) { " -- $Detail" } else { '' }))
+    $status = if ($Passed) { 'PASS' } else { 'FAIL' }
+    $checks.Add([pscustomobject]@{ Name = $Name; Status = $status; Passed = $Passed; Detail = $Detail })
+    Write-Output ("  [{0}] {1}{2}" -f $status, $Name, $(if ($Detail) { " -- $Detail" } else { '' }))
+}
+
+function Add-NotApplicable {
+    # A third state, because two are not enough. Windows Sandbox runs with UAC
+    # off, so the elevation checks cannot be exercised here at all -- and
+    # reporting that as FAIL is worse than useless: it is red for something the
+    # code did not do wrong, which is how people learn to ignore a suite.
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][string] $Reason
+    )
+    # Passed is $null rather than $true. Not applicable is not a pass, and the
+    # overall verdict counts failures rather than adding up passes, so a check
+    # that could not run neither helps nor hurts.
+    $checks.Add([pscustomobject]@{ Name = $Name; Status = 'N/A'; Passed = $null; Detail = $Reason })
+    Write-Output ("  [N/A ] {0} -- {1}" -f $Name, $Reason)
 }
 
 try {
@@ -72,15 +89,36 @@ try {
 
     Write-Output ''
     Write-Output '== UAC =='
-    # EnableLUA stays 1 so Test-ElevationCapability still allows the run.
     # ConsentPromptBehaviorAdmin 0 means "elevate without prompting", which is
-    # what lets the child start with nobody at the keyboard.
+    # what would let an elevated child start with nobody at the keyboard.
     $policy = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
     Set-ItemProperty -Path $policy -Name 'ConsentPromptBehaviorAdmin' -Value 0 -Type DWord
     $enableLua = (Get-ItemProperty -Path $policy -Name 'EnableLUA').EnableLUA
     $consent   = (Get-ItemProperty -Path $policy -Name 'ConsentPromptBehaviorAdmin').ConsentPromptBehaviorAdmin
     Write-Output "  EnableLUA=$enableLua ConsentPromptBehaviorAdmin=$consent"
-    Add-Check -Name 'UAC still enabled' -Passed ($enableLua -eq 1) -Detail "EnableLUA=$enableLua"
+
+    # Windows Sandbox ships with UAC off, and turning it back on needs a restart
+    # that a disposable machine cannot perform. With EnableLUA at 0 there is no
+    # split token: everything runs elevated, RunLevel Limited cannot produce an
+    # unelevated child, and Update-Everything never reaches the self-elevation
+    # path at all.
+    #
+    # That is a limit of this harness, not a fault in the module, so the checks
+    # it makes impossible are reported as not applicable. The first run of this
+    # test reported them as failures, which said the module was broken when the
+    # sandbox simply could not ask the question.
+    $script:UacAvailable = ($enableLua -eq 1)
+
+    if ($script:UacAvailable) {
+        Add-Check -Name 'UAC is on, so elevation can be exercised' -Passed $true -Detail "EnableLUA=$enableLua"
+    } else {
+        Add-NotApplicable -Name 'UAC is on, so elevation can be exercised' `
+            -Reason "EnableLUA=$enableLua; Windows Sandbox runs with UAC off and cannot restart to change it"
+        Write-Output ''
+        Write-Output '  NOTE: the self-elevation path is NOT covered by this run.'
+        Write-Output '        Install, reinstall and the update pass are. Real elevation coverage'
+        Write-Output '        needs a VM that can boot with UAC on.'
+    }
 
     Write-Output ''
     Write-Output '== Install command, taken from README =='
@@ -175,8 +213,13 @@ try {
     $run = Get-Content $runResult -Raw | ConvertFrom-Json
     Write-Output "  ran as $($run.User), elevated=$($run.Elevated)"
 
-    Add-Check -Name 'payload ran without administrator rights' -Passed (-not $run.Elevated) `
-        -Detail "elevated=$($run.Elevated)"
+    if ($script:UacAvailable) {
+        Add-Check -Name 'payload ran without administrator rights' -Passed (-not $run.Elevated) `
+            -Detail "elevated=$($run.Elevated)"
+    } else {
+        Add-NotApplicable -Name 'payload ran without administrator rights' `
+            -Reason "elevated=$($run.Elevated); with UAC off there is no split token to drop, so RunLevel Limited cannot de-elevate"
+    }
     Add-Check -Name 'module imported after install' -Passed ([bool] $run.Imported)
     Add-Check -Name 'run reported no error' -Passed ([string]::IsNullOrEmpty($run.Error)) -Detail $run.Error
 
@@ -190,8 +233,17 @@ try {
     # Two: the parent's, which records the handoff, and the elevated child's own.
     # One means the child died before it could log -- which is exactly how the
     # relaunch parse error presented, and why counting them is the assertion.
-    Add-Check -Name 'both parent and elevated child left a transcript' -Passed ($new.Count -ge 2) `
-        -Detail "$($new.Count) found"
+    #
+    # It only counts for anything where elevation could happen. With UAC off the
+    # run is already elevated, so there is no handoff and one transcript is the
+    # correct answer rather than a symptom.
+    if ($script:UacAvailable) {
+        Add-Check -Name 'both parent and elevated child left a transcript' -Passed ($new.Count -ge 2) `
+            -Detail "$($new.Count) found"
+    } else {
+        Add-NotApplicable -Name 'both parent and elevated child left a transcript' `
+            -Reason "$($new.Count) found; with UAC off the run is already elevated, so there is no handoff to record"
+    }
 
     $childReachedSummary = $false
     foreach ($name in $new) {
@@ -210,14 +262,27 @@ try {
     Write-Output "HARNESS ERROR: $($_.Exception.Message)"
 }
 
+# Counts failures rather than adding up passes, so a check that could not run
+# neither helps nor hurts. A green result here means nothing failed, not that
+# everything was covered -- which is what NotCovered exists to say out loud.
+$failed    = @($checks | Where-Object { $_.Status -eq 'FAIL' })
+$notCovered = @($checks | Where-Object { $_.Status -eq 'N/A' })
+
 $summary = [pscustomobject]@{
-    Finished = (Get-Date).ToString('o')
-    Passed   = @($checks | Where-Object { -not $_.Passed }).Count -eq 0
-    Checks   = $checks.ToArray()
+    Finished   = (Get-Date).ToString('o')
+    Passed     = $failed.Count -eq 0
+    NotCovered = $notCovered.Count
+    Checks     = $checks.ToArray()
 }
 
 Write-Output ''
-Write-Output "== $(if ($summary.Passed) { 'ALL CHECKS PASSED' } else { 'FAILURES PRESENT' }) =="
+if ($failed.Count -gt 0) {
+    Write-Output "== $($failed.Count) FAILURE(S) =="
+} elseif ($notCovered.Count -gt 0) {
+    Write-Output "== PASSED, with $($notCovered.Count) check(s) this machine could not run =="
+} else {
+    Write-Output '== ALL CHECKS PASSED =='
+}
 
 [System.IO.File]::WriteAllText(
     (Join-Path $OutputPath 'result.json'),


### PR DESCRIPTION
## What the first real run reported

Three failures that were not failures:

```
FAIL UAC still enabled -- EnableLUA=0
FAIL payload ran without administrator rights -- elevated=True
FAIL both parent and elevated child left a transcript -- 1 found
```

**Windows Sandbox ships with UAC off**, and turning it back on needs a restart a
disposable machine cannot perform. With `EnableLUA=0` there is no split token:
everything runs elevated, `RunLevel Limited` cannot produce an unelevated child,
and `Update-Everything` never reaches self-elevation at all. One transcript is
the correct answer there, not a symptom.

So the harness was showing red for something the module did not do — worse than
saying nothing, because a suite that cries wolf is one people stop reading, and
these three would have cried wolf on **every** run.

## A third state

`Add-NotApplicable` sits beside `Add-Check`, and sets `Passed` to `$null` rather
than `$true`, because not applicable is not a pass. The verdict counts
*failures* rather than adding up passes, so a check that could not run neither
helps nor hurts:

```
FAILED
passed, with N check(s) this machine could not run
passed, with everything covered
```

Only the last is an unqualified green. That distinction matters most to whoever
is deciding whether it is safe to release.

The harness also says it out loud when it happens:

```
NOTE: the self-elevation path is NOT covered by this run.
      Install, reinstall and the update pass are. Real elevation coverage
      needs a VM that can boot with UAC on.
```

## The README no longer overstates it

Of the three defects that motivated this harness, Sandbox covers two — the
missing `pwsh` and the `-Force` reinstall — and **not** the relaunch parse
error, which was the worst of them. That is now stated plainly, along with why
the first version got it wrong.

Real elevation coverage needs a VM that can boot with UAC on: a Hyper-V
checkpoint restored between runs. That is described and deliberately not built
here — it is a materially heavier harness and worth a separate decision.

## Testing

498 tests, 0 failed, all three harness scripts lint clean.

Verified by re-running the fresh-machine test itself: the same three checks now
report `N/A` with their reason, and the run reports passed-with-gaps rather than
failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
