### PR TITLE
Select steps by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,41 @@ thing that crosses a process boundary.
 | `-PromptTimeoutSeconds` | `60` | How long that prompt waits before starting anyway. |
 | `-DelayMinutes` | `60` | How long the "wait, then run" answer waits. |
 | `-Notify` | off | Show a toast when the run finishes, plus an urgent one if a restart is needed. Intended for scheduled runs. |
-| `-AllowInstall` | *(none)* | Which missing components may be installed: `All`, or any of `PowerShell7`, `PSWindowsUpdate`, `NuGetProvider`, `BurntToast`, `PowerShellGet`. |
+| `-AllowInstall` | *(none)* | Which missing components may be installed: `All`, or any of `PowerShell7`, `PSWindowsUpdate`, `NuGetProvider`, `BurntToast`, `PowerShellGet`, `PSResourceGet`. |
+| `-Tag` | *(all)* | Run only the steps carrying one of these tags. Everything else is reported as skipped. |
+| `-ExcludeTag` | *(none)* | Run everything except the steps carrying one of these tags. Exclusion wins when both are given. |
 | `-LogRetentionDays` | `30` | Prune logs and settings.json backups older than this. `0` keeps everything. |
 | `-UpdateSelf` | off | Reinstall this module from GitHub first, whether or not the version differs. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. Off by default because it fetches and runs an installer from a branch. |
+
+## Selecting steps
+
+`-Tag` and `-ExcludeTag` narrow a run to part of the work. A step carries one or
+more of:
+
+`Windows` `Microsoft` `PowerShell` `PackageManager` `Python` `Node` `DotNet`
+`Rust` `Git` `Self`
+
+```powershell
+Update-Everything -Tag Python
+Update-Everything -ExcludeTag Python
+```
+
+Both may be given at once and exclusion wins, so `-Tag Python -ExcludeTag Node`
+is not a contradiction and `-Tag Python -ExcludeTag Python` selects nothing
+rather than erroring.
+
+A step ruled out this way is reported as `Skipped` with the reason rather than
+dropped, so the summary still accounts for every step and the count does not
+quietly change between runs.
+
+The point is two scheduled tasks dividing the work. Something pinned to a
+version another application depends on wants updating on its own schedule, not
+on the one that keeps everything else current:
+
+```powershell
+Register-UpdateEverythingTask -ExcludeTag Python -Cadence Daily
+Register-UpdateEverythingTask -Tag Python -Cadence Monthly
+```
 
 ## What it updates
 

--- a/src/Private/Get-UpdateTaskArgument.ps1
+++ b/src/Private/Get-UpdateTaskArgument.ps1
@@ -29,6 +29,10 @@ function Get-UpdateTaskArgument {
 
         [string[]] $AllowInstall = @(),
 
+        [string[]] $Tag = @(),
+
+        [string[]] $ExcludeTag = @(),
+
         [string[]] $ExtraArgument = @()
     )
 
@@ -37,6 +41,11 @@ function Get-UpdateTaskArgument {
     if ($PromptBeforeRun) { $call += " -PromptBeforeRun -PromptTimeoutSeconds $PromptTimeoutSeconds" }
     if ($AllowInstall) {
         $call += ' -AllowInstall ' + (($AllowInstall | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }) -join ',')
+    }
+    foreach ($set in @(@{ Name = 'Tag'; Value = $Tag }, @{ Name = 'ExcludeTag'; Value = $ExcludeTag })) {
+        if ($set.Value) {
+            $call += " -$($set.Name) " + (($set.Value | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }) -join ',')
+        }
     }
     if ($ExtraArgument) { $call += ' ' + ($ExtraArgument -join ' ') }
 

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -8,9 +8,24 @@
         # skipped with the reason rather than left to fail with a permissions
         # error that reads like a bug.
         [switch]                            $RequiresAdmin,
+        # What this step is about, for -Tag and -ExcludeTag. Declared on the call
+        # rather than in a table elsewhere, so a tag and its step cannot drift.
+        [string[]]                          $Tag = @(),
         # Native exit codes this step should treat as success.
         [int[]]                             $AllowedExitCodes = @()
     )
+
+    # Tag filter first: a step the caller excluded should not even be checked for
+    # administrator rights or for its tool, because neither is why it is skipped.
+    if (-not (Test-StepTagMatch -StepTag $Tag -Tag $script:TagFilter -ExcludeTag $script:ExcludeTagFilter)) {
+        $reason = if (@($script:TagFilter).Count) {
+            "does not match -Tag $($script:TagFilter -join ',')"
+        } else {
+            "excluded by -ExcludeTag $($script:ExcludeTagFilter -join ',')"
+        }
+        Add-SkippedStep -Name $Name -Reason $reason
+        return
+    }
 
     # Step names carry spaces, parens and '=' -- legal on NTFS but awkward on
     # disk. The run stamp keeps each run's step logs together and stops any one

--- a/src/Private/Test-StepTagMatch.ps1
+++ b/src/Private/Test-StepTagMatch.ps1
@@ -1,0 +1,47 @@
+function Test-StepTagMatch {
+    <#
+        .SYNOPSIS
+        Decides whether a step runs, given its own tags and the run's filters.
+
+        .DESCRIPTION
+        -Tag is "nothing but these". -ExcludeTag is "anything but these". Both
+        may be given at once, and exclusion wins, so -Tag Python -ExcludeTag Node
+        is not a contradiction and -Tag Python -ExcludeTag Python selects nothing
+        rather than erroring.
+
+        A step carrying no tags is selected by an empty -Tag, because an empty
+        filter means "everything", but never by a non-empty one: asking for
+        Python and receiving a step that claims no subject at all would make the
+        filter meaningless.
+
+        .EXAMPLE
+        Test-StepTagMatch -StepTag Python, PackageManager -ExcludeTag Node
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        # The tags the step declares.
+        [string[]] $StepTag = @(),
+
+        # The run's -Tag, if any.
+        [string[]] $Tag = @(),
+
+        # The run's -ExcludeTag, if any.
+        [string[]] $ExcludeTag = @()
+    )
+
+    # Every list is filtered before it is counted, because @($null) has a Count
+    # of 1 in PowerShell. Counting the raw parameter would read an unset filter
+    # as "one entry, matching nothing" and skip the entire run.
+    $mine    = @($StepTag    | Where-Object { $_ })
+    $wanted  = @($Tag        | Where-Object { $_ })
+    $refused = @($ExcludeTag | Where-Object { $_ })
+
+    if ($refused.Count -and @($mine | Where-Object { $_ -in $refused }).Count) {
+        return $false
+    }
+
+    if (-not $wanted.Count) { return $true }
+
+    return [bool] @($mine | Where-Object { $_ -in $wanted }).Count
+}

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -132,6 +132,15 @@
         [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
 
+        # Passed straight through to the run this task performs, so one machine
+        # can carry a daily task that skips a toolchain and a monthly one that
+        # updates only that toolchain.
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')]
+        [string[]] $Tag = @(),
+
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')]
+        [string[]] $ExcludeTag = @(),
+
         [ValidateSet('Normal', 'Minimized', 'Hidden')]
         [string] $WindowStyle = 'Normal',
 
@@ -169,7 +178,8 @@
     $arguments = Get-UpdateTaskArgument -ModuleRoot $script:ModuleRoot -Notify $Notify `
         -WindowStyle $effectiveWindowStyle -PromptBeforeRun:$PromptBeforeRun `
         -PromptTimeoutSeconds $PromptTimeoutSeconds `
-        -AllowInstall $AllowInstall -ExtraArgument $ExtraArgument
+        -AllowInstall $AllowInstall -Tag $Tag -ExcludeTag $ExcludeTag `
+        -ExtraArgument $ExtraArgument
 
     $action = New-ScheduledTaskAction -Execute (Get-PowerShellHostPath) -Argument $arguments
 

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -177,6 +177,27 @@
         task that quietly followed main would be making that decision on every
         run.
 
+    .PARAMETER Tag
+        Run only the steps carrying one of these tags. Everything else is
+        reported as skipped with that reason, so the summary still accounts for
+        every step.
+
+        A step carries one or more of: Windows, Microsoft, PowerShell,
+        PackageManager, Python, Node, DotNet, Rust, Git, Self.
+
+            Update-Everything -Tag Python
+
+    .PARAMETER ExcludeTag
+        Run everything except the steps carrying one of these tags. Takes the
+        same values as -Tag.
+
+            Update-Everything -ExcludeTag Python
+
+        Both may be given at once, and exclusion wins. That makes two scheduled
+        tasks able to divide the work between them: one that updates everything
+        but Python daily, and one that updates only Python monthly, for a
+        toolchain something else depends on being held steady.
+
     .PARAMETER LogRetentionDays
         Delete logs and settings.json backups in the log directory older than this
         many days. Default: 30. Set to 0 to keep everything.
@@ -228,6 +249,10 @@
         [switch] $Notify,
         [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')]
+        [string[]] $Tag = @(),
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')]
+        [string[]] $ExcludeTag = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30,
         [switch] $UpdateSelf
@@ -381,6 +406,19 @@
 
     $script:Results = [System.Collections.Generic.List[object]]::new()
 
+    # Read by Invoke-Step, which decides per step. Held at script scope for the
+    # same reason as $script:isAdmin: a step action runs inside Invoke-Step, not
+    # here.
+    $script:TagFilter        = $Tag
+    $script:ExcludeTagFilter = $ExcludeTag
+
+    if ($Tag -or $ExcludeTag) {
+        $selection = @()
+        if ($Tag)        { $selection += "only $($Tag -join ', ')" }
+        if ($ExcludeTag) { $selection += "excluding $($ExcludeTag -join ', ')" }
+        Write-Host "Step selection: $($selection -join ', '). Everything else is reported as skipped." -ForegroundColor Cyan
+    }
+
     # winget exit codes that mean "nothing to do" rather than "failed".
     #   0x8A15002B (-1978335189) APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE
     #   0x8A150014 (-1978335212) APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND
@@ -392,7 +430,7 @@
     # 1b. The module itself
     # ---------------------------------------------------------------------------
     if ($UpdateSelf) {
-        Invoke-Step -Name 'UpdateEverything (self)' -Action {
+        Invoke-Step -Name 'UpdateEverything (self)' -Tag 'Self' -Action {
             # Reinstalls whether or not the version differs. The version does not
             # move with every commit and the module is distributed from a branch
             # rather than the gallery, so "already 1.0.0" is the normal state of
@@ -430,7 +468,7 @@
     # ---------------------------------------------------------------------------
     # 2. winget (apps from winget + Microsoft Store sources)
     # ---------------------------------------------------------------------------
-    Invoke-Step -Name 'winget self-update' -RequiresCommand 'winget' -Action {
+    Invoke-Step -Name 'winget self-update' -RequiresCommand 'winget' -Tag 'Windows', 'PackageManager' -Action {
         # Refresh the source indexes first. A stale index makes 'upgrade --all'
         # quietly miss packages rather than fail loudly, so this is not just hygiene.
         winget source update --disable-interactivity
@@ -449,7 +487,7 @@
         }
     }
 
-    Invoke-Step -Name 'winget (all sources)' -RequiresCommand 'winget' -Action {
+    Invoke-Step -Name 'winget (all sources)' -RequiresCommand 'winget' -Tag 'Windows', 'PackageManager' -Action {
         winget upgrade --all --include-unknown --silent `
             --accept-source-agreements --accept-package-agreements --disable-interactivity
         $code = $LASTEXITCODE
@@ -470,7 +508,7 @@
     # 2b. PowerShell 7 (install if missing, else upgrade to the latest release)
     # ---------------------------------------------------------------------------
     if ($IncludePowerShell7) {
-        Invoke-Step -Name 'PowerShell 7 (latest)' -RequiresCommand 'winget' -RequiresAdmin -Action {
+        Invoke-Step -Name 'PowerShell 7 (latest)' -RequiresCommand 'winget' -RequiresAdmin -Tag 'PowerShell', 'Windows' -Action {
             $id  = 'Microsoft.PowerShell'
             $exe = Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'
 
@@ -532,7 +570,7 @@
     # ---------------------------------------------------------------------------
     # 2c. Microsoft 365 Apps (click-to-run)
     # ---------------------------------------------------------------------------
-    Invoke-Step -Name 'Microsoft 365 Apps' -Action {
+    Invoke-Step -Name 'Microsoft 365 Apps' -Tag 'Microsoft' -Action {
         $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
         # Indexed rather than "| Select-Object -First 1": that stops the upstream
         # pipeline, and inside a step -- where every stream is merged with *>&1 --
@@ -567,7 +605,7 @@
     # prompt, not an error. Trust is stored per-user under LOCALAPPDATA, and UAC
     # elevation keeps the same user profile, so setting it once here sticks for
     # both the elevated and the non-elevated run.
-    Invoke-Step -Name 'Trust PSGallery' -Action {
+    Invoke-Step -Name 'Trust PSGallery' -Tag 'PowerShell' -Action {
         # PowerShellGet v2 pulls the NuGet provider on first use and prompts for it.
         if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
             if (-not (Approve-Install -Component 'NuGetProvider' -Approved $AllowInstall `
@@ -616,7 +654,7 @@
     # machine could carry a years-old NuGet provider or a PowerShellGet 2.1 for
     # as long as it lived. This runs before 'PowerShell modules' because that
     # step is one of the things that depends on it.
-    Invoke-Step -Name 'Gallery tooling' -Action {
+    Invoke-Step -Name 'Gallery tooling' -Tag 'PowerShell' -Action {
         # Not admin-gated, and -Scope AllUsers fails without elevation, so the
         # scope follows what the run actually has.
         $scope = if ($isAdmin) { 'AllUsers' } else { 'CurrentUser' }
@@ -733,7 +771,7 @@
         }
     }
 
-    Invoke-Step -Name 'PowerShell modules' -Action {
+    Invoke-Step -Name 'PowerShell modules' -Tag 'PowerShell' -Action {
         if (Get-Command Update-PSResource -ErrorAction SilentlyContinue) {
             # -TrustRepository suppresses the prompt for this call even when the
             # Trust PSGallery step could not persist the setting.
@@ -769,7 +807,7 @@
         }
     }
 
-    Invoke-Step -Name 'PowerShell help' -Action {
+    Invoke-Step -Name 'PowerShell help' -Tag 'PowerShell' -Action {
         $helpParams = @{ Force = $true; ErrorAction = 'SilentlyContinue' }
 
         # -Scope only exists on PS 6+; AllUsers writes under $PSHOME and needs admin.
@@ -786,7 +824,7 @@
     # ---------------------------------------------------------------------------
     # 4. Python toolchain
     # ---------------------------------------------------------------------------
-    Invoke-Step -Name 'Python (Install Manager)' -Action {
+    Invoke-Step -Name 'Python (Install Manager)' -Tag 'Python' -Action {
         # Reported as skipped rather than OK. A step that did nothing because
         # the tool is absent is not the same as a step that updated something,
         # and the summary should not read as though Python were handled.
@@ -795,7 +833,7 @@
         else   { Stop-StepAsSkipped -Reason 'the Python Install Manager is not installed' }
     }
 
-    Invoke-Step -Name 'uv' -RequiresCommand 'uv' -Action {
+    Invoke-Step -Name 'uv' -RequiresCommand 'uv' -Tag 'Python' -Action {
         # Self-update only what nothing else is managing. Running "uv self
         # update" against a uv that scoop or winget installed fights whichever
         # one owns it, and that manager's own step will update it anyway.
@@ -821,14 +859,14 @@
         }
     }
 
-    Invoke-Step -Name 'pipx packages' -RequiresCommand 'pipx' -Action {
+    Invoke-Step -Name 'pipx packages' -RequiresCommand 'pipx' -Tag 'Python' -Action {
         pipx upgrade-all
     }
 
     # ---------------------------------------------------------------------------
     # 5. Node / npm
     # ---------------------------------------------------------------------------
-    Invoke-Step -Name 'npm' -RequiresCommand 'npm' -Action {
+    Invoke-Step -Name 'npm' -RequiresCommand 'npm' -Tag 'Node' -Action {
         # npm writes progress and deprecation notices to stderr as a matter of course,
         # so judge it by exit code only.
         # Output is captured as well as passed through, because the reason npm failed
@@ -867,7 +905,7 @@
     # ---------------------------------------------------------------------------
     # 6. .NET global tools
     # ---------------------------------------------------------------------------
-    Invoke-Step -Name '.NET global tools' -RequiresCommand 'dotnet' -Action {
+    Invoke-Step -Name '.NET global tools' -RequiresCommand 'dotnet' -Tag 'DotNet' -Action {
         # 'dotnet' exists for runtime-only installs too, and 'dotnet --version' fails
         # outright when there is no SDK or when a global.json pins a missing one.
         # Validate the string before casting it to an int.
@@ -919,7 +957,7 @@
         }
     }
 
-    Invoke-Step -Name '.NET workloads' -RequiresCommand 'dotnet' -Action {
+    Invoke-Step -Name '.NET workloads' -RequiresCommand 'dotnet' -Tag 'DotNet' -Action {
         # No-ops cleanly ("No workloads to update") when none are installed, but a
         # runtime-only install has no workload command at all.
         dotnet workload update
@@ -934,11 +972,11 @@
     # ---------------------------------------------------------------------------
     # 1641 and 3010 are the MSI "reboot initiated" / "reboot required" codes, which
     # Chocolatey passes straight through on an otherwise successful upgrade.
-    Invoke-Step -Name 'Chocolatey' -RequiresCommand 'choco' -AllowedExitCodes 1641, 3010 -Action {
+    Invoke-Step -Name 'Chocolatey' -RequiresCommand 'choco' -AllowedExitCodes 1641, 3010 -Tag 'PackageManager' -Action {
         choco upgrade all -y
     }
 
-    Invoke-Step -Name 'Scoop' -RequiresCommand 'scoop' -Action {
+    Invoke-Step -Name 'Scoop' -RequiresCommand 'scoop' -Tag 'PackageManager' -Action {
         # Run the three phases independently: a failure in one (a broken bucket, an
         # app that will not clean up) should not hide the others.
         $phases = @(
@@ -957,11 +995,11 @@
         }
     }
 
-    Invoke-Step -Name 'rustup' -RequiresCommand 'rustup' -Action {
+    Invoke-Step -Name 'rustup' -RequiresCommand 'rustup' -Tag 'Rust' -Action {
         rustup update
     }
 
-    Invoke-Step -Name 'GitHub CLI extensions' -RequiresCommand 'gh' -Action {
+    Invoke-Step -Name 'GitHub CLI extensions' -RequiresCommand 'gh' -Tag 'Git' -Action {
         # 'gh extension upgrade --all' exits non-zero when nothing is installed,
         # which would otherwise fail the step. Check before calling it.
         $installed = (gh extension list 2>&1 | Out-String).Trim()
@@ -976,7 +1014,7 @@
     # ---------------------------------------------------------------------------
     # 8. WSL kernel
     # ---------------------------------------------------------------------------
-    Invoke-Step -Name 'WSL kernel' -RequiresCommand 'wsl' -Action {
+    Invoke-Step -Name 'WSL kernel' -RequiresCommand 'wsl' -Tag 'Windows' -Action {
         # wsl.exe ships in System32 on every Windows 11 machine, so -RequiresCommand
         # proves nothing here. --status fails when the feature is not actually enabled.
         wsl --status
@@ -997,7 +1035,7 @@
     # ---------------------------------------------------------------------------
     # 9. Microsoft Defender signatures
     # ---------------------------------------------------------------------------
-    Invoke-Step -Name 'Defender signatures' -RequiresCommand 'Update-MpSignature' -RequiresAdmin -Action {
+    Invoke-Step -Name 'Defender signatures' -RequiresCommand 'Update-MpSignature' -RequiresAdmin -Tag 'Windows', 'Microsoft' -Action {
         # The Defender cmdlets are present even on machines where a third-party AV has
         # taken over and the antimalware service is off. Probe before updating so that
         # a managed device does not report a failed step every run.
@@ -1020,7 +1058,7 @@
     #     (placed before Windows Update so an AutoReboot can't skip it)
     # ---------------------------------------------------------------------------
     if ($SetPwshTerminalDefault) {
-        Invoke-Step -Name 'Windows Terminal default = PowerShell 7' -Action {
+        Invoke-Step -Name 'Windows Terminal default = PowerShell 7' -Tag 'PowerShell', 'Windows' -Action {
             Set-PwshAsWindowsTerminalDefault -LogDir $logDir
         }
     } else {
@@ -1031,7 +1069,7 @@
     # 10. Windows Update (OS + drivers) via PSWindowsUpdate
     # ---------------------------------------------------------------------------
     if ($IncludeWindowsUpdate) {
-        Invoke-Step -Name 'Windows Update' -RequiresAdmin -Action {
+        Invoke-Step -Name 'Windows Update' -RequiresAdmin -Tag 'Windows', 'Microsoft' -Action {
             if (-not $isAdmin) { throw 'Administrator rights required for Windows Update.' }
 
             if (-not (Get-Module -ListAvailable -Name PSWindowsUpdate)) {

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -26,6 +26,8 @@ BeforeDiscovery {
         @{ Name = 'SkipElevation';             TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'Notify';                    TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'AllowInstall';              TypeName = 'string[]'; Type = [string[]]; Default = '@()' }
+        @{ Name = 'Tag';                       TypeName = 'string[]'; Type = [string[]]; Default = '@()' }
+        @{ Name = 'ExcludeTag';                TypeName = 'string[]'; Type = [string[]]; Default = '@()' }
         @{ Name = 'PromptBeforeRun';           TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'PromptTimeoutSeconds';      TypeName = 'int';      Type = [int];      Default = '60' }
         @{ Name = 'DelayMinutes';              TypeName = 'int';      Type = [int];      Default = '60' }
@@ -454,7 +456,7 @@ Describe 'Update-Everything' -Tag 'Static' {
 
         It 'declares no parameters beyond the documented contract' {
             $script:DeclaredParameters.Name.VariablePath.UserPath |
-                Should-BeCollection -Count 14 -Because 'a new parameter needs docs and a test'
+                Should-BeCollection -Count 16 -Because 'a new parameter needs docs and a test'
         }
 
         It 'bounds -LogRetentionDays with ValidateRange' {
@@ -782,7 +784,7 @@ Describe 'Variable hygiene' -Tag 'Static' {
             'ShellId', 'NestedPromptLevel', 'StackTrace', 'switch', 'foreach',
             # Set by the module loader, and by the caller of a private helper.
             'ModuleRoot', 'Results', 'logDir', 'runStamp', 'isAdmin', 'InstallDecision',
-            'NotificationsAvailable', 'WingetNothingToDo'
+            'NotificationsAvailable', 'WingetNothingToDo', 'TagFilter', 'ExcludeTagFilter'
         )
 
         $bare = { param($p) ($p -replace '^(script|global|local|private):', '') }

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1473,3 +1473,157 @@ Describe 'The Gallery tooling step' -Tag 'Static' {
         $script:MainSource | Should-MatchString 'no newer version could be looked up on this host'
     }
 }
+
+Describe 'Test-StepTagMatch' -Tag 'Unit' {
+
+    Context 'No filter' {
+
+        # @($null) has a Count of 1 in PowerShell, so counting a filter without
+        # first stripping nulls reads an unset one as "one entry, matching
+        # nothing" -- which skipped every step in the run.
+        It 'runs a step when both filters are null' {
+            Test-StepTagMatch -StepTag @('Python') -Tag $null -ExcludeTag $null | Should-BeTrue
+        }
+
+        It 'runs a step when both filters are empty' {
+            Test-StepTagMatch -StepTag @('Python') | Should-BeTrue
+        }
+
+        It 'runs an untagged step when there is no filter' {
+            Test-StepTagMatch -StepTag @() | Should-BeTrue
+        }
+    }
+
+    Context '-Tag selects' {
+
+        It 'runs a step carrying the tag' {
+            Test-StepTagMatch -StepTag @('Python') -Tag @('Python') | Should-BeTrue
+        }
+
+        It 'runs a step carrying one of several tags' {
+            Test-StepTagMatch -StepTag @('Windows', 'PackageManager') -Tag @('PackageManager') | Should-BeTrue
+        }
+
+        It 'skips a step carrying none of them' {
+            Test-StepTagMatch -StepTag @('Node') -Tag @('Python') | Should-BeFalse
+        }
+
+        # Asking for Python and receiving a step that claims no subject at all
+        # would make the filter meaningless.
+        It 'skips an untagged step when a tag was asked for' {
+            Test-StepTagMatch -StepTag @() -Tag @('Python') | Should-BeFalse
+        }
+    }
+
+    Context '-ExcludeTag refuses' {
+
+        It 'skips a step carrying the excluded tag' {
+            Test-StepTagMatch -StepTag @('Python') -ExcludeTag @('Python') | Should-BeFalse
+        }
+
+        It 'runs a step carrying none of them' {
+            Test-StepTagMatch -StepTag @('Node') -ExcludeTag @('Python') | Should-BeTrue
+        }
+
+        It 'runs an untagged step' {
+            Test-StepTagMatch -StepTag @() -ExcludeTag @('Python') | Should-BeTrue
+        }
+
+        It 'skips a step that carries the excluded tag among others' {
+            Test-StepTagMatch -StepTag @('Windows', 'Microsoft') -ExcludeTag @('Microsoft') | Should-BeFalse
+        }
+    }
+
+    Context 'Both at once' {
+
+        # Not a contradiction: the pair is how one task takes everything in a
+        # subject except one part of it.
+        It 'runs a step selected by -Tag and not excluded' {
+            Test-StepTagMatch -StepTag @('Python') -Tag @('Python') -ExcludeTag @('Node') | Should-BeTrue
+        }
+
+        It 'lets exclusion win over selection' {
+            Test-StepTagMatch -StepTag @('Python') -Tag @('Python') -ExcludeTag @('Python') | Should-BeFalse
+        }
+    }
+}
+
+Describe 'Every step declares a tag' -Tag 'Static' {
+
+    # A step with no tag is invisible to -Tag and unstoppable by -ExcludeTag, so
+    # it would quietly run in every filtered run. The ValidateSet is the other
+    # half: a tag no step carries selects nothing, and a typo would.
+
+    BeforeAll {
+        $script:MainPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1'
+        $script:MainAst = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:MainPath, [ref] $null, [ref] $null)
+
+        $script:StepTags = @{}
+        foreach ($call in $script:MainAst.FindAll({
+                    param($n)
+                    $n -is [System.Management.Automation.Language.CommandAst] -and
+                    $n.GetCommandName() -eq 'Invoke-Step'
+                }, $true)) {
+
+            $elements = $call.CommandElements
+            $name = $null
+            $tags = @()
+            for ($i = 0; $i -lt $elements.Count; $i++) {
+                if ($elements[$i] -isnot [System.Management.Automation.Language.CommandParameterAst]) { continue }
+                switch ($elements[$i].ParameterName) {
+                    'Name' { if ($i + 1 -lt $elements.Count) { $name = $elements[$i + 1].Value } }
+                    'Tag'  {
+                        if ($i + 1 -lt $elements.Count) {
+                            $tags = @($elements[$i + 1].Extent.Text -split ',' |
+                                ForEach-Object { $_.Trim().Trim("'", '"') })
+                        }
+                    }
+                }
+            }
+            if ($name) { $script:StepTags[$name] = $tags }
+        }
+
+        # The set both public entry points validate against.
+        $script:DeclaredTags = @('Windows', 'Microsoft', 'PowerShell', 'PackageManager',
+                                 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')
+    }
+
+    It 'found the steps to check' {
+        $script:StepTags.Count | Should-BeGreaterThan 20
+    }
+
+    It 'gives every step at least one tag' {
+        $untagged = $script:StepTags.GetEnumerator() |
+            Where-Object { -not $_.Value -or -not @($_.Value | Where-Object { $_ }).Count } |
+            ForEach-Object { $_.Key }
+
+        $untagged | Should-BeNull -Because "these run in every filtered run and cannot be excluded:`n$($untagged -join "`n")"
+    }
+
+    It 'uses only tags the ValidateSet accepts' {
+        $unknown = $script:StepTags.GetEnumerator() |
+            ForEach-Object {
+                $step = $_.Key
+                $_.Value | Where-Object { $_ -and $_ -notin $script:DeclaredTags } |
+                    ForEach-Object { "$step -> $_" }
+            }
+
+        $unknown | Should-BeNull -Because "a tag outside the ValidateSet can never be asked for:`n$($unknown -join "`n")"
+    }
+
+    It 'declares no tag that no step carries' {
+        $used = $script:StepTags.Values | ForEach-Object { $_ } | Where-Object { $_ } | Select-Object -Unique
+        $orphans = $script:DeclaredTags | Where-Object { $_ -notin $used }
+
+        $orphans | Should-BeNull -Because "these select nothing, so asking for one runs an empty pass: $($orphans -join ', ')"
+    }
+
+    It 'accepts -<_> on both entry points' -ForEach @('Tag', 'ExcludeTag') {
+        $parameter = $_
+        foreach ($file in 'src\Public\Update-Everything.ps1', 'src\Public\Register-UpdateEverythingTask.ps1') {
+            Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) $file) -Raw |
+                Should-MatchString "\`$$parameter = @\(\)"
+        }
+    }
+}


### PR DESCRIPTION
Closes #18.

There was no way to run part of the update pass. The only selection was three
`[bool]` parameters covering three of twenty-three steps, and they did not
compose.

## What this adds

```powershell
Update-Everything -Tag Python
Update-Everything -ExcludeTag Python
```

Tags: `Windows` `Microsoft` `PowerShell` `PackageManager` `Python` `Node`
`DotNet` `Rust` `Git` `Self`.

Declared on the `Invoke-Step` call rather than in a table elsewhere, so a tag
and its step cannot drift apart. Both parameters are a `ValidateSet`, so a typo
fails at parameter binding rather than selecting nothing and reporting a
successful run over an empty pass.

`Register-UpdateEverythingTask` takes both and `Get-UpdateTaskArgument`
round-trips them, which is the whole point — **two tasks dividing the work**,
which is what #20 needs:

```powershell
Register-UpdateEverythingTask -ExcludeTag Python -Cadence Daily
Register-UpdateEverythingTask -Tag Python -Cadence Monthly
```

## Decisions

**Exclusion wins.** `-Tag Python -ExcludeTag Node` is not a contradiction, and
`-Tag Python -ExcludeTag Python` selects nothing rather than erroring.

**An excluded step is `Skipped` with the reason, not absent.** The summary still
accounts for every step, so the count does not quietly change between runs.

**The filter runs before the admin and tool checks.** Neither is why the step
was skipped, and the reason should say what actually happened.

**An untagged step is never selected by a non-empty `-Tag`.** Asking for Python
and receiving a step that claims no subject would make the filter meaningless. A
test asserts no step is untagged, and another asserts no declared tag is unused.

## The bug worth naming

It failed twenty tests at once and would have shipped as *nothing ever runs*:

```powershell
@($null).Count   # 1, not 0
```

Counting a filter parameter without stripping nulls first reads an unset filter
as "one entry, matching nothing". Every list is now filtered before it is
counted, with a test that passes `$null` explicitly.

## Testing

552 tests, 0 failed (was 524). PSScriptAnalyzer clean over `src` under its
default rules.

Verified by running it, not by reading it:

```
-Tag Microsoft   OK  Microsoft 365 Apps
                 OK  Defender signatures
                 OK  Windows Update
                 20 skipped

-Tag Rust        22 skipped with "does not match -Tag Rust"
                 rustup skipped with "command 'rustup' not found"
                 -- the tool check, not the filter
```

And the task command line:

```
exit (Update-Everything -Notify -AllowInstall 'BurntToast' -ExcludeTag 'Python').FailedCount
exit (Update-Everything -Notify -Tag 'Python').FailedCount
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)