### PR TITLE
Keep the gallery tooling current, not just present

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,16 @@ The assertions this suite uses, all of which exist:
 `Should-BeOfType` and `Should-NotBeNullOrEmpty` do **not** exist in Pester 6.
 Reach for `Should-HaveType` and `Should-NotBeEmptyString`.
 
+There is no `Should-NotThrow` either — only `Should-Throw`. To assert that
+something does not throw, call it and assert on what it returned; a test that
+inspects the result has already proved it.
+
+Check a name before reaching for it rather than after:
+
+```powershell
+(Get-Command -Module Pester -Name 'Should-*').Name
+```
+
 **PowerShell 7 from the MSI, not the Store.** The MSIX build cannot be elevated,
 cannot use in-process COM (the DISM cmdlets fail with "Class not registered"),
 and its path carries a version stamp that a scheduled task cannot rely on. The

--- a/src/Private/Approve-Install.ps1
+++ b/src/Private/Approve-Install.ps1
@@ -24,7 +24,10 @@
     if (-not (Test-CanPrompt)) {
         # A scheduled run has nobody to ask, and silently installing software on
         # a machine nobody is watching is exactly what this gate exists to stop.
-        Write-Warning "$Component is not installed, and this run cannot prompt for consent. Re-run with -AllowInstall $Component (or -AllowInstall All) to permit it."
+        # "needs installing", not "is not installed": a component can also reach
+        # here when it is present in a form that cannot be updated in place, and
+        # replacing that is still an install.
+        Write-Warning "$Component needs installing, and this run cannot prompt for consent. Re-run with -AllowInstall $Component (or -AllowInstall All) to permit it."
         $script:InstallDecision[$Component] = $false
         return $false
     }

--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -1,0 +1,77 @@
+function Get-GalleryModuleStatus {
+    <#
+        .SYNOPSIS
+        Compares the newest installed version of a module against the newest on
+        the PowerShell Gallery.
+
+        .DESCRIPTION
+        Returns Installed, Available and NeedsUpdate.
+
+        Installed is $null when the module is not on the machine at all, which is
+        a different answer from "installed but old" and the caller acts on it
+        differently: one is an install and needs consent, the other is an update
+        and does not.
+
+        Available is $null when the gallery could not be reached. NeedsUpdate is
+        then $false, so a network failure presents as "cannot tell" rather than
+        as a reason to reinstall. It never reports an update as available for a
+        module that is not installed.
+
+        Updatable reports whether Update-Module can move this copy forward at
+        all. It refuses anything it did not install -- "Module 'X' was not
+        installed by using Install-Module, so it cannot be updated" -- which
+        covers every module that shipped with the host, wherever it sits.
+        Windows PowerShell ships PowerShellGet 1.0.0.1 under Program Files
+        rather than $PSHOME, so the path is not the test; whether PowerShellGet
+        recorded the install is.
+
+        A shipped copy is not stuck, but moving it forward is a side-by-side
+        install rather than an update, and so it is an install decision.
+
+        .EXAMPLE
+        Get-GalleryModuleStatus -Name PowerShellGet
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Name
+    )
+
+    # Indexed rather than "| Select-Object -First 1": that halts the upstream
+    # pipeline, and inside a step action the transcript records the stop as a
+    # TerminatingError.
+    $present = @(Get-Module -Name $Name -ListAvailable -ErrorAction SilentlyContinue |
+        Sort-Object Version -Descending)
+    $installed = if ($present.Count) { [version] $present[0].Version } else { $null }
+
+    # Ask PowerShellGet what it installed, rather than inferring it from the
+    # path. Get-InstalledModule reports only what came through Install-Module,
+    # which is exactly the set Update-Module will act on.
+    $updatable = $false
+    if ($present.Count -and (Get-Command Get-InstalledModule -ErrorAction SilentlyContinue)) {
+        $updatable = [bool] (Get-InstalledModule -Name $Name -ErrorAction SilentlyContinue)
+    }
+
+    $available = $null
+    try {
+        $found = Find-Module -Name $Name -Repository PSGallery -ErrorAction Stop
+
+        # Find-Module returns the version as a string on some PowerShellGet
+        # versions and a [version] on others, and a prerelease carries a suffix
+        # that [version] cannot parse. Trim the suffix and let the cast decide.
+        $raw = "$($found.Version)" -replace '-.*$', ''
+        if ($raw) { $available = [version] $raw }
+    } catch {
+        Write-Verbose "Could not ask the gallery about ${Name}: $($_.Exception.Message)"
+    }
+
+    [pscustomobject]@{
+        Name        = $Name
+        Installed   = $installed
+        Available   = $available
+        Updatable   = $updatable
+        NeedsUpdate = [bool] ($installed -and $available -and $available -gt $installed)
+    }
+}

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -129,7 +129,7 @@
 
         [bool] $Notify = $true,
 
-        [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet')]
+        [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
 
         [ValidateSet('Normal', 'Minimized', 'Hidden')]

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -108,6 +108,14 @@
                            2.x, which can accept module licenses and can see
                            modules installed by newer versions (AllUsers when
                            elevated, otherwise CurrentUser)
+          PSResourceGet    install Microsoft.PowerShell.PSResourceGet, the
+                           current gallery client. Changes which client every
+                           later module update uses (AllUsers when elevated,
+                           otherwise CurrentUser)
+
+        NuGetProvider also covers refreshing a provider that is already present.
+        There is no update command for a package provider, so moving one forward
+        means installing the newer version, and that asks.
 
         A scheduled task cannot prompt, so pass the approvals it should have:
             -AllowInstall PSWindowsUpdate,BurntToast
@@ -218,7 +226,7 @@
         [ValidateRange(1, 1440)]
         [int]    $DelayMinutes            = 60,
         [switch] $Notify,
-        [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet')]
+        [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30,
@@ -597,34 +605,130 @@
             }
         }
 
-        # Windows PowerShell ships PowerShellGet 1.0.0.1 and never updates it.
-        # Test-ParameterSupport keeps that version from failing the module step
-        # outright, but it cannot fix the deeper problem: v1 does not see modules
-        # installed by v2, so Update-Module on 5.1 quietly skips most of what is
-        # actually installed. Offer the upgrade rather than assuming it.
+        # This step sets trust and stops there. Moving PowerShellGet itself
+        # forward belongs to the Gallery tooling step below, which handles the
+        # 1.0.0.1 Windows ships as one case of a general rule rather than as a
+        # version comparison of its own.
+    }
+
+    # The tooling every other gallery step runs on. It is bootstrapped above when
+    # missing, but nothing until now brought it forward once present, so a
+    # machine could carry a years-old NuGet provider or a PowerShellGet 2.1 for
+    # as long as it lived. This runs before 'PowerShell modules' because that
+    # step is one of the things that depends on it.
+    Invoke-Step -Name 'Gallery tooling' -Action {
+        # Not admin-gated, and -Scope AllUsers fails without elevation, so the
+        # scope follows what the run actually has.
+        $scope = if ($isAdmin) { 'AllUsers' } else { 'CurrentUser' }
+
+        # --- NuGet package provider ------------------------------------------
         #
-        # Declining is not fatal here, unlike the NuGet provider above: trust has
-        # already been set, and the module step still runs on v1.
-        # Indexed rather than "| Select-Object -First 1": that halts the upstream
-        # pipeline, and inside a step action the transcript records the stop as a
-        # TerminatingError.
-        $psgetAll = @(Get-Module PowerShellGet -ListAvailable | Sort-Object Version -Descending)
-        $psget    = if ($psgetAll.Count) { $psgetAll[0] } else { $null }
+        # There is no Update-PackageProvider; Install-PackageProvider is the only
+        # way to move one forward. That makes the refresh an install command
+        # fetching a binary provider assembly, so it asks under the same
+        # 'NuGetProvider' component as the bootstrap rather than proceeding on
+        # the grounds that something is already there. Declining is not fatal:
+        # the provider that is present keeps working.
+        $nuget = @(Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue |
+            Sort-Object Version -Descending)
+        if (-not $nuget.Count) {
+            Write-Output 'No NuGet package provider is present; the Trust PSGallery step reports why.'
+        } else {
+            $current = $nuget[0].Version
+            $newest = $null
+            try {
+                $candidates = @(Find-PackageProvider -Name NuGet -ErrorAction Stop |
+                    Sort-Object Version -Descending)
+                if ($candidates.Count) { $newest = $candidates[0].Version }
+            } catch {
+                # PowerShell 7 registers no provider bootstrap source, so this
+                # cannot be answered there at all and fails with "No match was
+                # found". Windows PowerShell answers it. Neither is a fault, and
+                # the provider that is present keeps working either way, so the
+                # detail goes to the verbose stream rather than the summary.
+                Write-Verbose "Could not ask for the newest NuGet provider: $($_.Exception.Message)"
+            }
 
-        if ($psget -and $psget.Version -lt [version]'2.0.0') {
-            Write-Output "PowerShellGet $($psget.Version) is the version Windows ships."
+            if (-not $newest) {
+                # Not the same as up to date, and must not read like it.
+                Write-Output "NuGet package provider $current is installed; no newer version could be looked up on this host."
+            } elseif ($newest -gt $current) {
+                if (Approve-Install -Component 'NuGetProvider' -Approved $AllowInstall `
+                        -Description "The NuGet package provider is at $current and $newest is available. There is no update command for a provider, so this would install the newer one $(if ($isAdmin) { 'for all users on this machine' } else { 'for the current user only' }).") {
+                    $null = Install-PackageProvider -Name NuGet -Force -Scope $scope -ErrorAction Stop
+                    Write-Output "NuGet package provider $current -> $newest."
+                }
+            } else {
+                Write-Output "NuGet package provider $current is current."
+            }
+        }
 
-            # This step is not admin-gated, and -Scope AllUsers fails without
-            # elevation, so the scope follows what the run actually has.
-            $scope = if ($isAdmin) { 'AllUsers' } else { 'CurrentUser' }
-            $where = if ($isAdmin) { 'for all users on this machine' } else { 'for the current user only' }
+        # --- PowerShellGet and PSResourceGet ---------------------------------
+        #
+        # Three cases, and they are not the same decision:
+        #
+        #   absent                  an install, and asks
+        #   present but not ours    a copy the host shipped. Update-Module
+        #                           refuses it, so moving it forward is a
+        #                           side-by-side install, and asks
+        #   present and ours        an update, and does not ask
+        #
+        # The middle case is why the version alone is not the test. Windows
+        # PowerShell ships PowerShellGet 1.0.0.1 under Program Files rather than
+        # $PSHOME, and Update-Module answers "Module 'PowerShellGet' was not
+        # installed by using Install-Module, so it cannot be updated".
+        foreach ($tool in @(
+                @{ Module = 'PowerShellGet';                      Component = 'PowerShellGet' }
+                @{ Module = 'Microsoft.PowerShell.PSResourceGet'; Component = 'PSResourceGet' }
+            )) {
+            $name = $tool.Module
+            $status = Get-GalleryModuleStatus -Name $name
 
-            if (Approve-Install -Component 'PowerShellGet' -Approved $AllowInstall `
-                    -Description "PowerShellGet $($psget.Version) cannot accept module licenses and does not see modules installed by newer versions, so module updates on this host will miss most of what is installed. This would install PowerShellGet 2.x from the PowerShell Gallery $where.") {
+            if (-not $status.Available) {
+                $known = if ($status.Installed) { "$name $($status.Installed) is installed" } else { "$name is not installed" }
+                Write-Output "$known; the gallery could not be asked about it."
+                continue
+            }
 
-                Install-Module PowerShellGet -Force -AllowClobber -Scope $scope `
+            if ($status.Installed -and $status.Updatable -and -not $status.NeedsUpdate) {
+                Write-Output "$name $($status.Installed) is current."
+                continue
+            }
+
+            if ($status.Installed -and $status.Updatable) {
+                Write-Output "$name $($status.Installed) -> $($status.Available)..."
+                if (Get-Command Update-PSResource -ErrorAction SilentlyContinue) {
+                    Update-PSResource -Name $name -TrustRepository -Confirm:$false -ErrorAction Stop
+                } else {
+                    Update-Module -Name $name -Force -Confirm:$false -ErrorAction Stop
+                }
+
+                # The same trap as -UpdateSelf: the module is already loaded, so
+                # the files on disk are replaced and the cmdlets running now stay
+                # on the code in memory.
+                Write-Output "$name updated. It loads in the next session; this run continues on the version already in memory."
+                continue
+            }
+
+            # Nothing left but an install: either absent, or a shipped copy that
+            # can only be replaced side by side.
+            if ($status.Installed -and $status.Installed -ge $status.Available) {
+                Write-Output "$name $($status.Installed) shipped with this host and is not behind the gallery; leaving it alone."
+                continue
+            }
+
+            $what = if ($status.Installed) {
+                "$name $($status.Installed) is the copy this PowerShell shipped with, which cannot be updated in place. Installing $($status.Available) alongside it is the only way forward"
+            } else {
+                "$name is not installed. It is the current PowerShell Gallery client, and installing it changes which client every later module update uses. This would install $($status.Available)"
+            }
+
+            if (Approve-Install -Component $tool.Component -Approved $AllowInstall `
+                    -Description "$what $(if ($isAdmin) { 'for all users on this machine' } else { 'for the current user only' }).") {
+
+                Install-Module -Name $name -Force -AllowClobber -Scope $scope `
                     -Confirm:$false -ErrorAction Stop
-                Write-Output "Installed PowerShellGet 2.x ($scope). It takes effect in the next session; this run continues on the version already loaded."
+                Write-Output "Installed $name $($status.Available) ($scope). It loads in the next session."
             }
         }
     }

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -1021,7 +1021,12 @@ Describe 'No step updates through a tool it has not verified' -Tag 'Static','Mod
             'Trust PSGallery', 'PowerShell modules', 'PowerShell help',
             'Windows Update', 'Windows Terminal default = PowerShell 7',
             # Invoke-WebRequest is built in and powershell.exe is always there.
-            'UpdateEverything (self)'
+            'UpdateEverything (self)',
+            # PackageManagement and PowerShellGet ship with every supported
+            # Windows, so Get-PackageProvider and Find-Module always resolve.
+            # The step reports each component it did not find rather than
+            # driving anything it has not confirmed.
+            'Gallery tooling'
         )
 
         $offenders = foreach ($call in $ast.FindAll({

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -948,12 +948,22 @@ Describe 'The PowerShellGet upgrade offer' -Tag 'Static' {
             (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
     }
 
+    # The component name now comes from the table the step loops over, so the
+    # gate is asserted through that rather than as a literal. InstallConsent's
+    # "guards every install command with an approval check" is the general
+    # proof; this is the one that says PowerShellGet is still in the set.
     It 'is gated behind the same consent prompt as every other install' {
-        $script:MainSource | Should-MatchString "Approve-Install -Component 'PowerShellGet'"
+        $script:MainSource | Should-MatchString 'Approve-Install -Component \$tool\.Component'
+        $script:MainSource | Should-MatchString "Module = 'PowerShellGet';\s+Component = 'PowerShellGet'"
     }
 
-    It 'only fires when the installed version predates 2.0' {
-        $script:MainSource | Should-MatchString "\`$psget\.Version -lt \[version\]'2\.0\.0'"
+    # The version is not the test, and was never quite the right one. Windows
+    # ships PowerShellGet 1.0.0.1 in a form Update-Module refuses, and so does
+    # PowerShell 7 with its own 2.2.5 -- the shared condition is whether
+    # PowerShellGet recorded the install, not what number it carries.
+    It 'decides by whether the copy can be updated, not by its version' {
+        $script:MainSource | Should-NotMatchString "\`$psget\.Version -lt \[version\]'2\.0\.0'"
+        $script:MainSource | Should-MatchString '\$status\.Updatable'
     }
 
     # The Trust PSGallery step carries no -RequiresAdmin, and -Scope AllUsers
@@ -974,7 +984,7 @@ Describe 'The PowerShellGet upgrade offer' -Tag 'Static' {
         'src\Public\Register-UpdateEverythingTask.ps1'
     ) {
         Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) $_) -Raw |
-            Should-MatchString "ValidateSet\('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet'\)"
+            Should-MatchString "ValidateSet\('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet'\)"
     }
 }
 
@@ -1265,5 +1275,201 @@ Describe 'Invoke-Step -RequiresAdmin' -Tag 'Unit','Security' {
             Invoke-Step -Name 'needs-admin' -RequiresAdmin -Action { 'x' } 6>$null
             $script:Results[0].Status | Should-Be 'OK'
         }
+    }
+}
+
+Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
+
+    # Get-Module is left real and asked about modules whose presence is already
+    # known: Pester is installed, because it is running this. Mocking Get-Module
+    # would put a mock in the path of Pester's own calls to it.
+    #
+    # Find-Module is mocked in every case, so nothing here needs a network.
+
+    BeforeAll {
+        $script:PesterVersion = @(Get-Module Pester -ListAvailable |
+            Sort-Object Version -Descending)[0].Version
+        $script:Absent = 'UpdateEverything.NoSuchModule.7f3a1c'
+    }
+
+    It 'reports an update when the gallery is ahead of what is installed' {
+        $newer = [version]::new($script:PesterVersion.Major + 1, 0, 0)
+        Mock Find-Module { [pscustomobject]@{ Version = $newer } }
+
+        $status = Get-GalleryModuleStatus -Name Pester
+
+        $status.Installed   | Should-Be $script:PesterVersion
+        $status.Available   | Should-Be $newer
+        $status.NeedsUpdate | Should-BeTrue
+    }
+
+    It 'reports no update when the gallery matches what is installed' {
+        Mock Find-Module { [pscustomobject]@{ Version = $script:PesterVersion } }
+
+        (Get-GalleryModuleStatus -Name Pester).NeedsUpdate | Should-BeFalse
+    }
+
+    It 'reports no update when the gallery is behind what is installed' {
+        Mock Find-Module { [pscustomobject]@{ Version = '0.0.1' } }
+
+        (Get-GalleryModuleStatus -Name Pester).NeedsUpdate | Should-BeFalse
+    }
+
+    # A gallery that cannot be reached must present as "cannot tell", never as
+    # "up to date" and never as a reason to reinstall.
+    It 'reports Available as null when the gallery cannot be reached' {
+        Mock Find-Module { throw 'no such host is known' }
+
+        $status = Get-GalleryModuleStatus -Name Pester
+
+        $status.Available   | Should-BeNull
+        $status.NeedsUpdate | Should-BeFalse
+        $status.Installed   | Should-Be $script:PesterVersion
+    }
+
+    It 'reports Installed as null for a module that is not on the machine' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+
+        (Get-GalleryModuleStatus -Name $script:Absent).Installed | Should-BeNull
+    }
+
+    # An absent module is an install decision, not an update, and the caller
+    # tells them apart by this flag.
+    It 'never reports an update for a module that is not installed' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+
+        (Get-GalleryModuleStatus -Name $script:Absent).NeedsUpdate | Should-BeFalse
+    }
+
+    # Update-Module refuses anything it did not install, so this is the flag that
+    # decides between an update and a side-by-side install. Get-InstalledModule
+    # is mocked rather than read, because whether this machine's Pester arrived
+    # through Install-Module is not something a test should depend on.
+    It 'reports Updatable when PowerShellGet recorded the install' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledModule { [pscustomobject]@{ Name = 'Pester' } }
+
+        (Get-GalleryModuleStatus -Name Pester).Updatable | Should-BeTrue
+    }
+
+    It 'reports a copy the host shipped as not updatable' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledModule { }
+
+        (Get-GalleryModuleStatus -Name Pester).Updatable | Should-BeFalse
+    }
+
+    # NeedsUpdate answers "is the gallery ahead", not "can this be updated".
+    # The caller needs both, and conflating them is what drove Update-Module at
+    # a shipped PowerShellGet 1.0.0.1 and failed the step.
+    It 'still reports NeedsUpdate for a shipped copy the gallery is ahead of' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledModule { }
+
+        $status = Get-GalleryModuleStatus -Name Pester
+        $status.NeedsUpdate | Should-BeTrue
+        $status.Updatable   | Should-BeFalse
+    }
+
+    It 'reports a module that is not installed as not updatable' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+
+        (Get-GalleryModuleStatus -Name $script:Absent).Updatable | Should-BeFalse
+    }
+
+    # Find-Module returns the version as a string on some PowerShellGet versions
+    # and a [version] on others, and a prerelease carries a suffix that [version]
+    # cannot parse at all.
+    It 'strips a prerelease suffix rather than failing on it' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9-preview3' } }
+
+        (Get-GalleryModuleStatus -Name Pester).Available | Should-Be ([version]'9.9.9')
+    }
+}
+
+Describe 'The Gallery tooling step' -Tag 'Static' {
+
+    # The gallery tooling was installed when missing and then never brought
+    # forward, so a machine could carry a years-old NuGet provider or a
+    # PowerShellGet 2.1 indefinitely. Every other gallery step runs on it.
+
+    BeforeAll {
+        $script:MainSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+
+        $script:ToolingAt = $script:MainSource.IndexOf("Invoke-Step -Name 'Gallery tooling'")
+        $script:ModulesAt = $script:MainSource.IndexOf("Invoke-Step -Name 'PowerShell modules'")
+        $script:TrustAt   = $script:MainSource.IndexOf("Invoke-Step -Name 'Trust PSGallery'")
+    }
+
+    It 'exists' {
+        $script:ToolingAt | Should-BeGreaterThan -1
+    }
+
+    # Trust has to be set before anything installs, or the install stops on the
+    # untrusted-repository prompt rather than failing.
+    It 'runs after the trust step' {
+        $script:ToolingAt | Should-BeGreaterThan $script:TrustAt
+    }
+
+    # The module step is one of the things that runs on this tooling, so
+    # updating it afterwards would leave the run using the version it was
+    # trying to replace.
+    It 'runs before the step that depends on it' {
+        $script:ToolingAt | Should-BeLessThan $script:ModulesAt
+    }
+
+    It 'asks the gallery through the shared helper rather than inline' {
+        $script:MainSource | Should-MatchString 'Get-GalleryModuleStatus -Name \$name'
+    }
+
+    It 'covers PSResourceGet as well as PowerShellGet' {
+        $script:MainSource | Should-MatchString ([regex]::Escape('Microsoft.PowerShell.PSResourceGet'))
+    }
+
+    # Update-Module refuses anything it did not install, so a copy the host
+    # shipped can only be replaced side by side -- which is an install, and asks.
+    # Windows PowerShell ships PowerShellGet 1.0.0.1 exactly this way, and
+    # driving it with Update-Module fails the step outright.
+    It 'tells a shipped copy apart from one it can update' {
+        $script:MainSource | Should-MatchString '\$status\.Updatable'
+    }
+
+    It 'asks before replacing a shipped copy side by side' {
+        $script:MainSource | Should-MatchString 'cannot be updated in place'
+    }
+
+    # Updating something already present needs no approval, and Update-Module
+    # and Update-PSResource are the commands that say so. Install-Module -Force
+    # would also work and would read as an install.
+    It 'updates a present module with an update command, not an install' {
+        $script:MainSource | Should-MatchString 'Update-PSResource -Name \$name'
+        $script:MainSource | Should-MatchString 'Update-Module -Name \$name'
+    }
+
+    # The module is already loaded, so the files on disk are replaced and the
+    # cmdlets running now stay on the code in memory. Reporting it as though the
+    # run then benefits is the mistake this guards.
+    It 'says an update takes effect in the next session' {
+        $script:MainSource | Should-MatchString 'loads in the next session'
+    }
+
+    # There is no Update-PackageProvider, so moving a provider forward means
+    # running an install command against a binary provider assembly. It asks
+    # under the component that already covers the bootstrap.
+    It 'gates the provider refresh behind the NuGetProvider component' {
+        $script:MainSource | Should-MatchString "Approve-Install -Component 'NuGetProvider'[\s\S]{0,600}Install-PackageProvider -Name NuGet -Force"
+    }
+
+    It 'does not treat a gallery it could not reach as up to date' {
+        $script:MainSource | Should-MatchString 'the gallery could not be asked about it'
+    }
+
+    # Find-PackageProvider fails outright on PowerShell 7, which registers no
+    # provider bootstrap source. Reporting that as "current" would claim a
+    # machine is up to date on the strength of a lookup that never happened --
+    # the same mistake as above, in the branch that does not use the helper.
+    It 'does not treat a provider it could not look up as up to date' {
+        $script:MainSource | Should-MatchString 'no newer version could be looked up on this host'
     }
 }


### PR DESCRIPTION
Closes #27.

The NuGet provider, PowerShellGet and PSResourceGet were installed when missing
and then never brought forward. Every other gallery step runs on that tooling,
so it is the one set that should be current before the run rather than as part
of it.

## The new step

`Gallery tooling` sits between `Trust PSGallery` and `PowerShell modules`:
after trust, because an install without it stops on the untrusted-repository
prompt; before the module step, because that step is one of the things running
on what this fixes.

`Get-GalleryModuleStatus` reports `Installed`, `Available`, `Updatable` and
`NeedsUpdate`. `Available` is `$null` when the gallery could not be reached and
`NeedsUpdate` is then `$false`, so a network failure presents as *cannot tell*
rather than as up to date or as a reason to reinstall.

Three cases, and they are not the same decision:

| State | Action | Asks |
|---|---|---|
| Absent | install | yes |
| Present, shipped with the host | side-by-side install | yes |
| Present, installed by PowerShellGet | update | no |

The third follows the rule: updating something already present needs no
permission.

## What running it on 5.1 found

The middle case is why the version is not the test, and I only learned that by
running the step rather than reasoning about it:

```
PowerShellGet 1.0.0.1 -> 2.2.5...
FAILED: Module 'PowerShellGet' was not installed by using Install-Module,
        so it cannot be updated.
```

`Update-Module` refuses anything it did not install. My first fix — checking
whether the module sits under `$PSHOME` — was also wrong: Windows ships
PowerShellGet 1.0.0.1 under Program Files, not `$PSHOME`, so the path finds
nothing. `Get-InstalledModule` answers it directly, reporting only what came
through `Install-Module`, which is exactly the set `Update-Module` acts on.
PowerShell 7's own 2.2.5 is in the same position.

## Two smaller defects, both from running it

**The provider branch claimed currency from a lookup that never happened.**
`Find-PackageProvider` fails outright on PowerShell 7, which registers no
provider bootstrap source, and the first draft printed *"is current"* anyway —
the same mistake I had written a test against for modules and missed one branch
over. It now says *"no newer version could be looked up on this host"*, with a
test.

**`Approve-Install` said "is not installed"** for a component that is present in
a form that cannot be updated in place. Now "needs installing".

## Removed duplication

The 1.x-to-2.x block moves out of `Trust PSGallery`, which now sets trust and
stops. It was the same decision expressed as a version comparison, and two
places offering one install is one too many.

## The NuGet provider asks, and that is a deliberate deviation

There is no `Update-PackageProvider`, so moving a provider forward runs an
install command against a binary provider assembly. It asks under the
`NuGetProvider` component that already covers the bootstrap.

That is a narrow departure from *updating needs no permission*, on the grounds
that the only available API is an install and the repo's guard against silent
installs is worth more than a consent-free refresh. **Flagging it rather than
burying it** — happy to flip it if you would rather the refresh be silent.

## Testing

524 tests, 0 failed (was 517). PSScriptAnalyzer clean over `src` under its
default rules.

The real step body was lifted out of the source by the AST — not copied, so
this exercises the shipped code — and run on both editions:

```
PS7   NuGet 3.0.0.1 installed; no newer version could be looked up on this host
      PowerShellGet 2.2.5 shipped with this host and is not behind the gallery
      PSResourceGet 1.2.0 shipped with this host and is not behind the gallery
      COMPLETED (4.4 s)

5.1   NuGet package provider 2.8.5.208 is current
      PowerShellGet needs installing (declined, non-interactive)
      PSResourceGet needs installing (declined, non-interactive)
      COMPLETED (8.0 s)
```

`Get-GalleryModuleStatus` was also run against the live gallery: PowerShellGet
2.2.5/2.2.5, PSResourceGet 1.2.0/1.2.0, and a name that does not exist coming
back as `installed=none available=none needsUpdate=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)