### PR TITLE
Run a package manager before the toolchains it owns

### DIFF
--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -549,7 +549,42 @@
     }
 
     # ---------------------------------------------------------------------------
-    # 2b. PowerShell 7 (install if missing, else upgrade to the latest release)
+    # A manager runs before the tools it may own. Chocolatey and Scoop install
+    # language toolchains, so updating uv or npm first and the manager that owns
+    # it second updates a tool and then the thing responsible for it. The
+    # toolchain steps ask Get-ToolInstallSource before self-updating, so this is
+    # sequence rather than a live conflict -- but the sequence should read the
+    # way the dependency runs.
+    # ---------------------------------------------------------------------------
+    # 2b. Chocolatey and Scoop, before the toolchains they may own
+    # ---------------------------------------------------------------------------
+    # 1641 and 3010 are the MSI "reboot initiated" / "reboot required" codes, which
+    # Chocolatey passes straight through on an otherwise successful upgrade.
+    Invoke-Step -Name 'Chocolatey' -RequiresCommand 'choco' -AllowedExitCodes 1641, 3010 -Tag 'PackageManager' -Action {
+        choco upgrade all -y
+    }
+
+    Invoke-Step -Name 'Scoop' -RequiresCommand 'scoop' -Tag 'PackageManager' -Action {
+        # Run the three phases independently: a failure in one (a broken bucket, an
+        # app that will not clean up) should not hide the others.
+        $phases = @(
+            @{ Label = 'scoop update (scoop itself + buckets)'; Args = @('update') },
+            @{ Label = 'scoop update * (installed apps)';       Args = @('update', '*') },
+            @{ Label = 'scoop cleanup * (old versions)';        Args = @('cleanup', '*') }
+        )
+        foreach ($phase in $phases) {
+            Write-Output "-> $($phase.Label)"
+            $phaseArgs = $phase.Args
+            & scoop @phaseArgs
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "$($phase.Label) returned $LASTEXITCODE; continuing with the next phase."
+                $global:LASTEXITCODE = 0
+            }
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # 2c. PowerShell 7 (install if missing, else upgrade to the latest release)
     # ---------------------------------------------------------------------------
     if ($IncludePowerShell7) {
         Invoke-Step -Name 'PowerShell 7 (latest)' -RequiresCommand 'winget' -RequiresAdmin -Tag 'PowerShell', 'Windows' -Action {
@@ -612,7 +647,7 @@
     }
 
     # ---------------------------------------------------------------------------
-    # 2c. Microsoft 365 Apps (click-to-run)
+    # 2d. Microsoft 365 Apps (click-to-run)
     # ---------------------------------------------------------------------------
     Invoke-Step -Name 'Microsoft 365 Apps' -Tag 'Microsoft' -Action {
         $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
@@ -1012,33 +1047,8 @@
     }
 
     # ---------------------------------------------------------------------------
-    # 7. Other package managers (run only if installed)
+    # 7. Self-updating tools
     # ---------------------------------------------------------------------------
-    # 1641 and 3010 are the MSI "reboot initiated" / "reboot required" codes, which
-    # Chocolatey passes straight through on an otherwise successful upgrade.
-    Invoke-Step -Name 'Chocolatey' -RequiresCommand 'choco' -AllowedExitCodes 1641, 3010 -Tag 'PackageManager' -Action {
-        choco upgrade all -y
-    }
-
-    Invoke-Step -Name 'Scoop' -RequiresCommand 'scoop' -Tag 'PackageManager' -Action {
-        # Run the three phases independently: a failure in one (a broken bucket, an
-        # app that will not clean up) should not hide the others.
-        $phases = @(
-            @{ Label = 'scoop update (scoop itself + buckets)'; Args = @('update') },
-            @{ Label = 'scoop update * (installed apps)';       Args = @('update', '*') },
-            @{ Label = 'scoop cleanup * (old versions)';        Args = @('cleanup', '*') }
-        )
-        foreach ($phase in $phases) {
-            Write-Output "-> $($phase.Label)"
-            $phaseArgs = $phase.Args
-            & scoop @phaseArgs
-            if ($LASTEXITCODE -ne 0) {
-                Write-Warning "$($phase.Label) returned $LASTEXITCODE; continuing with the next phase."
-                $global:LASTEXITCODE = 0
-            }
-        }
-    }
-
     Invoke-Step -Name 'rustup' -RequiresCommand 'rustup' -Tag 'Rust' -Action {
         rustup update
     }

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1687,3 +1687,71 @@ Describe 'Get-UpdateToolInventory' -Tag 'Unit' {
         $LASTEXITCODE | Should-Be 0
     }
 }
+
+Describe 'Step order' -Tag 'Static' {
+
+    # The order is a contract, not a preference, so it is asserted rather than
+    # left to whoever edits the file next. Everything here is a dependency
+    # somebody would otherwise have to rediscover.
+
+    BeforeAll {
+        $script:OrderSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+
+        $script:Order = @([regex]::Matches($script:OrderSource, "Invoke-Step -Name '([^']+)'") |
+            ForEach-Object { $_.Groups[1].Value })
+
+        $script:PositionOf = {
+            param($name)
+            $i = [array]::IndexOf($script:Order, $name)
+            if ($i -lt 0) { throw "No step named '$name'." }
+            $i
+        }
+    }
+
+    It 'found every step' {
+        $script:Order.Count | Should-BeGreaterThan 20
+    }
+
+    It 'takes the inventory before it changes anything' {
+        & $script:PositionOf 'Inventory' | Should-Be 0
+    }
+
+    # Chocolatey and Scoop install language toolchains. Updating uv or npm
+    # first and the manager that owns it second updates a tool and then the
+    # thing responsible for it.
+    It '<_> runs before the toolchains it may own' -ForEach @('Chocolatey', 'Scoop') {
+        $manager = & $script:PositionOf $_
+        foreach ($toolchain in 'uv', 'pipx packages', 'npm', 'rustup', '.NET global tools') {
+            $manager | Should-BeLessThan (& $script:PositionOf $toolchain)
+        }
+    }
+
+    # winget owns Chocolatey and Scoop on plenty of machines, and App Installer
+    # is winget updating itself.
+    It 'updates winget before the managers winget may own' {
+        $winget = & $script:PositionOf 'winget self-update'
+        $winget | Should-BeLessThan (& $script:PositionOf 'winget (all sources)')
+        $winget | Should-BeLessThan (& $script:PositionOf 'Chocolatey')
+        $winget | Should-BeLessThan (& $script:PositionOf 'Scoop')
+    }
+
+    # The module step runs on the client the tooling step installs.
+    It 'sets up the gallery before it uses the gallery' {
+        (& $script:PositionOf 'Trust PSGallery')  | Should-BeLessThan (& $script:PositionOf 'Gallery tooling')
+        (& $script:PositionOf 'Gallery tooling')  | Should-BeLessThan (& $script:PositionOf 'PowerShell modules')
+    }
+
+    # -AutoReboot can restart the machine out from under whatever follows, so
+    # nothing may follow.
+    It 'leaves Windows Update until last' {
+        & $script:PositionOf 'Windows Update' | Should-Be ($script:Order.Count - 1)
+    }
+
+    # Windows Terminal's default profile points at the pwsh the PowerShell 7
+    # step installs, so it has to exist first.
+    It 'installs PowerShell 7 before pointing Terminal at it' {
+        (& $script:PositionOf 'PowerShell 7 (latest)') |
+            Should-BeLessThan (& $script:PositionOf 'Windows Terminal default = PowerShell 7')
+    }
+}


### PR DESCRIPTION
Closes #17.

Chocolatey and Scoop ran in section 7, *after* the language toolchains in
sections 4-6. But they are frequently what installed those toolchains, so the
order updated a tool and then updated the manager responsible for it.

## The order now

```
 1. Inventory                                    what the machine has
 2. UpdateEverything (self)
 3. winget self-update                           winget owns Chocolatey and Scoop
 4. winget (all sources)                             on plenty of machines
 5. Chocolatey                                   managers, before the toolchains
 6. Scoop                                            they may own
 7. PowerShell 7 (latest)
 8. Microsoft 365 Apps
 9. Trust PSGallery                              set up the gallery
10. Gallery tooling
11. PowerShell modules                           then use it
12. PowerShell help
13. Python (Install Manager)                     toolchains that self-update
14. uv
15. pipx packages
16. npm
17. .NET global tools
18. .NET workloads
19. rustup
20. GitHub CLI extensions
21. WSL kernel
22. Defender signatures
23. Windows Terminal default = PowerShell 7      needs the pwsh from step 7
24. Windows Update                               last: -AutoReboot can restart
```

The toolchain steps already ask `Get-ToolInstallSource` before self-updating and
skip when another manager owns the tool, so this is **sequence rather than a
live conflict** — but the sequence should read the way the dependency runs.

## The order is now asserted

Each assertion is a dependency somebody would otherwise have to rediscover by
breaking it:

- The inventory comes first, because it is what the rest of the run is read
  against
- winget precedes the managers winget may own
- Trust → tooling → modules, since the module step runs on the client the
  tooling step installs
- PowerShell 7 exists before Terminal is pointed at it
- **Windows Update is last**, because `-AutoReboot` can restart the machine out
  from under anything after it

## Testing

569 tests, 0 failed (was 561). PSScriptAnalyzer clean over `src` under its
default rules.

Confirmed against a real run rather than only in source order — the summary
lists all 24 steps in the new sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)