### PR TITLE
Report what the module pass changed, let it be turned off, and update from the gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ thing that crosses a process boundary.
 | `-IncludeWindowsUpdate` | `$true` | Install pending updates via PSWindowsUpdate, scanning Microsoft Update so Office and other Microsoft products come along with the OS and drivers. Needs admin; may require a reboot. |
 | `-IncludePowerShell7` | `$true` | Install or upgrade PowerShell 7. The machine-wide MSI install needs admin. |
 | `-SetPwshTerminalDefault` | `$true` | Point Windows Terminal's default profile at PowerShell 7. Per-user; skipped if Terminal is not installed. |
+| `-IncludePowerShellModules` | `$true` | Update every installed PowerShell module. Set to `$false` when one is pinned to a version something else depends on. |
 | `-AutoReboot` | off | Let Windows Update reboot on its own. Off by default; the run reports a pending reboot instead. |
 | `-IncludePrerelease` | off | Include prerelease builds where supported, currently PowerShell module updates. |
 | `-UpdateGlobalNpm` | off | Upgrade global npm packages as well as npm itself. Off by default because global upgrades can break pinned toolchains. |
@@ -174,7 +175,8 @@ thing that crosses a process boundary.
 | `-Tag` | *(all)* | Run only the steps carrying one of these tags. Everything else is reported as skipped. |
 | `-ExcludeTag` | *(none)* | Run everything except the steps carrying one of these tags. Exclusion wins when both are given. |
 | `-LogRetentionDays` | `30` | Prune logs and settings.json backups older than this. `0` keeps everything. |
-| `-UpdateSelf` | off | Reinstall this module from GitHub first, whether or not the version differs. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. Off by default because it fetches and runs an installer from a branch. |
+| `-UpdateSelf` | off | Update this module before anything else. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. |
+| `-UpdateSelfSource` | `Gallery` | Where `-UpdateSelf` gets it from. `Gallery` is the newest published release; `Main` is the development head, fetched from GitHub. |
 
 ## Selecting steps
 

--- a/src/Private/Get-ModuleVersionMap.ps1
+++ b/src/Private/Get-ModuleVersionMap.ps1
@@ -1,0 +1,39 @@
+function Get-ModuleVersionMap {
+    <#
+        .SYNOPSIS
+        The highest installed version of every module on this machine, by name.
+
+        .DESCRIPTION
+        Taken before and after an update pass and compared, this is what turns
+        "OK (94 s)" into a list of what actually moved. Update-Module and
+        Update-PSResource are both silent on success, so without the comparison a
+        run that updated forty modules and one that updated none read the same.
+
+        Returns a hashtable keyed on module name, so a caller can diff two of
+        them without sorting or matching. Case-insensitive, because module names
+        are.
+
+        .EXAMPLE
+        $before = Get-ModuleVersionMap
+        Update-Module -Force
+        $after = Get-ModuleVersionMap
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    $map = @{}
+
+    foreach ($module in Get-Module -ListAvailable -ErrorAction SilentlyContinue) {
+        $name = $module.Name
+        $version = $module.Version
+
+        # A module is installed side by side, one folder per version, so the same
+        # name arrives more than once. The highest is the one that binds.
+        if (-not $map.ContainsKey($name) -or $version -gt $map[$name]) {
+            $map[$name] = $version
+        }
+    }
+
+    $map
+}

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -18,10 +18,14 @@
     # Tag filter first: a step the caller excluded should not even be checked for
     # administrator rights or for its tool, because neither is why it is skipped.
     if (-not (Test-StepTagMatch -StepTag $Tag -Tag $script:TagFilter -ExcludeTag $script:ExcludeTagFilter)) {
-        $reason = if (@($script:TagFilter).Count) {
-            "does not match -Tag $($script:TagFilter -join ',')"
+        # Which filter actually refused it. Exclusion wins when both are given,
+        # so asking "was -Tag set" first would blame -Tag for an exclusion and
+        # send someone looking at the wrong parameter.
+        $refused = @($Tag | Where-Object { $_ -and $_ -in @($script:ExcludeTagFilter | Where-Object { $_ }) })
+        $reason = if ($refused.Count) {
+            "excluded by -ExcludeTag $($refused -join ',')"
         } else {
-            "excluded by -ExcludeTag $($script:ExcludeTagFilter -join ',')"
+            "does not match -Tag $(@($script:TagFilter | Where-Object { $_ }) -join ',')"
         }
         Add-SkippedStep -Name $Name -Reason $reason
         return

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -72,6 +72,16 @@
         Point Windows Terminal's default profile at PowerShell 7. Default: $true.
         Per-user change; silently skipped if Windows Terminal is not installed.
 
+    .PARAMETER IncludePowerShellModules
+        Update every installed PowerShell module. Default: $true.
+
+        Set it to $false for a run that should leave modules alone, which is
+        usually because one is pinned to a version something else depends on.
+        The step is reported as skipped rather than dropped.
+
+        -ExcludeTag PowerShell is the broader hammer: it also skips the gallery
+        trust, the gallery tooling, help, PowerShell 7 and the Terminal default.
+
     .PARAMETER AutoReboot
         Allow Windows Update to reboot automatically if required. Default: $false
 
@@ -153,29 +163,18 @@
         warning has scrolled well out of sight.
 
     .PARAMETER UpdateSelf
-        Reinstall this module from the main branch on GitHub before doing
-        anything else, whether or not the installed version differs.
-        Default: $false.
+        Update this module before doing anything else. Default: $false.
+        -UpdateSelfSource decides where from, and defaults to the gallery.
 
-        This tracks the development head, not the latest release. To move
-        between published versions, use the gallery instead:
+        It takes effect on the *next* run either way. Unlike winget, which is a
+        fresh process every step, this module is already loaded by the time the
+        step runs: the files on disk are replaced, and the functions executing
+        now stay on the code already in memory.
 
-            Update-Module UpdateEverything
-
-        The module version does not move with every commit, so "already 1.0.0"
-        is the normal state of an out-of-date working copy and a version check
-        cannot decide whether a reinstall is needed. Hence the unconditional
-        reinstall.
-
-        It takes effect on the *next* run. Unlike winget, which is a fresh
-        process every step, this module is already loaded by the time the step
-        runs: the files on disk are replaced, and the functions executing now
-        stay on the code already in memory.
-
-        Off by default. It fetches and runs an installer from a branch, which is
-        a supply-chain decision rather than a routine update, and a scheduled
-        task that quietly followed main would be making that decision on every
-        run.
+        Off by default. From Main it fetches and runs an installer from a
+        branch, which is a supply-chain decision rather than a routine update,
+        and a scheduled task that quietly followed main would be making that
+        decision on every run.
 
     .PARAMETER Tag
         Run only the steps carrying one of these tags. Everything else is
@@ -198,6 +197,20 @@
         tasks able to divide the work between them: one that updates everything
         but Python daily, and one that updates only Python monthly, for a
         toolchain something else depends on being held steady.
+
+    .PARAMETER UpdateSelfSource
+        Where -UpdateSelf gets this module from. Default: Gallery.
+
+          Gallery  the newest published release, through Update-Module
+          Main     the development head, by fetching Install.ps1 from GitHub
+
+        Gallery is the default because a published release is what most people
+        want. Main is for tracking a fix that has landed but not shipped, and
+        for testing.
+
+        Gallery cannot move a copy that PowerShellGet did not install -- one put
+        there by the GitHub installer, for instance. The run says so and names
+        the way forward rather than failing.
 
     .PARAMETER LogRetentionDays
         Delete logs and settings.json backups in the log directory older than this
@@ -238,6 +251,7 @@
         [bool]   $IncludeWindowsUpdate   = $true,
         [bool]   $IncludePowerShell7     = $true,
         [bool]   $SetPwshTerminalDefault = $true,
+        [bool]   $IncludePowerShellModules = $true,
         [switch] $AutoReboot,
         [switch] $IncludePrerelease,
         [switch] $UpdateGlobalNpm,
@@ -256,7 +270,9 @@
         [string[]] $ExcludeTag = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30,
-        [switch] $UpdateSelf
+        [switch] $UpdateSelf,
+        [ValidateSet('Gallery', 'Main')]
+        [string] $UpdateSelfSource = 'Gallery'
     )
 
     # State shared with the private helpers is assigned with $script:. Inside a
@@ -475,10 +491,31 @@
     # ---------------------------------------------------------------------------
     if ($UpdateSelf) {
         Invoke-Step -Name 'UpdateEverything (self)' -Tag 'Self' -Action {
-            # Reinstalls whether or not the version differs. The version does not
-            # move with every commit and the module is distributed from a branch
-            # rather than the gallery, so "already 1.0.0" is the normal state of
-            # an out-of-date copy and is no reason to skip.
+            if ($UpdateSelfSource -eq 'Gallery') {
+                $status = Get-GalleryModuleStatus -Name 'UpdateEverything'
+
+                if (-not $status.Available) {
+                    Write-Output "UpdateEverything $($status.Installed) is installed; the gallery could not be asked about it."
+                } elseif (-not $status.Updatable) {
+                    # A copy the GitHub installer put there was not installed by
+                    # PowerShellGet, so Update-Module refuses it. That is not a
+                    # fault, and -UpdateSelfSource Main is the matching path.
+                    Write-Output "UpdateEverything $($status.Installed) was not installed from the gallery, so Update-Module cannot move it. The published version is $($status.Available)."
+                    Write-Output 'Use -UpdateSelfSource Main to track the branch it came from, or Install-Module UpdateEverything -Force to switch to the gallery copy.'
+                } elseif (-not $status.NeedsUpdate) {
+                    Write-Output "UpdateEverything $($status.Installed) is the newest published release."
+                } else {
+                    Write-Output "UpdateEverything $($status.Installed) -> $($status.Available)..."
+                    Update-Module -Name 'UpdateEverything' -Force -Confirm:$false -ErrorAction Stop
+                    Write-Output 'Updated. The new version loads on the next run; this one continues on the code already in memory.'
+                }
+                return
+            }
+
+            # Main. Reinstalls whether or not the version differs, because the
+            # module version does not move with every commit: "already 1.0.0" is
+            # the normal state of an out-of-date working copy, so a version
+            # check cannot decide whether a reinstall is needed.
             $uri = 'https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Install.ps1'
             $installer = Join-Path ([System.IO.Path]::GetTempPath()) "Install-UpdateEverything-$script:runStamp.ps1"
 
@@ -850,7 +887,15 @@
         }
     }
 
+    if (-not $IncludePowerShellModules) {
+        Add-SkippedStep -Name 'PowerShell modules'
+    } else {
     Invoke-Step -Name 'PowerShell modules' -Tag 'PowerShell' -Action {
+        # Both update commands are silent on success, so the step reported OK and
+        # a duration and nothing else. Taken either side of the pass, this says
+        # what actually moved.
+        $before = Get-ModuleVersionMap
+
         if (Get-Command Update-PSResource -ErrorAction SilentlyContinue) {
             # -TrustRepository suppresses the prompt for this call even when the
             # Trust PSGallery step could not persist the setting.
@@ -883,7 +928,28 @@
             Update-Module @p
         } else {
             Write-Output 'No PowerShellGet/PSResourceGet available; skipping.'
+            return
         }
+
+        $after = Get-ModuleVersionMap
+
+        $moved = foreach ($name in ($after.Keys | Sort-Object)) {
+            if (-not $before.ContainsKey($name)) {
+                "  {0} {1} (new)" -f $name, $after[$name]
+            } elseif ($after[$name] -gt $before[$name]) {
+                "  {0} {1} -> {2}" -f $name, $before[$name], $after[$name]
+            }
+        }
+
+        $moved = @($moved)
+        if ($moved.Count) {
+            Write-Output ''
+            Write-Output "$($moved.Count) module(s) updated:"
+            $moved | ForEach-Object { Write-Output $_ }
+        } else {
+            Write-Output "No modules needed updating. $($after.Count) installed."
+        }
+    }
     }
 
     Invoke-Step -Name 'PowerShell help' -Tag 'PowerShell' -Action {

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -20,6 +20,7 @@ BeforeDiscovery {
         @{ Name = 'IncludeWindowsUpdate';      TypeName = 'bool';     Type = [bool];     Default = '$true' }
         @{ Name = 'IncludePowerShell7';        TypeName = 'bool';     Type = [bool];     Default = '$true' }
         @{ Name = 'SetPwshTerminalDefault';    TypeName = 'bool';     Type = [bool];     Default = '$true' }
+        @{ Name = 'IncludePowerShellModules'; TypeName = 'bool';     Type = [bool];     Default = '$true' }
         @{ Name = 'AutoReboot';                TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'IncludePrerelease';         TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'UpdateGlobalNpm';           TypeName = 'switch';   Type = [switch];   Default = $null }
@@ -33,6 +34,7 @@ BeforeDiscovery {
         @{ Name = 'DelayMinutes';              TypeName = 'int';      Type = [int];      Default = '60' }
         @{ Name = 'LogRetentionDays';          TypeName = 'int';      Type = [int];      Default = '30' }
         @{ Name = 'UpdateSelf';                TypeName = 'switch';   Type = [switch];   Default = $null }
+        @{ Name = 'UpdateSelfSource';          TypeName = 'string';   Type = [string];   Default = "'Gallery'" }
     )
 
     # Each of these either reboots the machine, moves pinned toolchains, or
@@ -456,7 +458,7 @@ Describe 'Update-Everything' -Tag 'Static' {
 
         It 'declares no parameters beyond the documented contract' {
             $script:DeclaredParameters.Name.VariablePath.UserPath |
-                Should-BeCollection -Count 16 -Because 'a new parameter needs docs and a test'
+                Should-BeCollection -Count 18 -Because 'a new parameter needs docs and a test'
         }
 
         It 'bounds -LogRetentionDays with ValidateRange' {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1548,6 +1548,49 @@ Describe 'Test-StepTagMatch' -Tag 'Unit' {
     }
 }
 
+Describe 'The skip reason names the filter that refused the step' -Tag 'Unit' {
+
+    # Exclusion wins when both filters are given, so a reason worked out by
+    # asking "was -Tag set" first blames -Tag for an exclusion and sends someone
+    # looking at the wrong parameter.
+
+    BeforeEach {
+        $script:logDir = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $null = New-Item -ItemType Directory -Path $script:logDir -Force
+        $script:runStamp = 'reason'
+        $script:isAdmin = $true
+        $script:Results = [System.Collections.Generic.List[object]]::new()
+        $script:TagFilter = @()
+        $script:ExcludeTagFilter = @()
+    }
+
+    It 'blames -ExcludeTag when that is what refused it' {
+        $script:TagFilter = @('PowerShell')
+        $script:ExcludeTagFilter = @('Windows')
+
+        Invoke-Step -Name 'both' -Tag 'PowerShell', 'Windows' -Action { 'x' } 6>$null
+
+        $script:Results[0].Status | Should-Be 'Skipped'
+    }
+
+    It 'blames -Tag when nothing was excluded' {
+        $script:TagFilter = @('Python')
+
+        Invoke-Step -Name 'other' -Tag 'Node' -Action { 'x' } 6>$null
+
+        $script:Results[0].Status | Should-Be 'Skipped'
+    }
+
+    It 'runs a step that survives both filters' {
+        $script:TagFilter = @('PowerShell')
+        $script:ExcludeTagFilter = @('Windows')
+
+        Invoke-Step -Name 'kept' -Tag 'PowerShell' -Action { 'x' } 6>$null
+
+        $script:Results[0].Status | Should-Be 'OK'
+    }
+}
+
 Describe 'Every step declares a tag' -Tag 'Static' {
 
     # A step with no tag is invisible to -Tag and unstoppable by -ExcludeTag, so
@@ -1753,5 +1796,92 @@ Describe 'Step order' -Tag 'Static' {
     It 'installs PowerShell 7 before pointing Terminal at it' {
         (& $script:PositionOf 'PowerShell 7 (latest)') |
             Should-BeLessThan (& $script:PositionOf 'Windows Terminal default = PowerShell 7')
+    }
+}
+
+Describe 'Get-ModuleVersionMap' -Tag 'Unit' {
+
+    It 'returns a hashtable keyed on module name' {
+        $map = Get-ModuleVersionMap
+        $map | Should-HaveType ([hashtable])
+    }
+
+    It 'finds the module running these tests' {
+        (Get-ModuleVersionMap).ContainsKey('Pester') | Should-BeTrue
+    }
+
+    # A module is installed side by side, one folder per version, so the same
+    # name arrives more than once and the highest is the one that binds.
+    It 'keeps the highest version of a name installed more than once' {
+        $map = Get-ModuleVersionMap
+        $highest = @(Get-Module Pester -ListAvailable | Sort-Object Version -Descending)[0].Version
+
+        $map['Pester'] | Should-Be $highest
+    }
+
+    It 'reports a version, not a string' {
+        (Get-ModuleVersionMap)['Pester'] | Should-HaveType ([version])
+    }
+}
+
+Describe 'The PowerShell modules step' -Tag 'Static' {
+
+    BeforeAll {
+        $script:ModSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    # Update-Module and Update-PSResource are both silent on success, so the
+    # step reported OK and a duration and nothing else. Forty updates and none
+    # read the same.
+    It 'takes a version map either side of the pass' {
+        $script:ModSource | Should-MatchString '\$before = Get-ModuleVersionMap'
+        $script:ModSource | Should-MatchString '\$after = Get-ModuleVersionMap'
+    }
+
+    It 'reports what moved rather than only that it finished' {
+        $script:ModSource | Should-MatchString 'module\(s\) updated'
+    }
+
+    It 'says so when nothing needed updating' {
+        $script:ModSource | Should-MatchString 'No modules needed updating'
+    }
+
+    It 'can be turned off' {
+        $script:ModSource | Should-MatchString 'if \(-not \$IncludePowerShellModules\)'
+    }
+
+    # Skipped rather than dropped, so the summary still accounts for every step.
+    It 'reports the step as skipped rather than removing it' {
+        $script:ModSource | Should-MatchString "Add-SkippedStep -Name 'PowerShell modules'"
+    }
+}
+
+Describe 'Updating the module itself' -Tag 'Static' {
+
+    BeforeAll {
+        $script:SelfSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    It 'defaults to the published release rather than the branch' {
+        $script:SelfSource | Should-MatchString "\`$UpdateSelfSource = 'Gallery'"
+    }
+
+    It 'still offers the branch' {
+        $script:SelfSource | Should-MatchString "ValidateSet\('Gallery', 'Main'\)"
+    }
+
+    # The gallery path reuses the same check the tooling step needed: a copy the
+    # GitHub installer put there was not installed by PowerShellGet, and
+    # Update-Module refuses it.
+    It 'notices a copy the gallery cannot move, and names the way forward' {
+        $script:SelfSource | Should-MatchString 'was not installed from the gallery'
+        $script:SelfSource | Should-MatchString '-UpdateSelfSource Main'
+    }
+
+    It 'says an update lands on the next run, on both paths' {
+        $matches = [regex]::Matches($script:SelfSource, 'loads on the next run')
+        $matches.Count | Should-BeGreaterThanOrEqual 2
     }
 }


### PR DESCRIPTION
Closes #30.

Three gaps in the `PowerShell modules` step. The pass already covered every
installed module, so none of this changes what it updates.

## 1. Nothing said what changed

`Update-Module` and `Update-PSResource` are both silent on success, so the step
reported a status and a duration. Forty updates and none read the same.

`Get-ModuleVersionMap` is taken either side of the pass and the difference
printed. On this machine:

```
=== STARTING: PowerShell modules ===
No modules needed updating. 78 installed.
COMPLETED: PowerShell modules (7.6 s)
```

and when something moves:

```
2 module(s) updated:
  PSReadLine 2.3.4 -> 2.3.6
  Az.Accounts 3.0.2 (new)
```

## 2. There was no way to turn it off

Every other broad step has a gate; this was the one a run could not decline —
while being the step most likely to be unwanted, since a module pinned to a
version something else depends on is exactly that case.

`-IncludePowerShellModules` defaults to `$true` and reports the step as
`Skipped` rather than dropping it:

```
SKIP  PowerShell modules (disabled by parameter)
```

**The issue's open question was whether `-ExcludeTag PowerShell` makes this
redundant.** It does not — that tag also takes the gallery trust, the gallery
tooling, help, PowerShell 7 and the Terminal default. Much larger hammer. The
switch matches the three `-Include*` bools already there, and the help points at
the tag as the broader option.

## 3. `-UpdateSelf` pointed only at `main`

Right before publishing, wrong as the only option afterwards. `-UpdateSelfSource`
takes `Gallery` or `Main` and **defaults to Gallery**.

The gallery path reuses `Get-GalleryModuleStatus` from #27, so a copy the GitHub
installer put there is recognised as one `Update-Module` cannot move, and the run
names both ways forward instead of failing:

```
UpdateEverything 1.0.0 was not installed from the gallery, so Update-Module
cannot move it. The published version is 1.1.0.
Use -UpdateSelfSource Main to track the branch it came from, or
Install-Module UpdateEverything -Force to switch to the gallery copy.
```

## The bug running it found

With both filters set, the skip reason always blamed `-Tag`, because it asked
"was `-Tag` given" before checking what actually refused the step. A step
excluded by `-ExcludeTag` reported `does not match -Tag PowerShell` and sent the
reader to the wrong parameter. Now:

```
SKIP  winget self-update (excluded by -ExcludeTag Windows)
SKIP  PowerShell 7 (latest) (excluded by -ExcludeTag Windows)
```

## Testing

594 tests, 0 failed (was 569). PSScriptAnalyzer clean over `src` under its
default rules.

Verified against real runs: the module pass and its new reporting, the gate, the
corrected skip reasons, and `-UpdateSelf` on the gallery path reporting
`UpdateEverything 1.0.0 is the newest published release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)