### PR TITLE
Prepare 1.0.0 for the gallery, and keep history out of the comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,40 @@ disagree.
 *Enforced:* a test asserts every parameter is documented, and that nothing is
 documented that no longer exists.
 
+### Comments
+
+**A comment states a fact about the code, not the story of how it got there.**
+The reader is whoever changes this file next year, and what helps them is the
+constraint that is still true: the API that returns `$null`, the exit code that
+means "nothing to do", the parser rule that forces two statements apart. How
+that constraint came to be known does not help them.
+
+So: no version history (`used to`, `an earlier draft`, `they now rotate`), no
+narration of a debugging session or a review discussion, no measurements taken
+on one machine on one day, and no second person. Git holds that already, and a
+comment repeating it goes stale the moment the code moves.
+
+```powershell
+# Wrong -- narrates a debugging session
+# Counting every entry made a single leftover DEL396A.tmp announce a pending
+# reboot on every run, while CBS and Windows Update both reported nothing.
+
+# Right -- states what is true
+# A pair with an empty destination is a scheduled deletion, which installers
+# queue constantly for their own temp files and which needs no restart.
+```
+
+Explaining *why* is still in scope and is often the only thing worth writing.
+A "why" that is a property of Windows, of PowerShell, or of a tool's contract
+is a fact. A "why" that is a property of a past pull request is not.
+
+**Never start a line inside a help block with a dot.** A line whose first
+non-space character is a dot is read as a help keyword, whatever word follows
+it. A wrapped `.NET global tools` ends the section it sits in and discards every
+section after it — `Get-Help` reports no error, it just returns an empty
+description. Write `dotnet`, or reflow the line. *Enforced:* a test scans every
+`<# #>` block for a leading dot that is not a real keyword.
+
 ### Adopted with a documented exception
 
 These three are good general advice and wrong for parts of this module. The
@@ -409,10 +443,12 @@ longer exists. Assert both ways.
   it requires elevating, installing, or rebooting, it is being tested wrong.
 - No new `exit` in `src`, no `$ErrorActionPreference` in `src`, no empty
   `catch`.
+- Comments state facts about the code, not its history. The story of the change
+  belongs in the commit message and the pull request, where it stays accurate.
 - Commit messages say what changed and why, in the imperative, with the evidence
   where there is any — "Measured on 5.1: two occurrences before, one after" is
   worth more than an adjective. `git log` here is meant to read as a record of
-  decisions.
+  decisions, which is why the code does not have to be.
 
 ## Publishing
 
@@ -429,3 +465,20 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File .\Publish.ps1 -WhatIf
 
 It prompts for the API key rather than accepting it as an argument, so the key
 stays out of shell history and out of any transcript.
+
+Before publishing:
+
+- Raise `ModuleVersion` in the manifest. A version already on the gallery cannot
+  be replaced, and `Publish.ps1` refuses one that is not newer.
+- Rewrite `PrivateData.PSData.ReleaseNotes` to describe *this* version. It is the
+  package page, and it is as permanent as the version it ships with.
+- Run the [fresh-machine smoke test](tests/FreshMachine/README.md). It is not
+  part of `test.ps1`, it needs a hypervisor and several minutes, and it belongs
+  before a release rather than before a commit.
+
+Afterwards, tag the exact commit that was published, so the permanent version
+has something in the history pointing at it:
+
+```bash
+git tag -a v1.0.0 -m "1.0.0" && git push origin v1.0.0
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,28 @@ and tell you what happened with a toast notification.
 
 ## Install
 
-Nothing but the URL is needed. Paste this into PowerShell:
+From the PowerShell Gallery:
+
+```powershell
+Install-Module UpdateEverything -Scope CurrentUser
+```
+
+Then:
+
+```powershell
+Import-Module UpdateEverything
+```
+
+`-Scope AllUsers` installs machine-wide and needs elevation. `Update-Module
+UpdateEverything` moves to the next published release.
+
+Requires PowerShell 5.1 or later on Windows 10 or a matching Server release.
+
+### Install from GitHub
+
+The gallery carries releases. `main` carries what is being worked on, which is
+where to get a fix that has landed but not shipped. Nothing but the URL is
+needed:
 
 ```powershell
 $i = Join-Path $env:TEMP 'Install-UpdateEverything.ps1'; Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1 -OutFile $i -UseBasicParsing; Unblock-File $i; powershell -NoProfile -ExecutionPolicy Bypass -File $i -Force
@@ -25,11 +46,8 @@ it does nothing; on every one after, it is what makes the line safe to paste
 again. Nothing is lost if it is interrupted: the installer stages the new copy
 and validates it before it replaces the old one.
 
-Then:
-
-```powershell
-Import-Module UpdateEverything
-```
+`Update-Everything -UpdateSelf` does the same thing from inside a run, and also
+tracks `main` rather than the gallery.
 
 ### Why that command is shaped the way it is
 
@@ -72,8 +90,6 @@ To load it without installing, point `Import-Module` at the source:
 ```powershell
 Import-Module .\UpdateEverything\src\UpdateEverything.psd1
 ```
-
-Requires PowerShell 5.1 or later on Windows 10 or a matching Server release.
 
 ### Execution policy
 

--- a/src/Private/Get-UpdateTaskArgument.ps1
+++ b/src/Private/Get-UpdateTaskArgument.ps1
@@ -42,11 +42,10 @@ function Get-UpdateTaskArgument {
 
     # The manifest, not the folder holding it. Given a directory, Import-Module
     # looks for a manifest named after that directory, so a versioned install
-    # path ending in \1.0.0 sends it hunting for 1.0.0.psd1 and it reports
-    # "no valid module file was found". The call still worked, because invoking
-    # Update-Everything auto-loaded the module by name a moment later, but every
-    # run opened with a red error and the version that loaded was whatever the
-    # module path happened to resolve rather than the one asked for.
+    # path ending in \1.0.0 sends it hunting for 1.0.0.psd1 and reports "no
+    # valid module file was found". Calling Update-Everything would still
+    # auto-load the module by name a moment later, but from whatever the module
+    # path resolves to rather than from the copy the task names.
     $manifest = Join-Path $ModuleRoot 'UpdateEverything.psd1'
     $escModule = "'" + ($manifest -replace "'", "''") + "'"
     $command = "Import-Module $escModule -Force; exit ($call).FailedCount"

--- a/src/Private/Invoke-SelfElevation.ps1
+++ b/src/Private/Invoke-SelfElevation.ps1
@@ -5,14 +5,13 @@
         exit code that run finished with.
 
         .DESCRIPTION
-        As a script this relaunched $PSCommandPath. A module has no script path,
-        so the child imports the module by its own folder and calls the function.
-        Importing by path rather than by name matters: the elevated session may
-        resolve a different copy of the module, or none at all, if the module is
-        installed for the current user only.
+        The child imports this module by its own folder path and calls the
+        function. Importing by path rather than by name matters: the elevated
+        session may resolve a different copy of the module, or none at all, when
+        the module is installed for the current user only.
 
-        It returns rather than exits. Killing the session someone called a
-        function from would be a poor way to repay them for asking.
+        It returns rather than exits, so calling it does not end the caller's
+        session.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of a console maintenance tool. Its output is progress a person watches, not data a caller consumes, and the summary uses colour to separate failures from noise.')]
     [CmdletBinding()]
@@ -68,17 +67,15 @@
     $manifest = Join-Path $script:ModuleRoot 'UpdateEverything.psd1'
     $escModule = "'" + ($manifest -replace "'", "''") + "'"
 
-    # The call is built on its own, separately from the import. Parentheses in
-    # PowerShell hold an expression, not a statement list, so wrapping both
-    # together --
+    # The import and the call are separate statements. Parentheses in PowerShell
+    # hold an expression, not a statement list, so combining them --
     #
     #     exit (Import-Module '...' -Force; Update-Everything).FailedCount
     #
-    # -- is a parse error: "Missing closing ')' in expression". The elevated
-    # window opened, pwsh exited 1 before running a line of it, and it closed
-    # again too fast to read, leaving no transcript and no clue. Import first,
-    # then exit on the call alone, which is what Get-UpdateTaskArgument has
-    # always done for the scheduled task.
+    # -- is a parse error ("Missing closing ')' in expression") and the elevated
+    # host exits 1 without running a line. Import first, then exit on the call
+    # alone, which is the shape Get-UpdateTaskArgument builds for the scheduled
+    # task.
     $call = 'Update-Everything'
 
     foreach ($entry in $BoundParameters.GetEnumerator()) {

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -45,31 +45,27 @@
         # Reset so a cmdlet-only step can't inherit a stale exit code from an earlier native command
         $global:LASTEXITCODE = 0
 
-        # *>&1 rather than 4>&1: Write-Host goes to the information stream and
-        # native stderr to the error stream, so the old warning-only redirect put
-        # almost nothing in the step log. The ForEach-Object both accumulates the
-        # output for inspection and passes it through, so the console and the
-        # transcript still see it live during long-running steps.
-        # Out-String -Stream, then a single writer. Tee-Object -FilePath writes
-        # UTF-16LE in Windows PowerShell and has no -Encoding there, so it fought
-        # with Write-StepLog's ANSI over the same file and left every captured
-        # line as interleaved nulls. Out-String also renders the Format* records
-        # a table arrives as into the table itself, which writing the objects one
-        # at a time would not.
-        # Out-Host on the end, for the same reason the summary table has one.
-        # Inside a function, unassigned pipeline output is the return value, so
-        # every line a step produced was being returned to the caller rather than
-        # displayed. $result = Update-Everything -- the form the README documents
-        # -- therefore captured 63 objects with the result buried among them, and
-        # the transcript recorded none of the run it was supposed to be a record
-        # of. Sending it to the host displays it live, the transcript picks it up
-        # from there, and only the result object comes back.
-        # The Where-Object drops progress repaints. PowerShell splits captured
-        # native output on carriage returns, so a tool that redraws a progress
-        # bar in place -- winget above all -- arrives as one line per repaint
-        # and a single download becomes a column of percentages and spinner
-        # ticks, on the console and in the log alike. Nothing upstream prevents
-        # it: --disable-interactivity governs prompts, not rendering.
+        # *>&1 captures every stream, not just warnings: Write-Host writes to the
+        # information stream and native stderr to the error stream. The first
+        # ForEach-Object accumulates output for the error-record check below and
+        # passes each object through, so the console and the transcript see it
+        # live during long-running steps.
+        #
+        # Out-String -Stream renders the Format* records a table arrives as into
+        # the table itself, and leaves Write-StepLog as the file's only writer.
+        # Tee-Object is not usable here: it writes UTF-16LE in Windows PowerShell
+        # and has no -Encoding parameter there.
+        #
+        # Where-Object drops progress repaints. PowerShell splits captured native
+        # output on carriage returns, so a tool that redraws a progress bar in
+        # place -- winget above all -- arrives as one line per repaint. Nothing
+        # upstream prevents it: --disable-interactivity governs prompts, not
+        # rendering.
+        #
+        # Out-Host displays the output rather than returning it. Inside a
+        # function, unassigned pipeline output is the return value, so without it
+        # every line a step produced would reach the caller alongside the result
+        # object and the transcript would record none of it.
         #
         # $stepOutput is filled before the filter, so the error-record check
         # below still sees everything the step produced.

--- a/src/Private/Read-TimedChoice.ps1
+++ b/src/Private/Read-TimedChoice.ps1
@@ -31,8 +31,7 @@
             if ($remaining -ne $lastShown) {
                 # [Console]::Write, not Write-Host: transcription does not see a
                 # raw console write, so the countdown redraws on screen without
-                # writing a line per second into the run log. A 60 second wait
-                # was putting 52 lines of countdown into a 276 line transcript.
+                # writing a line per second into the run log.
                 # The extra parentheses matter. Inside a method call the comma
                 # separates arguments, so Write("..." -f $a, $b) is parsed as
                 # Write(("..." -f $a), $b): the format string gets one argument

--- a/src/Private/Set-PwshAsWindowsTerminalDefault.ps1
+++ b/src/Private/Set-PwshAsWindowsTerminalDefault.ps1
@@ -3,11 +3,10 @@
     # profile. Only the defaultProfile value is rewritten; nothing else is touched.
     #
     # Write-Output, not Write-Host. This runs inside an Invoke-Step action, where
-    # *>&1 merges the information stream into the pipeline: Write-Host wrote to
-    # the console and emitted an InformationRecord that Out-Default then rendered
-    # again, so every line here appeared twice in the transcript -- once wrapped
-    # to console width, once not. Write-Host stays the right call in
-    # Update-Everything's own summary, which is not inside a step.
+    # *>&1 merges the information stream into the pipeline: Write-Host would both
+    # write to the console and emit an InformationRecord for Out-Default to
+    # render, putting every line in the transcript twice. Write-Host remains
+    # correct in Update-Everything's own summary, which is not inside a step.
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Called from one step, which reports what it did and backs the file up before writing. The step, not this helper, is where a caller decides whether to proceed.')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'The parameter belongs to a MatchEvaluator delegate signature and must be declared whether or not the body reads it.')]
     param([Parameter(Mandatory)][string] $LogDir)
@@ -84,9 +83,9 @@
     Write-Output "Backed up settings.json -> $backup"
 
     $newKv = '"defaultProfile": "' + $ps7Guid + '"'
-    # Match any string value, not just a GUID. Terminal also accepts a profile
-    # name here, and the old GUID-only pattern missed that case and fell through
-    # to the insert branch, producing a second defaultProfile key.
+    # Match any string value, not just a GUID: Terminal also accepts a profile
+    # name here. A GUID-only pattern would miss that case and fall through to the
+    # insert branch, producing a second defaultProfile key.
     $pattern = '"defaultProfile"\s*:\s*"[^"]*"'
     if ($raw -match $pattern) {
         $updated = [regex]::Replace($raw, $pattern, [System.Text.RegularExpressions.MatchEvaluator]{ param($m) $newKv })

--- a/src/Private/Test-AdministratorGroupMember.ps1
+++ b/src/Private/Test-AdministratorGroupMember.ps1
@@ -2,15 +2,12 @@
     # Whether this account could become an administrator, as opposed to already
     # being one. Returns $true, $false, or $null when it cannot be determined.
     #
-    # The obvious implementation -- looking for S-1-5-32-544 in the current
-    # token's groups -- does not work, and fails in the dangerous direction. On
-    # a filtered (split) token Windows drops that SID entirely, so a genuine
-    # administrator reports as a standard user and the script would refuse to
-    # elevate someone who could have elevated perfectly well. Verified on a real
-    # machine: 'net localgroup Administrators' listed the user while
-    # WindowsIdentity.Groups did not contain the SID.
+    # Checking the current token's groups for S-1-5-32-544 does not work, and
+    # fails in the dangerous direction: on a filtered (split) token Windows drops
+    # that SID entirely, so a genuine administrator reports as a standard user
+    # and the caller would refuse to elevate an account that could have elevated.
     #
-    # So ask the group instead, by SID rather than by name, because
+    # The group is queried instead, by SID rather than by name, because
     # 'Administrators' is localised. Anything unresolvable returns $null, and the
     # caller treats unknown as "attempt it" rather than "refuse".
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Deliberately tri-state: true, false, or null when membership cannot be determined. No single OutputType describes that honestly.')]

--- a/src/Public/Test-PendingReboot.ps1
+++ b/src/Public/Test-PendingReboot.ps1
@@ -37,12 +37,8 @@ if ($sessionManager -and
     # that is in use, and the restart is what completes it. A pair with an empty
     # destination is a scheduled *deletion*, which installers queue constantly
     # for their own temp files and which needs no restart to be meaningful.
-    #
-    # Counting every entry made a single leftover
-    #   *1\??\C:\Users\...\AppData\Local\Temp\DEL396A.tmp
-    # announce "[!] A reboot is pending" on every run, while Component Based
-    # Servicing and Windows Update both reported nothing pending at all. A
-    # restart prompt nobody needs is one people learn to ignore.
+    # Counting every entry would report a reboot as pending for a single leftover
+    # temp-file deletion such as *1\??\C:\...\Temp\DEL396A.tmp.
     $entries     = @($sessionManager.PendingFileRenameOperations)
     $renamePaths = [System.Collections.Generic.List[string]]::new()
     $deletions   = 0
@@ -60,11 +56,9 @@ if ($sessionManager -and
             continue
         }
 
-        # Report which file, not just how many. "Pending file renames (1)" sent
-        # someone through the event log, the servicing keys and the Office
-        # update state to work out what a restart was actually for, and the
-        # answer was unrecoverable by then: the queue is consumed at boot and
-        # nothing else records it. The path is the whole answer, so log it.
+        # Report which file, not just how many. The queue is consumed at boot and
+        # nothing else records it, so a bare count cannot be resolved back into a
+        # reason after a restart.
         #
         # Sources carry NT object-manager syntax and MoveFileEx markers --
         # "\??\C:\x", "*1\??\C:\x" and "!\??\C:\x" all mean C:\x. Trim them so

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -6,48 +6,53 @@
         through the package managers and update channels it can find.
 
     .DESCRIPTION
-        v3 adds:
-          - Installs PowerShell 7 if missing, or upgrades it to the latest release,
-            via winget. Keeps the MSI package format so it lands in
-            C:\Program Files\PowerShell\7 (the path Windows Terminal looks for).
-          - Makes PowerShell 7 the default Windows Terminal profile by pointing
-            settings.json "defaultProfile" at the PowerShell Core profile GUID.
-            Only that one value is changed; the rest of settings.json is preserved.
+        Each update channel runs as an isolated step, so one failure does not stop
+        the rest. Every step writes its own log, and the run ends with a summary
+        table and a result object.
 
-        Inherited from v2:
-          - Captures full stdout/stderr per step into dedicated log files
-          - Validates external CLI exit codes ($LASTEXITCODE), reset per step so a
-            cmdlet-only step cannot inherit a stale code from an earlier native command
-          - Relaunches elevated via -Command (not -File) so typed [bool] parameters
-            survive the elevation
-          - Structured summary with log file references and reboot detection
+        What it drives:
+          - winget: the source indexes, App Installer (winget itself, which
+            "winget upgrade --all" does not reliably cover), then every source
+          - Windows Update via the PSWindowsUpdate module, scanning Microsoft
+            Update rather than Windows Update alone, so Office and other
+            Microsoft products are included
+          - Microsoft 365 Apps via OfficeC2RClient, and Defender signatures
+          - PowerShell modules and help, with PSGallery trusted once
+            (PowerShellGet v2 and PSResourceGet v3) so neither stops on the
+            untrusted-repository prompt
+          - Python (Install Manager), uv, pipx, npm, Chocolatey, Scoop, rustup,
+            dotnet global tools and workloads, GitHub CLI extensions, WSL kernel
+          - PowerShell 7 itself, installed or upgraded through winget in MSI form
+            so it lands in C:\Program Files\PowerShell\7, the path Windows
+            Terminal looks for
+          - Windows Terminal's defaultProfile, pointed at the PowerShell Core
+            profile GUID. Only that one value is changed; the rest of
+            settings.json is preserved
 
-        Also in this revision:
-          - Trusts PSGallery once (PowerShellGet v2 + PSResourceGet v3) so module
-            and help updates never stop on the untrusted-repository prompt
-          - Refreshes the winget source indexes and updates App Installer (winget
-            itself), which "winget upgrade --all" does not reliably cover
-          - Updates Microsoft 365 Apps via OfficeC2RClient, .NET workloads, and
-            GitHub CLI extensions
-          - Scans Microsoft Update rather than Windows Update alone, so Office and
-            other Microsoft products are included
-          - Stamps step logs per run and prunes old ones via -LogRetentionDays
-
-        Robustness notes (why this script is shaped the way it is):
-          - Steps capture every stream (*>&1), not just warnings, so the step log is
-            a complete record. Native stderr surfaces as error records too, and many
-            CLIs write ordinary progress there, so only errors raised by PowerShell
-            itself are counted -- those mark a step 'Warning' rather than 'OK'.
-          - Package managers routinely return non-zero for "nothing to do" or for a
-            partial success. Those codes are enumerated per step rather than being
-            treated as run failures.
-          - Presence of an .exe is not proof a feature is installed. wsl.exe ships in
-            System32 on every Windows 11 machine; Defender cmdlets exist even where a
-            third-party AV has taken over. Both are probed before use.
-          - winget output is localised and its Id column is truncated to the console
-            width, so package presence is decided by exit code, never by text match.
-          - The script exits with the number of failed steps, so a scheduled task or
-            monitoring wrapper can detect a bad run.
+        How it behaves:
+          - Steps capture every stream (*>&1), not just warnings, so the step log
+            is a complete record. Native stderr surfaces as error records too, and
+            many CLIs write ordinary progress there, so only errors raised by
+            PowerShell itself are counted -- those mark a step 'Warning' rather
+            than 'OK'.
+          - Package managers routinely return non-zero for "nothing to do" or for
+            a partial success. Those codes are enumerated per step rather than
+            being treated as run failures.
+          - $LASTEXITCODE is reset per step, so a cmdlet-only step cannot inherit
+            a stale code from an earlier native command.
+          - Presence of an .exe is not proof a feature is installed. wsl.exe ships
+            in System32 on every Windows 11 machine; Defender cmdlets exist even
+            where a third-party AV has taken over. Both are probed before use.
+          - winget output is localised and its Id column is truncated to the
+            console width, so package presence is decided by exit code, never by
+            text match.
+          - The elevated relaunch passes -Command rather than -File, so typed
+            [bool] parameters survive it.
+          - Step logs and the transcript share one per-run stamp and are pruned by
+            -LogRetentionDays.
+          - The failed-step count is returned rather than exited with, so calling
+            this from a session does not end that session. A scheduled task turns
+            FailedCount into an exit code itself.
 
         Policy note: winget runs here with --accept-package-agreements, which
         accepts vendor licence agreements on your behalf for every package it
@@ -140,23 +145,29 @@
         warning has scrolled well out of sight.
 
     .PARAMETER UpdateSelf
-        Reinstall this module from GitHub before doing anything else, whether or
-        not the installed version differs. Default: $false.
+        Reinstall this module from the main branch on GitHub before doing
+        anything else, whether or not the installed version differs.
+        Default: $false.
 
-        The version does not move with every commit and the module is
-        distributed from a branch rather than the PowerShell Gallery, so
-        "already 1.0.0" is the normal state of an out-of-date copy. This is what
-        makes tracking main practical.
+        This tracks the development head, not the latest release. To move
+        between published versions, use the gallery instead:
+
+            Update-Module UpdateEverything
+
+        The module version does not move with every commit, so "already 1.0.0"
+        is the normal state of an out-of-date working copy and a version check
+        cannot decide whether a reinstall is needed. Hence the unconditional
+        reinstall.
 
         It takes effect on the *next* run. Unlike winget, which is a fresh
-        process every step, this module is already loaded by the time it runs:
-        the files on disk are replaced, and the functions executing now stay on
-        the code already in memory.
+        process every step, this module is already loaded by the time the step
+        runs: the files on disk are replaced, and the functions executing now
+        stay on the code already in memory.
 
-        Off by default, and deliberately. It fetches and runs an installer from
-        a branch, which is a supply-chain decision rather than a routine update,
-        and a scheduled task that quietly followed main would be making that
-        decision every week on its own.
+        Off by default. It fetches and runs an installer from a branch, which is
+        a supply-chain decision rather than a routine update, and a scheduled
+        task that quietly followed main would be making that decision on every
+        run.
 
     .PARAMETER LogRetentionDays
         Delete logs and settings.json backups in the log directory older than this
@@ -214,21 +225,20 @@
         [switch] $UpdateSelf
     )
 
-    # $script:, not a plain local. As a script these lived at script scope and
-    # the private helpers read them as $script:. Inside a module a plain
-    # assignment is function-scoped, so Invoke-Step would read an unset
-    # $script:logDir and fail on every single step.
-    # TLS: no hardcoded override. Modern Windows/PowerShell negotiates TLS 1.2/1.3 automatically.
+    # State shared with the private helpers is assigned with $script:. Inside a
+    # module a plain assignment is function-scoped, so Invoke-Step would read an
+    # unset $script:logDir and fail on every step.
+    #
+    # No hardcoded TLS override: current Windows and PowerShell negotiate TLS
+    # 1.2/1.3 on their own.
     $originalOutputEncoding = Initialize-ConsoleEncoding
 
     # ---------------------------------------------------------------------------
     # 1. Logging
     #
-    # Before the elevation decision, not after it. Logging used to start once
-    # elevation had already succeeded, so every way this run could decline to
-    # start -- a standard user, UAC switched off, a host that cannot be elevated
-    # at all -- produced no log whatsoever. A PowerShell 7 run that could not
-    # elevate left nothing behind to read, and never would have.
+    # Set up before the elevation decision, not after it, so that every way this
+    # run can decline to start -- a standard user, UAC switched off, a host that
+    # cannot be elevated at all -- still leaves a log behind to read.
     # ---------------------------------------------------------------------------
     $script:logDir = Get-UpdateLogDirectory
 
@@ -237,8 +247,8 @@
     $script:runStamp = '{0:yyyyMMdd-HHmmss}' -f (Get-Date)
     $mainLog  = Join-Path $logDir "Update-Everything-$runStamp.log"
 
-    # Step logs used to be a fixed name appended to forever. They now rotate per run,
-    # so prune the old ones (and stale Terminal settings backups) instead.
+    # Step logs rotate per run rather than being appended to forever, so old ones
+    # (and stale Terminal settings backups) are pruned by age instead.
     if ($LogRetentionDays -gt 0) {
         $cutoff = (Get-Date).AddDays(-$LogRetentionDays)
         Get-ChildItem -LiteralPath $logDir -File -ErrorAction SilentlyContinue |
@@ -276,18 +286,17 @@
         # Close the transcript before handing off, and reopen it afterwards to
         # record the outcome.
         #
-        # The child computes its own run stamp and starts its own transcript. The
-        # stamps have one-second resolution, so if the two land in the same second
-        # they resolve to the same file -- and two processes with it open at once
-        # is not benign: -Append reports success and then the child's content is
-        # silently lost. Measured here, a child needs ~1.7s to start and import
-        # before it stamps, so today the stamps always differ. That is a timing
-        # margin under 2x on one machine, it narrows on faster hardware, and the
-        # failure it guards is the loss of the elevated transcript -- the one that
-        # did the work. Not overlapping costs nothing and does not depend on it.
-        # Said before the close, not after: if the elevated child hangs or the
-        # machine dies mid-run, this transcript is all there is, and it should
-        # name the log the real work went to.
+        # The child computes its own run stamp and starts its own transcript.
+        # Stamps have one-second resolution, so two starting in the same second
+        # resolve to the same path, and two processes holding it open is not
+        # benign: -Append reports success and the child's content is then lost.
+        # A child needs long enough to start and import that the stamps differ in
+        # practice, but not overlapping costs nothing and does not rely on that
+        # margin holding on faster hardware.
+        #
+        # The note is written before the close, not after. If the elevated child
+        # hangs, this transcript is all there is, and it has to name the log the
+        # real work went to.
         $childNote = "Handing off to an elevated run. Its transcript is a separate Update-Everything-*.log in $logDir, stamped when it starts."
         Write-Host $childNote -ForegroundColor Yellow
 
@@ -321,15 +330,9 @@
         Write-Warning 'Running without administrator rights. Steps that require admin will be skipped and listed in the summary.'
     }
 
-    # Notifications are resolved before any work starts, not after it. A warning
-    # raised at the end has scrolled past on an interactive run, and on a scheduled
-    # run there is no console reading it at all -- here it lands near the top of the
-    # transcript, where someone looking for "why did I not get a toast" will find it.
-    # It also means -InstallNotificationModule installs before the run rather than
-    # after everything it was meant to report on.
     # Offer a way out before anything is touched. This sits after the transcript
-    # starts, so the decision is on record, and before the notification and install
-    # checks, so skipping costs nothing.
+    # starts, so the decision is on record, and before the notification and
+    # install checks, so skipping costs nothing.
     if ($PromptBeforeRun) {
         if (-not (Test-CanPrompt)) {
             # A hidden window or redirected input cannot answer. Starting anyway
@@ -341,7 +344,7 @@
                     Write-Host 'Skipped at your request. Nothing was changed.' -ForegroundColor Yellow
                     if ($transcriptRunning) { try { Stop-Transcript | Out-Null } catch { Write-Verbose "Transcript already stopped." } }
                     try { [Console]::OutputEncoding = $originalOutputEncoding } catch { Write-Verbose "Could not restore the console encoding." }
-                    # Not a failure. You decided, and the next scheduled run stands.
+                    # Ran $false, not a failure: the next scheduled run stands.
                     return (New-UpdateEverythingResult -Ran $false -Elevated:$isAdmin `
                         -Reason 'Skipped at the pre-run prompt.' -LogDirectory $logDir -MainLog $mainLog)
                 }
@@ -358,6 +361,9 @@
     # about at most once.
     $script:InstallDecision = @{}
 
+    # Resolved before any work starts, so a missing prerequisite is reported at
+    # the top of the transcript rather than after the run it was meant to report
+    # on, and so BurntToast is installed before rather than afterwards.
     $script:NotificationsAvailable = $false
     $notificationStatus = $null
     if ($Notify) {
@@ -392,19 +398,18 @@
                 Unblock-File -LiteralPath $installer -ErrorAction SilentlyContinue
 
                 # In a child process, and powershell rather than the current
-                # host: the installer imports the module when it finishes, and
-                # doing that inside the session currently running a function
-                # from that module is asking for trouble. powershell.exe is also
-                # always present, which pwsh is not.
+                # host: the installer imports the module when it finishes, which
+                # inside this session would re-import a module whose files have
+                # just been replaced under it. powershell.exe is also always
+                # present, which pwsh is not.
                 & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer -Force
                 if ($LASTEXITCODE -ne 0) {
                     throw "The installer exited with code $LASTEXITCODE."
                 }
 
-                # Said plainly, because the obvious assumption is wrong. Unlike
-                # winget, which is a fresh process every step, this module is
-                # already loaded: the functions running now stay on the old code
-                # however new the files on disk are.
+                # Unlike winget, which is a fresh process every step, this module
+                # is already loaded: the functions running now stay on the code
+                # in memory however new the files on disk are.
                 Write-Output 'Updated. The new version loads on the next run; this one continues on the code already in memory.'
             } finally {
                 Remove-Item -LiteralPath $installer -Force -ErrorAction SilentlyContinue
@@ -626,8 +631,8 @@
 
     Invoke-Step -Name 'PowerShell modules' -Action {
         if (Get-Command Update-PSResource -ErrorAction SilentlyContinue) {
-            # -TrustRepository is the belt to the trust step's braces: it suppresses
-            # the prompt even if the persisted trust could not be written.
+            # -TrustRepository suppresses the prompt for this call even when the
+            # Trust PSGallery step could not persist the setting.
             $p = @{
                 Name            = '*'
                 TrustRepository = $true
@@ -645,8 +650,8 @@
             }
 
             # PowerShellGet 1.0.0.1 -- the version Windows PowerShell ships -- has
-            # no -AcceptLicense, and splatting a parameter that does not exist is a
-            # terminating error, so this step used to fail outright on 5.1.
+            # no -AcceptLicense, and splatting a parameter that does not exist is
+            # a terminating error, which would fail this step outright on 5.1.
             if (Test-ParameterSupport -Command 'Update-Module' -Parameter 'AcceptLicense') {
                 $p.AcceptLicense = $true
             } else {
@@ -700,9 +705,8 @@
 
         if ($LASTEXITCODE -ne 0) {
             # uv refuses to self-update when a package manager owns it, and says
-            # so. That is correct behaviour rather than a failed run. Anything
-            # else is a real failure and gets reported as one, rather than
-            # excused with a guess about why it might have happened.
+            # so in its output. That is correct behaviour rather than a failed
+            # run. Any other non-zero exit is reported as a real failure.
             if (($output | Out-String) -match 'package manager|self-update.*(disabled|unavailable)') {
                 Write-Output 'uv declined to self-update because something else manages it.'
                 $global:LASTEXITCODE = 0
@@ -731,9 +735,9 @@
             $npmText = $npmOutput | Out-String
 
             # EBADENGINE means the newest npm does not support the installed Node,
-            # which is a fact about this machine rather than a fault in the update.
-            # Said plainly, because "exit code 1" sends people looking in the wrong
-            # place.
+            # which is a fact about this machine rather than a fault in the
+            # update. Reported in full, because the bare exit code does not say
+            # which of the two it is.
             if ($npmText -match 'EBADENGINE') {
                 $nodeVersion = try { node --version 2>$null } catch { 'unknown' }
                 Write-Error ("npm could not update itself: the latest npm does not support the installed Node.js ($nodeVersion). " +
@@ -957,10 +961,9 @@
             Import-Module PSWindowsUpdate -ErrorAction Stop
 
             # Windows Update alone offers the OS and drivers. Registering the
-            # Microsoft Update service widens the scan to Office and other Microsoft
-            # products, which is what the synopsis has always claimed to do.
-            # Managed devices often block this by policy, so degrade to a
-            # Windows-Update-only scan rather than failing the whole step.
+            # Microsoft Update service widens the scan to Office and other
+            # Microsoft products. Managed devices often block this by policy, so
+            # degrade to a Windows-Update-only scan rather than failing the step.
             $useMicrosoftUpdate = $false
             $muServiceId = '7971f918-a847-4430-9279-4a52d1efe18d'
             try {
@@ -991,9 +994,9 @@
     # ---------------------------------------------------------------------------
     Write-Host "`n================ SUMMARY ================" -ForegroundColor Green
     # Out-Host, not a bare pipeline. Inside a function, unassigned pipeline
-    # output is the return value, so this table stopped being displayed and
-    # started being returned: the caller got an array of formatting objects with
-    # the result buried among them, and the summary vanished from the run log.
+    # output is the return value, so without it the caller would receive the
+    # table's formatting objects alongside the result and the summary would not
+    # appear in the run log.
     $Results | Format-Table -AutoSize -Property Step, Status, Seconds | Out-Host
 
     $failedSteps  = @($Results | Where-Object { $_.Status -eq 'Failed' })
@@ -1044,10 +1047,9 @@
         Write-Host "    Reason: $($notificationStatus.Reason)" -ForegroundColor Yellow
         Write-Host '    The update run itself was unaffected.' -ForegroundColor Yellow
     } elseif (-not $Notify) {
-        # Say that nothing was asked for. Without this the run is simply silent
-        # about notifications, which reads as a broken feature rather than an
-        # unrequested one -- and sends people looking for a BurntToast prompt
-        # that was never going to appear.
+        # State that nothing was asked for. Without this the run says nothing at
+        # all about notifications, which reads as a broken feature rather than an
+        # unrequested one.
         Write-Host ''
         Write-Host 'Notifications: not requested. Pass -Notify for a toast when the run finishes.' -ForegroundColor DarkGray
     }

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -33,19 +33,43 @@
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
             ReleaseNotes = '# 1.0.0
 
-First release as a module. Previously a single script.
+First release. Updates a Windows machine through every package manager and
+update channel it can find, running each as an isolated step so one failure
+does not stop the rest.
 
-* Update-Everything returns a result object instead of exiting, so calling it
-  from a session no longer ends that session. A scheduled task turns
-  FailedCount into an exit code itself.
+## Commands
+
+* Update-Everything runs the update pass and returns a result object rather
+  than exiting, so calling it from a session does not end that session. A
+  scheduled task turns FailedCount into an exit code itself.
 * Register-UpdateEverythingTask, Get-UpdateEverythingTask and
-  Unregister-UpdateEverythingTask replace the switches on the old
-  Register-UpdateTask.ps1.
-* Nothing is installed for the first time without permission. -AllowInstall
-  approves in advance; an interactive run asks and defaults to No; a scheduled
-  run declines and reports the step as skipped.
+  Unregister-UpdateEverythingTask manage the scheduled task.
+* Test-PendingReboot reports whether Windows is waiting on a restart, and names
+  what is holding it.
+
+## Consent
+
+Nothing is installed for the first time without permission. -AllowInstall
+approves in advance; an interactive run asks and defaults to No; a
+non-interactive run declines and reports the step as skipped.
+
+## Running unelevated
+
+Elevation is checked before it is requested, so a standard user, a machine with
+UAC switched off, or an MSIX PowerShell that Windows will not run elevated each
+get an explanation instead of a UAC prompt that cannot succeed. -SkipElevation
+runs the steps that do not need administrator rights. Logging starts before the
+elevation decision, so a run that declines to start still leaves a log.
+
+## Also in this release
+
 * Optional toast notifications through BurntToast, including an urgent restart
   notice that breaks through Focus Assist.
+* -UpdateSelf reinstalls the module from the main branch on GitHub.
+* Per-run step logs and transcripts, pruned by -LogRetentionDays.
+* Windows PowerShell 5.1 and PowerShell 7 are both supported. Parameters absent
+  from the PowerShellGet 1.0.0.1 that Windows ships are probed rather than
+  assumed.
 '
         }
     }

--- a/src/UpdateEverything.psm1
+++ b/src/UpdateEverything.psm1
@@ -1,7 +1,7 @@
-# The OperatingSystem object, not its Version. An earlier draft took .Version
-# here and then asked it for .Platform, which is always $null. Windows
-# PowerShell has no $IsWindows to fall back on, so the guard fired and the module
-# refused to load on the very edition the manifest promises to support.
+# The OperatingSystem object, not its Version: .Platform is a property of the
+# former and is always $null on the latter. Windows PowerShell has no $IsWindows
+# to fall back on, so a $null here would fail the guard below on a supported
+# edition.
 $OS = [System.Environment]::OSVersion
 
 if ($OS.Platform -ne [System.PlatformID]::Win32NT) {

--- a/tests/FreshMachine/Sandbox/Start-Harness.ps1
+++ b/tests/FreshMachine/Sandbox/Start-Harness.ps1
@@ -124,9 +124,10 @@ try {
     Write-Output '== Install command, taken from README =='
     $readme = Get-Content (Join-Path $RepoPath 'README.md') -Raw
 
-    # The first fenced powershell block in the Install section is the command a
-    # new user pastes.
-    $section = [regex]::Match($readme, '(?s)\n## Install\r?\n(.*?)\r?\n## ').Groups[1].Value
+    # The GitHub one-liner, not the gallery command that now leads the section.
+    # This harness has no published version to install from -- it tests main, and
+    # the download-then-run path is where the defects it exists to catch were.
+    $section = [regex]::Match($readme, '(?s)\n### Install from GitHub\r?\n(.*?)\r?\n#{2,3} ').Groups[1].Value
     $command = [regex]::Match($section, '(?s)```powershell\r?\n(.*?)```').Groups[1].Value.Trim()
 
     $found = -not [string]::IsNullOrWhiteSpace($command)

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -488,6 +488,36 @@ Describe 'Update-Everything' -Tag 'Static' {
             (Get-Help Update-Everything).parameters.parameter.name |
                 Should-ContainCollection $Name -Because 'undocumented parameters drift into surprises'
         }
+
+        It 'has a description' {
+            (Get-Help Update-Everything).description |
+                Out-String | Should-NotBeEmptyString
+        }
+
+        # A line whose first non-space character is a dot is read as a help
+        # keyword, whatever word follows it. ".NET global tools" wrapped to the
+        # start of a line ends the section it sits in and silently discards
+        # every section after it -- Get-Help reports no error, it just returns
+        # empty descriptions and outputs.
+        It 'starts no help line with a dot that is not a help keyword' {
+            $keywords = 'SYNOPSIS', 'DESCRIPTION', 'PARAMETER', 'EXAMPLE', 'INPUTS',
+                        'OUTPUTS', 'NOTES', 'LINK', 'COMPONENT', 'ROLE',
+                        'FUNCTIONALITY', 'FORWARDHELPTARGETNAME',
+                        'FORWARDHELPCATEGORY', 'REMOTEHELPRUNSPACE', 'EXTERNALHELP'
+
+            $offenders = foreach ($file in Get-ChildItem $script:ModuleRoot -Recurse -Filter *.ps1) {
+                $text = Get-Content -LiteralPath $file.FullName -Raw
+                foreach ($block in [regex]::Matches($text, '(?s)<#(.*?)#>')) {
+                    foreach ($line in $block.Groups[1].Value -split "`r?`n") {
+                        if ($line -match '^\s*\.([A-Za-z]\w*)' -and $Matches[1].ToUpperInvariant() -notin $keywords) {
+                            "$($file.Name): $($line.Trim())"
+                        }
+                    }
+                }
+            }
+
+            $offenders | Should-BeNull -Because "these silently truncate comment-based help:`n$($offenders -join "`n")"
+        }
     }
 
     Context 'Step definitions' {


### PR DESCRIPTION
Everything standing between `main` and a first gallery release, plus a comment
pass across `src`.

## Comments state facts, not history

The comments had become a record of how the code was arrived at:

```powershell
# Counting every entry made a single leftover
#   *1\??\C:\Users\...\AppData\Local\Temp\DEL396A.tmp
# announce "[!] A reboot is pending" on every run, while Component Based
# Servicing and Windows Update both reported nothing pending at all. A
# restart prompt nobody needs is one people learn to ignore.
```

Accurate when written, and stale the moment the code moves. It is also already
in `git log`, told better. What the next reader needs is the constraint that is
still true:

```powershell
# A pair with an empty destination is a scheduled *deletion*, which installers
# queue constantly for their own temp files and which needs no restart to be
# meaningful. Counting every entry would report a reboot as pending for a
# single leftover temp-file deletion such as *1\??\C:\...\Temp\DEL396A.tmp.
```

Same for `Invoke-Step`'s pipeline, `Invoke-SelfElevation`'s relaunch shape, the
`.psm1` guard, `Test-AdministratorGroupMember`, the transcript handoff, and the
summary table. Every technical constraint survived; the war stories did not.

`CONTRIBUTING.md` gains the rule under House style, with the split stated
plainly: a *why* that is a property of Windows, PowerShell or a tool's contract
is a fact and belongs in the code. A *why* that is a property of a past pull
request belongs in the commit message.

## A defect the rewrite surfaced

Reflowing `Update-Everything`'s `.DESCRIPTION` put this at the start of a line:

```
            .NET global tools and workloads, GitHub CLI extensions, WSL kernel
```

A line whose first non-space character is a dot is read as a help keyword,
whatever word follows it. `.NET` ended the `.DESCRIPTION` and discarded every
section after it. `Get-Help` reported no error — it returned an empty
description and an empty `OUTPUTS`:

```
DESC LEN: 0
RETURNVALUES: @{type=}
```

The suite caught it only two sections downstream, through an assertion about
`FailedCount`. Now written as `dotnet`, with a test that scans every `<# #>`
block for a leading dot that is not one of the fifteen real keywords, so the
next occurrence is named at the point it happens.

## Release pre-flight

**`ReleaseNotes` describes 1.0.0.** They described the script-to-module
conversion and mentioned none of what actually shipped — elevation, consent,
`-UpdateSelf`, the 5.1 support. It is the package page, and it is as permanent
as the version it ships with.

**README leads with `Install-Module`.** The GitHub one-liner keeps its own
`### Install from GitHub` subsection, for tracking `main` and for a host whose
PowerShellGet cannot reach the gallery. The smoke test used to take *the first
fenced block in the Install section*, which would now hand it the gallery
command; it reads from the named subsection instead, since it has no published
version to install and the download-then-run path is the one it exists to test.

**`-UpdateSelf` says which thing it tracks.** It fetches `Install.ps1` from
`main`, so a gallery user asking the module to update itself gets the
development head. The help now says so and points at `Update-Module` for moving
between releases. Behaviour unchanged — it is the right behaviour while testing,
it was just undocumented.

**`CONTRIBUTING.md` gains the publishing pre-flight**: raise the version,
rewrite the notes, run the fresh-machine test, and tag the published commit —
gallery versions cannot be replaced, only unlisted, so the permanent version
needs something in the history pointing at it.

## Testing

500 tests, 0 failed (was 498; two added).

PSScriptAnalyzer clean over `src` under its **default** rules — the ones the
gallery runs and displays, not the repo's tuned set.

`Publish.ps1 -WhatIf`:

```
UpdateEverything 1.0.0
Not yet on PSGallery, so this would be the first release.
All checks passed.
Staged UpdateEverything 1.0.0 -- Files: 45
```

`Get-Help` verified in a fresh process rather than assumed: description 2943
characters, `OUTPUTS` naming `FailedCount`. Both README extraction regexes
re-run against the restructured file — the smoke test's and the two docs tests'
— and both still resolve to the right command.

## Not covered

The full elevation handoff still has no end-to-end coverage: development
sessions are already administrators, and Windows Sandbox ships `EnableLUA=0`.
The relaunch *command* is regression-tested at the layer it broke
(`Module.Tests.ps1`, real `Invoke-SelfElevation` with only `Start-Process`
mocked, output run through the parser), but "the elevated child starts, runs and
leaves its own transcript" needs the Hyper-V harness described in
`tests/FreshMachine/README.md` and not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
