### PR TITLE
Add issue forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Something did not work
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A step reported `Skipped` is usually not a bug — a package manager that
+        is not installed is skipped by design, with the reason in the summary.
+        `Failed` and `Warning` are the ones worth reporting.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you ran, and what it did instead of what you expected.
+      placeholder: |
+        Ran Update-Everything from an unelevated PowerShell 7 session.
+        The elevated window opened and closed immediately, and no transcript
+        was written for it.
+    validations:
+      required: true
+
+  - type: input
+    id: step
+    attributes:
+      label: Which step
+      description: The step name from the summary table, if it was one step rather than the whole run.
+      placeholder: "winget (all sources)"
+
+  - type: dropdown
+    id: edition
+    attributes:
+      label: PowerShell edition
+      options:
+        - Windows PowerShell 5.1
+        - PowerShell 7 (MSI, in Program Files)
+        - PowerShell 7 (MSIX, from the Store or winget default)
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: elevated
+    attributes:
+      label: Was the session elevated
+      options:
+        - "Yes — started as administrator"
+        - "No — it tried to self-elevate"
+        - "No — ran with -SkipElevation"
+        - Ran from the scheduled task
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Module version
+      description: "`(Get-Module UpdateEverything -ListAvailable).Version`"
+      placeholder: "1.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: windows
+    attributes:
+      label: Windows version
+      description: "`(Get-ComputerInfo).OsName` and the build, or just winver."
+      placeholder: "Windows 11 Enterprise 26100"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log
+      description: |
+        The transcript is `Update-Everything-<stamp>.log` in your log directory,
+        and each step has its own `<step>-<stamp>.log` beside it. The summary
+        table prints the path. Paste the relevant part rather than the whole
+        file, and check it for machine names or paths you would rather not post.
+      render: text
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: A managed device, a policy that blocks something, a third-party AV, an unusual module path.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# Blank issues stay enabled. A form is worth filling in for a bug report or a
+# feature; it is friction for "remember to look at this", and friction is how a
+# note ends up somewhere that is not the issue tracker.
+blank_issues_enabled: true
+
+contact_links:
+  - name: How this module is built
+    url: https://github.com/briankronberg/UpdateEverything/blob/main/CONTRIBUTING.md
+    about: House style, the rules a change has to satisfy, and how the tests work. Worth reading before opening a pull request.
+  - name: Before your first run
+    url: https://github.com/briankronberg/UpdateEverything/blob/main/README.md#before-your-first-run
+    about: What the first run does, what it asks for, and what it will not do without permission.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,76 @@
+name: Feature request
+description: Something it should do and does not
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The fields below are the ones that are hard to reconstruct later. Fill in
+        what you know; an idea recorded roughly beats one not recorded.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What it should do
+      description: The behaviour, from the outside. A command line or a snippet of output says it faster than a paragraph.
+      placeholder: |
+        Update-Everything -Tag Python
+
+        Runs only the steps tagged Python and reports the rest as skipped.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: |
+        The problem it solves, not the solution restated. This is the field
+        worth the most in six months, when the "what" still makes sense and the
+        reason for it has gone.
+      placeholder: |
+        Some tools want to be absolutely current and others want holding back,
+        because they are a prerequisite for an app this tool does not know
+        about. Today the run is all or nothing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: depends
+    attributes:
+      label: Depends on
+      description: Issues that have to land first, and why. Leave blank if nothing.
+      placeholder: "#18 — the parameters cannot be expressed until steps can be selected by tag."
+
+  - type: textarea
+    id: open
+    attributes:
+      label: Open questions
+      description: Decisions you have not made. Recording them stops them being re-argued, or worse, silently decided by whoever implements it.
+      placeholder: |
+        Should an unknown tag fail loudly, or match nothing?
+
+  - type: dropdown
+    id: installs
+    attributes:
+      label: Would this install anything
+      description: |
+        Anything that installs software for the first time goes through
+        `Approve-Install`. A change that installs something silently will not be
+        merged, however convenient — see CONTRIBUTING.md.
+      options:
+        - "No"
+        - "Yes — and it should go through -AllowInstall"
+        - "Yes — and it needs a new consent path"
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: admin
+    attributes:
+      label: Would this need administrator rights
+      options:
+        - "No"
+        - "Yes — the step should be marked -RequiresAdmin"
+        - Not sure


### PR DESCRIPTION
Two YAML issue forms and a config, under `.github/ISSUE_TEMPLATE/`.

## What they ask, and why

The **bug form** asks for the things that are hard to reconstruct after the
fact:

- **PowerShell edition, with MSI and MSIX as separate options.** That
  distinction decides whether the process can elevate at all, and it is not
  visible in a version number.
- **How the session got its rights** — started elevated, self-elevated,
  `-SkipElevation`, or the scheduled task. Four different code paths.
- **Which step**, since the summary table names it and a whole-run report is
  harder to act on.
- Where the logs live, and a reminder to check them for machine names before
  pasting.

It opens by saying a `Skipped` step is usually not a bug — a package manager
that is not installed is skipped by design, with the reason in the summary.

The **feature form** asks *why* separately from *what*. The what survives in the
title; the why is the part that goes missing and cannot be recovered. It also
asks for dependencies and open questions, so an undecided thing is recorded as
undecided rather than settled quietly by whoever picks it up.

Two dropdowns carry the repo's existing rules into the form: whether the change
would install anything (which routes it through `Approve-Install`) and whether
it needs administrator rights (`-RequiresAdmin`).

## Blank issues stay enabled

A form is worth filling in for a real report. It is friction for "remember to
look at this", and that friction is how a note ends up in a text file instead of
the tracker.

## Testing

Both forms parsed with PyYAML; required fields resolve as intended (`what`,
`edition`, `elevated`, `version` on the bug form; `what`, `why`, `installs` on
the feature form). The `config.yml` contact link to *Before your first run*
checked against the heading at `README.md:511`.

No change to `src`, so the suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)