### PR TITLE
Report what the machine has before updating it

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,32 @@ thing that crosses a process boundary.
 more of:
 
 `Windows` `Microsoft` `PowerShell` `PackageManager` `Python` `Node` `DotNet`
-`Rust` `Git` `Self`
+`Rust` `Git` `Self` `Inventory`
 
 ```powershell
 Update-Everything -Tag Python
 Update-Everything -ExcludeTag Python
 ```
+
+`-Tag Inventory` reports what the machine has and updates nothing, which is the
+quickest way to see why a run skipped what it skipped:
+
+```
+9 of 14 tools present.
+
+  winget           Unknown     v1.29.290
+  PowerShell 7     Unknown     PowerShell 7.6.5
+  uv               Standalone  uv 0.12.7
+
+Not installed: .NET SDK, Chocolatey, pipx, rustup, Scoop
+Their steps report Skipped, which is the expected result rather than a fault.
+
+WARNING: PowerShell 7 is installed in 2 places; the first is the one that runs:
+         C:\Program Files\PowerShell; ...\WindowsApps
+```
+
+That last warning is worth reading. A tool installed twice is updated by
+whichever manager owns the copy you are not running.
 
 Both may be given at once and exclusion wins, so `-Tag Python -ExcludeTag Node`
 is not a contradiction and `-Tag Python -ExcludeTag Python` selects nothing

--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -1,0 +1,110 @@
+function Get-UpdateToolInventory {
+    <#
+        .SYNOPSIS
+        Reports what this machine has of the tools Update-Everything drives.
+
+        .DESCRIPTION
+        One record per tool, with Name, Command, Present, Version, Owner and
+        Copies.
+
+        Every step already resolves its own tool and skips when it is absent, so
+        this changes no behaviour. What it adds is a picture: on a first run the
+        summary is a long column of skips, and nothing says whether that is a
+        machine with little installed or a run that went wrong.
+
+        Owner comes from Get-ToolInstallSource and answers who is responsible for
+        updating a tool. Copies counts the distinct directories an executable of
+        that name resolves from; more than one is worth knowing, because the
+        version reported here is the one that runs and the others are updated by
+        nobody.
+
+        Directories rather than files, because PATHEXT resolves npm.cmd and npm
+        from the same folder as two commands. That is one install, and reporting
+        it as two would train people to ignore the warning.
+
+        A tool that fails or hangs on its version argument reports Present with a
+        null Version rather than failing the inventory. Knowing something is there
+        is most of the value.
+
+        .PARAMETER Catalogue
+        The tools to look for. Defaults to the ones this module drives; a test
+        passes its own.
+
+        .EXAMPLE
+        Get-UpdateToolInventory | Where-Object Present
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [object[]] $Catalogue
+    )
+
+    if (-not $Catalogue) {
+        # Name is what a person calls it; Command is what resolves on PATH.
+        $Catalogue = @(
+            @{ Name = 'winget';          Command = 'winget';  VersionArgument = '--version' }
+            @{ Name = 'Chocolatey';      Command = 'choco';   VersionArgument = '--version' }
+            @{ Name = 'Scoop';           Command = 'scoop';   VersionArgument = $null }
+            @{ Name = 'PowerShell 7';    Command = 'pwsh';    VersionArgument = '--version' }
+            @{ Name = 'Node.js';         Command = 'node';    VersionArgument = '--version' }
+            @{ Name = 'npm';             Command = 'npm';     VersionArgument = '--version' }
+            @{ Name = 'Python launcher'; Command = 'py';      VersionArgument = '--version' }
+            @{ Name = 'Python manager';  Command = 'pymanager'; VersionArgument = '--version' }
+            @{ Name = 'uv';              Command = 'uv';      VersionArgument = '--version' }
+            @{ Name = 'pipx';            Command = 'pipx';    VersionArgument = '--version' }
+            @{ Name = '.NET SDK';        Command = 'dotnet';  VersionArgument = '--version' }
+            @{ Name = 'rustup';          Command = 'rustup';  VersionArgument = '--version' }
+            @{ Name = 'GitHub CLI';      Command = 'gh';      VersionArgument = '--version' }
+            @{ Name = 'WSL';             Command = 'wsl';     VersionArgument = $null }
+        )
+    }
+
+    foreach ($tool in $Catalogue) {
+        $resolved = @(Get-Command $tool.Command -CommandType Application -ErrorAction SilentlyContinue)
+        $places = @($resolved |
+            ForEach-Object { Split-Path $_.Source -Parent } |
+            Where-Object { $_ } |
+            Sort-Object -Unique)
+
+        if (-not $resolved.Count) {
+            [pscustomobject]@{
+                Name    = $tool.Name
+                Command = $tool.Command
+                Present = $false
+                Version = $null
+                Owner   = $null
+                Copies  = 0
+                Places  = @()
+            }
+            continue
+        }
+
+        # Scoop and WSL are left without a version argument on purpose. scoop is
+        # a PowerShell shim whose --version runs a git describe against its own
+        # repository, and wsl --version writes UTF-16 that arrives as spaced-out
+        # characters. Neither is worth the seconds or the mess.
+        $version = $null
+        if ($tool.VersionArgument) {
+            try {
+                $raw = & $tool.Command $tool.VersionArgument 2>&1
+                $global:LASTEXITCODE = 0
+                $version = @($raw | Out-String -Stream |
+                    Where-Object { $_ -and $_.Trim() } |
+                    ForEach-Object { $_.Trim() })[0]
+            } catch {
+                Write-Verbose "$($tool.Command) $($tool.VersionArgument) failed: $($_.Exception.Message)"
+                $global:LASTEXITCODE = 0
+            }
+        }
+
+        [pscustomobject]@{
+            Name    = $tool.Name
+            Command = $tool.Command
+            Present = $true
+            Version = $version
+            Owner   = Get-ToolInstallSource -Name $tool.Command
+            Copies  = $places.Count
+            Places  = $places
+        }
+    }
+}

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -135,10 +135,10 @@
         # Passed straight through to the run this task performs, so one machine
         # can carry a daily task that skips a toolchain and a monthly one that
         # updates only that toolchain.
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')]
         [string[]] $Tag = @(),
 
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')]
         [string[]] $ExcludeTag = @(),
 
         [ValidateSet('Normal', 'Minimized', 'Hidden')]

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -183,9 +183,10 @@
         every step.
 
         A step carries one or more of: Windows, Microsoft, PowerShell,
-        PackageManager, Python, Node, DotNet, Rust, Git, Self.
+        PackageManager, Python, Node, DotNet, Rust, Git, Self, Inventory.
 
             Update-Everything -Tag Python
+            Update-Everything -Tag Inventory    report what is installed, update nothing
 
     .PARAMETER ExcludeTag
         Run everything except the steps carrying one of these tags. Takes the
@@ -249,9 +250,9 @@
         [switch] $Notify,
         [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')]
         [string[]] $Tag = @(),
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')]
         [string[]] $ExcludeTag = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30,
@@ -425,6 +426,49 @@
     $WingetNothingToDo = @(-1978335189, -1978335212)
 
     Write-Host "Maintenance run started $(Get-Date)  |  Admin: $isAdmin  |  Main Log: $mainLog" -ForegroundColor Green
+
+    # ---------------------------------------------------------------------------
+    # 1a. What this machine actually has
+    # ---------------------------------------------------------------------------
+    Invoke-Step -Name 'Inventory' -Tag 'Inventory' -Action {
+        $inventory = @(Get-UpdateToolInventory)
+        $present = @($inventory | Where-Object Present)
+        $absent = @($inventory | Where-Object { -not $_.Present })
+
+        Write-Output "$($present.Count) of $($inventory.Count) tools present."
+        Write-Output ''
+
+        # Aligned by hand rather than with Format-Table. Inside a step action the
+        # output has to reach the pipeline so Invoke-Step can capture it for the
+        # step log, and Format-Table's records would only render correctly on
+        # their way to a host -- which is the one place a step must not write.
+        $nameWidth = 0
+        $ownerWidth = 0
+        foreach ($tool in $present) {
+            if ($tool.Name.Length -gt $nameWidth) { $nameWidth = $tool.Name.Length }
+            if ("$($tool.Owner)".Length -gt $ownerWidth) { $ownerWidth = "$($tool.Owner)".Length }
+        }
+        foreach ($tool in $present) {
+            Write-Output ("  {0,-$nameWidth}  {1,-$ownerWidth}  {2}" -f $tool.Name, $tool.Owner, $tool.Version)
+        }
+
+        if ($absent.Count) {
+            Write-Output ''
+            Write-Output "Not installed: $(($absent.Name | Sort-Object) -join ', ')"
+            Write-Output 'Their steps report Skipped, which is the expected result rather than a fault.'
+        }
+
+        # More than one executable of a name on PATH means the version above is
+        # the one that runs and the others are updated by nobody. It is also how
+        # a tool ends up updated by a manager that does not own the copy in use.
+        $duplicated = @($present | Where-Object { $_.Copies -gt 1 })
+        if ($duplicated.Count) {
+            Write-Output ''
+            foreach ($tool in $duplicated) {
+                Write-Warning "$($tool.Name) is installed in $($tool.Copies) places; the first is the one that runs: $($tool.Places -join '; ')"
+            }
+        }
+    }
 
     # ---------------------------------------------------------------------------
     # 1b. The module itself

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -967,15 +967,34 @@ Describe 'The summary is displayed, not returned' -Tag 'Static','Module' {
     # summary table stopped being displayed and started being returned, so the
     # caller got an array of formatting objects with the result buried in it and
     # the run log lost its summary entirely.
+    # The AST, not a text search. A line search also matches a comment that
+    # explains why Format-Table is not used somewhere, which formats nothing.
     It 'sends Format-Table to the host rather than the pipeline' {
-        $source = Get-Content (Join-Path $script:ModuleRoot 'Public\Update-Everything.ps1') -Raw
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            (Join-Path $script:ModuleRoot 'Public\Update-Everything.ps1'), [ref] $null, [ref] $null)
 
-        $formats = [regex]::Matches($source, '(?m)^.*Format-Table.*$')
+        $formats = @($ast.FindAll({
+                    param($n)
+                    $n -is [System.Management.Automation.Language.CommandAst] -and
+                    $n.GetCommandName() -eq 'Format-Table'
+                }, $true))
+
         $formats.Count | Should-BeGreaterThan 0
 
-        foreach ($f in $formats) {
-            $f.Value | Should-MatchString 'Out-Host'
+        $offenders = foreach ($f in $formats) {
+            $pipeline = $f.Parent
+            while ($pipeline -and $pipeline -isnot [System.Management.Automation.Language.PipelineAst]) {
+                $pipeline = $pipeline.Parent
+            }
+
+            $last = $pipeline.PipelineElements[-1]
+            if ($last -isnot [System.Management.Automation.Language.CommandAst] -or
+                $last.GetCommandName() -ne 'Out-Host') {
+                "line $($f.Extent.StartLineNumber): $($pipeline.Extent.Text -replace '\s+', ' ')"
+            }
         }
+
+        $offenders | Should-BeNull -Because "these return formatting objects instead of displaying them:`n$($offenders -join "`n")"
     }
 }
 
@@ -1028,7 +1047,10 @@ Describe 'No step updates through a tool it has not verified' -Tag 'Static','Mod
             # Windows, so Get-PackageProvider and Find-Module always resolve.
             # The step reports each component it did not find rather than
             # driving anything it has not confirmed.
-            'Gallery tooling'
+            'Gallery tooling',
+            # Resolves every tool it reports on, and reports absence as absence.
+            # Running nothing it has not found is the whole job.
+            'Inventory'
         )
 
         $offenders = foreach ($call in $ast.FindAll({

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1586,7 +1586,7 @@ Describe 'Every step declares a tag' -Tag 'Static' {
 
         # The set both public entry points validate against.
         $script:DeclaredTags = @('Windows', 'Microsoft', 'PowerShell', 'PackageManager',
-                                 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self')
+                                 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')
     }
 
     It 'found the steps to check' {
@@ -1625,5 +1625,65 @@ Describe 'Every step declares a tag' -Tag 'Static' {
             Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) $file) -Raw |
                 Should-MatchString "\`$$parameter = @\(\)"
         }
+    }
+}
+
+Describe 'Get-UpdateToolInventory' -Tag 'Unit' {
+
+    # A catalogue is passed in rather than using the real one, so the test does
+    # not depend on what happens to be installed on the machine running it.
+
+    BeforeAll {
+        $script:RealTool  = @{ Name = 'PowerShell'; Command = 'powershell'; VersionArgument = $null }
+        $script:FakeTool  = @{ Name = 'Nothing';    Command = 'ue-no-such-tool-7f3a1c'; VersionArgument = '--version' }
+    }
+
+    It 'reports a tool that is on the machine as present' {
+        $r = Get-UpdateToolInventory -Catalogue @($script:RealTool)
+        $r.Present | Should-BeTrue
+    }
+
+    It 'reports a tool that is not as absent' {
+        $r = Get-UpdateToolInventory -Catalogue @($script:FakeTool)
+        $r.Present | Should-BeFalse
+    }
+
+    It 'gives an absent tool no version, owner or place' {
+        $r = Get-UpdateToolInventory -Catalogue @($script:FakeTool)
+        $r.Version | Should-BeNull
+        $r.Owner   | Should-BeNull
+        $r.Copies  | Should-Be 0
+    }
+
+    It 'returns one record per catalogue entry' {
+        $r = @(Get-UpdateToolInventory -Catalogue @($script:RealTool, $script:FakeTool))
+        $r | Should-BeCollection -Count 2
+    }
+
+    It 'carries the friendly name through, not just the command' {
+        (Get-UpdateToolInventory -Catalogue @($script:FakeTool)).Name | Should-Be 'Nothing'
+    }
+
+    # PATHEXT resolves npm.cmd and npm from one folder as two commands. Counting
+    # files would report a single install as a conflict, and a warning that cries
+    # wolf is one people stop reading.
+    It 'counts places rather than executables' {
+        $r = Get-UpdateToolInventory -Catalogue @($script:RealTool)
+        $r.Copies | Should-Be @($r.Places).Count
+    }
+
+    It 'does not let a tool that fails its version argument fail the inventory' {
+        # A real executable given an argument it rejects.
+        $bad = @{ Name = 'Bad'; Command = 'powershell'; VersionArgument = '--definitely-not-a-flag' }
+
+        $r = Get-UpdateToolInventory -Catalogue @($bad)
+        $r.Present | Should-BeTrue
+    }
+
+    It 'leaves no non-zero exit code behind for the step runner to fail on' {
+        $bad = @{ Name = 'Bad'; Command = 'powershell'; VersionArgument = '--definitely-not-a-flag' }
+
+        $null = Get-UpdateToolInventory -Catalogue @($bad)
+        $LASTEXITCODE | Should-Be 0
     }
 }


### PR DESCRIPTION
Closes #16.

Every step already resolved its own tool and skipped when absent, so the run had
no overall picture. On a first run the summary is a long column of skips with
nothing saying whether that is a sparse machine or a broken run.

## The step

```
9 of 14 tools present.

  winget           Unknown     v1.29.290
  PowerShell 7     Unknown     PowerShell 7.6.5
  Node.js          Unknown     v24.19.0
  npm              Unknown     12.0.2
  Python launcher  Unknown     Python 3.14.7
  uv               Standalone  uv 0.12.7 (61291a8ca 2026-08-27 x86_64-pc-windows-msvc)
  GitHub CLI       Unknown     gh version 2.98.0 (2026-08-20)

Not installed: .NET SDK, Chocolatey, pipx, rustup, Scoop
Their steps report Skipped, which is the expected result rather than a fault.

WARNING: PowerShell 7 is installed in 2 places; the first is the one that runs:
         C:\Program Files\PowerShell\7; ...\WindowsApps
WARNING: npm is installed in 2 places: C:\Program Files\nodejs; ...\Roaming\npm
```

`Inventory` is a tag, so **`-Tag Inventory` reports and updates nothing**.

## The duplicate warning found something real

On the machine this was written on, `pwsh` resolves to both the MSI build and
the WindowsApps alias — the exact split behind the elevation failure this module
already carries code for. A tool installed twice is updated by whichever manager
owns the copy you are *not* running.

`Copies` counts **distinct directories, not executables**: PATHEXT resolves
`npm.cmd` and `npm` from one folder as two commands, and reporting a single
install as a conflict trains people to ignore the warning. That took npm from a
reported 4 down to a true 2.

## Decisions

**Scoop and WSL carry no version argument on purpose.** `scoop --version` runs a
git describe against its own repository, and `wsl --version` writes UTF-16 that
arrives as spaced-out characters. Neither is worth the seconds or the mess.

**A tool that fails its version argument reports `Present` with a null
`Version`** rather than failing the step — knowing it is there is most of the
value. `LASTEXITCODE` is reset so the step runner does not fail on the attempt.

**The rows are aligned by hand rather than with `Format-Table`.** Inside a step
action the output must reach the pipeline for `Invoke-Step` to capture it into
the step log; `Format-Table`'s records only render on their way to a host, which
is the one place a step must not write. Confirmed by reading the step log back
and finding the table in it.

## A test that needed the AST

The `Format-Table` guard matched lines of text, so it failed on a **comment
explaining why `Format-Table` is not used**. It now walks the AST and checks the
enclosing pipeline ends in `Out-Host` — the same trap, and the same fix, as the
install-hint test already documents.

## Testing

561 tests, 0 failed (was 552). PSScriptAnalyzer clean over `src` under its
default rules. The step was run for real on this machine, and the step log read
back to confirm the capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)