### PR TITLE
Add a setup menu and a developer-tools catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,70 @@ other runs. Check with `Get-ExecutionPolicy -List`.
 | Command | Does |
 |---|---|
 | `Update-Everything` | Runs the update pass and returns a result object |
+| `Initialize-UpdateEverything` | Setup menu: prerequisites, scheduled task, developer tools, first run |
 | `Register-UpdateEverythingTask` | Registers the scheduled task. Needs elevation |
 | `Get-UpdateEverythingTask` | Reports the registered task, or nothing if there is none |
 | `Unregister-UpdateEverythingTask` | Removes the task |
 | `Test-PendingReboot` | Reports whether Windows is waiting on a restart, and why |
 
 `Update-All` is an alias for `Update-Everything`.
+
+## Setting up
+
+```powershell
+Initialize-UpdateEverything
+```
+
+A menu, for a machine that has just had the module installed:
+
+```
+UpdateEverything setup
+
+  1. Run prerequisites only (PowerShell 7, notifications, gallery tooling)
+  2. Set up a scheduled task
+  3. Install developer tools
+  4. Perform a full first run
+  5. Exit
+
+Choose [1-5]:
+```
+
+Typed numbers rather than arrow keys, so it needs no extra module, works over a
+remote session and in a host with no cursor control, and can be tested without
+simulating key events. The menu repeats until you choose Exit.
+
+`-Choice` takes one option and returns, for a caller that already knows what it
+wants:
+
+```powershell
+Initialize-UpdateEverything -Choice DeveloperTools
+```
+
+### Developer tools
+
+Option 3 is the one deliberate exception to "this module updates, it does not
+install". On a fresh machine the honest first question is why nothing is
+installed, and the answer is a script everyone writes once and badly.
+
+```
+  1. Git                           Version control
+  2. Python                        Python, through the Install Manager this module updates
+  3. Node.js LTS                   JavaScript runtime, with npm
+  4. VS Code                       Editor
+  5. Windows Terminal              Terminal this module can set a default profile on
+  6. PowerShell 7      installed   PowerShell 7, MSI build so it can elevate
+  ...
+```
+
+You pick numbers; nothing else is installed. A tool already on PATH is marked
+and skipped, because the update run covers it from then on.
+
+**The catalogue is not an `-AllowInstall` component, and `-AllowInstall All`
+cannot reach it.** `All` means "approve the components this update run needs" —
+six named things, each a prerequisite for updating something else. Letting it
+also mean "install a dozen developer tools" would turn an unattended scheduled
+task from a maintenance job into a provisioning one, through a flag people
+already have in their task definitions.
 
 ## Running it
 

--- a/src/Private/Get-DeveloperToolCatalogue.ps1
+++ b/src/Private/Get-DeveloperToolCatalogue.ps1
@@ -1,0 +1,55 @@
+function Get-DeveloperToolCatalogue {
+    <#
+        .SYNOPSIS
+        The developer tools the setup menu can install, with their winget IDs.
+
+        .DESCRIPTION
+        This module updates; it does not install. The catalogue is the one
+        deliberate exception, and it is reachable only from the setup menu, where
+        a person picks from a list. It is not an -AllowInstall component, so no
+        unattended run can reach it and -AllowInstall All does not widen a
+        maintenance job into a provisioning one.
+
+        Every Id here was checked against "winget show --id <id> --exact" rather
+        than written from memory. A wrong Id fails at install time on somebody
+        else's machine.
+
+        Command is what the tool puts on PATH, so the menu can say what is
+        already present instead of offering to install it again.
+
+        .EXAMPLE
+        Get-DeveloperToolCatalogue | Format-Table Name, Id
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param()
+
+    # PowerShell 7 carries an installer type for the same reason the update step
+    # does: winget has defaulted Microsoft.PowerShell to MSIX since 7.6, and
+    # Windows will not run an MSIX process elevated.
+    $catalogue = @(
+        @{ Name = 'Git';              Id = 'Git.Git';                    Command = 'git';     Description = 'Version control' }
+        @{ Name = 'Python';           Id = 'Python.PythonInstallManager'; Command = 'py';     Description = 'Python, through the Install Manager this module updates' }
+        @{ Name = 'Node.js LTS';      Id = 'OpenJS.NodeJS.LTS';          Command = 'node';    Description = 'JavaScript runtime, with npm' }
+        @{ Name = 'VS Code';          Id = 'Microsoft.VisualStudioCode'; Command = 'code';    Description = 'Editor' }
+        @{ Name = 'Windows Terminal'; Id = 'Microsoft.WindowsTerminal';  Command = 'wt';      Description = 'Terminal this module can set a default profile on' }
+        @{ Name = 'PowerShell 7';     Id = 'Microsoft.PowerShell';       Command = 'pwsh';    Description = 'PowerShell 7, MSI build so it can elevate'; InstallerType = 'wix' }
+        @{ Name = 'GitHub CLI';       Id = 'GitHub.cli';                 Command = 'gh';      Description = 'gh, for repositories and pull requests' }
+        @{ Name = 'uv';               Id = 'astral-sh.uv';               Command = 'uv';      Description = 'Python package and project manager' }
+        @{ Name = 'Rust';             Id = 'Rustlang.Rustup';            Command = 'rustup';  Description = 'Rust toolchain installer' }
+        @{ Name = '.NET SDK';         Id = 'Microsoft.DotNet.SDK.9';     Command = 'dotnet';  Description = 'dotnet build, test and global tools' }
+        @{ Name = '7-Zip';            Id = '7zip.7zip';                  Command = '7z';      Description = 'Archives' }
+        @{ Name = 'Docker Desktop';   Id = 'Docker.DockerDesktop';       Command = 'docker';  Description = 'Containers' }
+    )
+
+    foreach ($entry in $catalogue) {
+        [pscustomobject]@{
+            Name          = $entry.Name
+            Id            = $entry.Id
+            Command       = $entry.Command
+            Description   = $entry.Description
+            InstallerType = $entry.InstallerType
+            Present       = [bool] (Get-Command $entry.Command -CommandType Application -ErrorAction SilentlyContinue)
+        }
+    }
+}

--- a/src/Private/Install-DeveloperTool.ps1
+++ b/src/Private/Install-DeveloperTool.ps1
@@ -1,0 +1,96 @@
+function Install-DeveloperTool {
+    <#
+        .SYNOPSIS
+        Installs tools chosen from the developer-tools catalogue, through winget.
+
+        .DESCRIPTION
+        -Name is what the person picked from the menu, and that selection is also
+        the approval: it is passed to Approve-Install as the approved list, so a
+        tool the person chose does not ask a second time and a tool they did not
+        choose cannot be installed.
+
+        The run's -AllowInstall is deliberately not consulted. -AllowInstall All
+        means "approve the components this update run needs", six named things
+        that are each a prerequisite for updating something else. Letting it also
+        mean "install a dozen developer tools" would turn an unattended scheduled
+        task from a maintenance job into a provisioning one, through a flag people
+        already have in their task definitions.
+
+        A tool already on PATH is reported and skipped. The update run covers it
+        from then on.
+
+        .PARAMETER Name
+        Catalogue names to install. Anything not in the catalogue is refused
+        rather than passed to winget, so a typo cannot install something else.
+
+        .EXAMPLE
+        Install-DeveloperTool -Name Git, 'Node.js LTS'
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Called only from the setup menu, where the caller has already picked from a list and confirmed. Approve-Install gates each install in turn.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of a console maintenance tool. This runs from an interactive menu, not inside a step, so it is not captured by Invoke-Step.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [string[]] $Name
+    )
+
+    if (-not (Get-Command winget -CommandType Application -ErrorAction SilentlyContinue)) {
+        Write-Warning 'winget is not available, so nothing can be installed. It ships with App Installer from the Microsoft Store.'
+        return
+    }
+
+    $catalogue = @(Get-DeveloperToolCatalogue)
+    $installed = 0
+    $skipped = 0
+    $failed = 0
+
+    foreach ($wanted in $Name) {
+        $tool = $catalogue | Where-Object { $_.Name -eq $wanted } | Select-Object -First 1
+
+        if (-not $tool) {
+            Write-Warning "'$wanted' is not in the catalogue; nothing was installed for it."
+            $skipped++
+            continue
+        }
+
+        if ($tool.Present) {
+            Write-Host "  $($tool.Name) is already installed; the update run covers it from here." -ForegroundColor DarkGray
+            $skipped++
+            continue
+        }
+
+        # The selection is the approval. $Name, not the run's -AllowInstall, so
+        # 'All' in a scheduled task cannot reach this.
+        if (-not (Approve-Install -Component $tool.Name -Approved $Name `
+                    -Description "$($tool.Description). This would install $($tool.Id) through winget.")) {
+            $skipped++
+            continue
+        }
+
+        Write-Host "  Installing $($tool.Name) ($($tool.Id))..." -ForegroundColor Cyan
+
+        $arguments = @('install', '--id', $tool.Id, '--exact', '--source', 'winget',
+                       '--accept-source-agreements', '--accept-package-agreements',
+                       '--disable-interactivity')
+        if ($tool.InstallerType) { $arguments += @('--installer-type', $tool.InstallerType) }
+
+        winget @arguments
+        $code = $LASTEXITCODE
+        $global:LASTEXITCODE = 0
+
+        if ($code -eq 0) {
+            Write-Host "  Installed $($tool.Name)." -ForegroundColor Green
+            $installed++
+        } else {
+            Write-Warning ("winget returned {0} (0x{0:X8}) for $($tool.Name); it was not installed." -f $code)
+            $failed++
+        }
+    }
+
+    [pscustomobject]@{
+        Installed = $installed
+        Skipped   = $skipped
+        Failed    = $failed
+    }
+}

--- a/src/Private/Invoke-SetupChoice.ps1
+++ b/src/Private/Invoke-SetupChoice.ps1
@@ -1,0 +1,117 @@
+function Invoke-SetupChoice {
+    <#
+        .SYNOPSIS
+        Carries out one option from the setup menu.
+
+        .DESCRIPTION
+        Split out from Initialize-UpdateEverything so each option can be tested
+        on its own, and so the menu loop stays a menu loop.
+
+        Every option says what it is about to do before it does it. The menu is
+        the confirmation for reaching the option; it is not a confirmation for
+        installing anything, which still goes through Approve-Install.
+
+        .EXAMPLE
+        Invoke-SetupChoice -Key Prerequisites
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of a console maintenance tool. This runs from an interactive menu, not inside a step.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Reached only from the setup menu, which is itself the choice. Installs go through Approve-Install and the task registration reports what it made.')]
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Prerequisites', 'ScheduledTask', 'DeveloperTools', 'FirstRun')]
+        [string] $Key
+    )
+
+    switch ($Key) {
+
+        'Prerequisites' {
+            Write-Host ''
+            Write-Host 'Running the prerequisite steps only: PowerShell 7, the gallery tooling and' -ForegroundColor Cyan
+            Write-Host 'the package managers. Nothing else is touched, and each install still asks.' -ForegroundColor Cyan
+            Write-Host ''
+
+            # -Notify because BurntToast is one of the prerequisites, and a toast
+            # at the end is the only proof it works. The tags keep this to the
+            # PowerShell and package-manager steps.
+            $null = Update-Everything -Tag PowerShell, PackageManager -Notify `
+                -IncludePowerShellModules $false
+        }
+
+        'ScheduledTask' {
+            Write-Host ''
+            if (Get-UpdateEverythingTask) {
+                Write-Host 'A scheduled task is already registered:' -ForegroundColor Yellow
+                Get-UpdateEverythingTask | Format-Table -AutoSize | Out-Host
+                Write-Host 'Use Register-UpdateEverythingTask to replace it, or Unregister-UpdateEverythingTask to remove it.' -ForegroundColor DarkGray
+                return
+            }
+
+            Write-Host 'Registering a weekly task that runs as you, elevated, with notifications.' -ForegroundColor Cyan
+            Write-Host 'Registering a scheduled task needs administrator rights.' -ForegroundColor DarkGray
+            Write-Host ''
+
+            try {
+                Register-UpdateEverythingTask -Cadence Weekly -Notify $true -ErrorAction Stop
+            } catch {
+                Write-Warning "Could not register the task: $($_.Exception.Message)"
+            }
+        }
+
+        'DeveloperTools' {
+            $catalogue = @(Get-DeveloperToolCatalogue)
+
+            Write-Host ''
+            Write-Host 'Developer tools' -ForegroundColor Cyan
+            Write-Host 'This module updates; it does not install. These are the exception, and' -ForegroundColor DarkGray
+            Write-Host 'nothing is installed that you do not pick.' -ForegroundColor DarkGray
+            Write-Host ''
+
+            for ($i = 0; $i -lt $catalogue.Count; $i++) {
+                $tool = $catalogue[$i]
+                $mark = if ($tool.Present) { 'installed' } else { '' }
+                Write-Host ("  {0,2}. {1,-18} {2,-10} {3}" -f ($i + 1), $tool.Name, $mark, $tool.Description)
+            }
+
+            Write-Host ''
+            Write-Host 'Numbers separated by commas, or blank to go back.' -ForegroundColor DarkGray
+            $answer = (Read-Host 'Install').Trim()
+
+            if (-not $answer) { return }
+
+            $wanted = foreach ($part in ($answer -split ',')) {
+                $trimmed = $part.Trim()
+                if (-not $trimmed) { continue }
+
+                $index = 0
+                if (-not [int]::TryParse($trimmed, [ref] $index) -or
+                    $index -lt 1 -or $index -gt $catalogue.Count) {
+                    Write-Warning "'$trimmed' is not one of the numbers listed."
+                    continue
+                }
+
+                $catalogue[$index - 1].Name
+            }
+
+            $wanted = @($wanted)
+            if (-not $wanted.Count) { return }
+
+            Write-Host ''
+            $result = Install-DeveloperTool -Name $wanted
+            if ($result) {
+                Write-Host ''
+                Write-Host "Installed $($result.Installed), skipped $($result.Skipped), failed $($result.Failed)." -ForegroundColor Cyan
+            }
+        }
+
+        'FirstRun' {
+            Write-Host ''
+            Write-Host 'Running Update-Everything. This is the ordinary run, and it will ask before' -ForegroundColor Cyan
+            Write-Host 'installing anything it does not already have.' -ForegroundColor Cyan
+            Write-Host ''
+
+            $null = Update-Everything
+        }
+    }
+}

--- a/src/Public/Initialize-UpdateEverything.ps1
+++ b/src/Public/Initialize-UpdateEverything.ps1
@@ -1,0 +1,94 @@
+function Initialize-UpdateEverything {
+    <#
+        .SYNOPSIS
+        Sets up UpdateEverything on a machine, from a menu.
+
+        .DESCRIPTION
+        A new install leaves you at Update-Everything with no guidance, and the
+        things worth doing first -- getting PowerShell 7 and a notification
+        module in place, registering a scheduled task, installing the tools this
+        module then has something to update -- are each a separate command to
+        discover.
+
+            UpdateEverything setup
+
+              1. Run prerequisites only
+              2. Set up a scheduled task
+              3. Install developer tools
+              4. Perform a full first run
+              5. Exit
+
+        Typed numbers rather than arrow keys. It needs no dependency, it works
+        over a remote session and in a host with no cursor control, and it can be
+        tested without simulating key events.
+
+        The menu repeats until you choose Exit, because setting a task up and
+        then running for the first time is two answers, not two sessions.
+
+        Nothing here installs anything without asking. Options 1 and 3 both go
+        through Approve-Install like every other install in this module.
+
+        .PARAMETER Choice
+        Take this option and return instead of showing the menu. Intended for
+        tests and for a caller that already knows what it wants; a person should
+        use the menu.
+
+        .EXAMPLE
+        Initialize-UpdateEverything
+
+        .EXAMPLE
+        Initialize-UpdateEverything -Choice DeveloperTools
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of a console maintenance tool. This is a menu a person reads and answers, not data a caller consumes.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'The menu is the confirmation. Every option states what it will do before doing it, and the installs go through Approve-Install.')]
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [ValidateSet('Prerequisites', 'ScheduledTask', 'DeveloperTools', 'FirstRun')]
+        [string] $Choice
+    )
+
+    $options = [ordered]@{
+        '1' = @{ Key = 'Prerequisites';  Label = 'Run prerequisites only (PowerShell 7, notifications, gallery tooling)' }
+        '2' = @{ Key = 'ScheduledTask';  Label = 'Set up a scheduled task' }
+        '3' = @{ Key = 'DeveloperTools'; Label = 'Install developer tools' }
+        '4' = @{ Key = 'FirstRun';       Label = 'Perform a full first run' }
+        '5' = @{ Key = 'Exit';           Label = 'Exit' }
+    }
+
+    if ($Choice) {
+        Invoke-SetupChoice -Key $Choice
+        return
+    }
+
+    if (-not (Test-CanPrompt)) {
+        Write-Warning 'The setup menu needs an interactive console, and this session cannot prompt.'
+        Write-Warning 'Pass -Choice to take one option directly, or run Update-Everything instead.'
+        return
+    }
+
+    while ($true) {
+        Write-Host ''
+        Write-Host 'UpdateEverything setup' -ForegroundColor Cyan
+        Write-Host ''
+        foreach ($entry in $options.GetEnumerator()) {
+            Write-Host ("  {0}. {1}" -f $entry.Key, $entry.Value.Label)
+        }
+        Write-Host ''
+
+        $answer = (Read-Host 'Choose [1-5]').Trim()
+
+        if (-not $options.Contains($answer)) {
+            Write-Host "  '$answer' is not one of the options." -ForegroundColor Yellow
+            continue
+        }
+
+        $key = $options[$answer].Key
+        if ($key -eq 'Exit') {
+            Write-Host 'Nothing further. Run Initialize-UpdateEverything again whenever you want this menu.' -ForegroundColor DarkGray
+            return
+        }
+
+        Invoke-SetupChoice -Key $key
+    }
+}

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -17,6 +17,7 @@
 
     FunctionsToExport = @(
         'Update-Everything'
+        'Initialize-UpdateEverything'
         'Register-UpdateEverythingTask'
         'Unregister-UpdateEverythingTask'
         'Get-UpdateEverythingTask'

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -49,6 +49,7 @@ BeforeDiscovery {
 
     $ExportedFunctions = @(
         'Update-Everything'
+        'Initialize-UpdateEverything'
         'Register-UpdateEverythingTask'
         'Unregister-UpdateEverythingTask'
         'Get-UpdateEverythingTask'

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1885,3 +1885,192 @@ Describe 'Updating the module itself' -Tag 'Static' {
         $matches.Count | Should-BeGreaterThanOrEqual 2
     }
 }
+
+Describe 'Get-DeveloperToolCatalogue' -Tag 'Unit' {
+
+    BeforeAll { $script:Catalogue = @(Get-DeveloperToolCatalogue) }
+
+    It 'offers something to install' {
+        $script:Catalogue.Count | Should-BeGreaterThan 5
+    }
+
+    It 'gives every entry a name, an id, a command and a description' {
+        $incomplete = $script:Catalogue |
+            Where-Object { -not $_.Name -or -not $_.Id -or -not $_.Command -or -not $_.Description } |
+            ForEach-Object { $_.Name }
+
+        $incomplete | Should-BeNull
+    }
+
+    It 'uses each name once' {
+        $duplicates = $script:Catalogue | Group-Object Name | Where-Object Count -gt 1 | ForEach-Object Name
+        $duplicates | Should-BeNull
+    }
+
+    It 'uses each winget id once' {
+        $duplicates = $script:Catalogue | Group-Object Id | Where-Object Count -gt 1 | ForEach-Object Name
+        $duplicates | Should-BeNull
+    }
+
+    It 'reports whether each tool is already on the machine' {
+        $script:Catalogue[0].Present | Should-HaveType ([bool])
+    }
+
+    # winget has defaulted Microsoft.PowerShell to MSIX since 7.6, and Windows
+    # will not run an MSIX process elevated. The update step forces wix for the
+    # same reason.
+    It 'forces the MSI build of PowerShell 7' {
+        $pwsh = $script:Catalogue | Where-Object { $_.Id -eq 'Microsoft.PowerShell' }
+        $pwsh.InstallerType | Should-Be 'wix'
+    }
+}
+
+Describe 'Install-DeveloperTool' -Tag 'Unit' {
+
+    # The whole point of the decision recorded in the issue: -AllowInstall All
+    # must not reach the catalogue, or an unattended scheduled task quietly
+    # becomes a provisioning job.
+    It 'never consults the run-wide AllowInstall' {
+        $source = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Install-DeveloperTool.ps1') -Raw
+
+        $source | Should-NotMatchString '\$AllowInstall'
+    }
+
+    It 'passes the selection itself as the approval' {
+        $source = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Install-DeveloperTool.ps1') -Raw
+
+        $source | Should-MatchString 'Approve-Install -Component \$tool\.Name -Approved \$Name'
+    }
+
+    It 'refuses a name that is not in the catalogue' {
+        $result = Install-DeveloperTool -Name 'NotARealTool' -WarningAction SilentlyContinue
+        $result.Installed | Should-Be 0
+    }
+
+    It 'installs nothing for a name it refused' {
+        $result = Install-DeveloperTool -Name 'NotARealTool' -WarningAction SilentlyContinue
+        $result.Skipped | Should-Be 1
+    }
+
+    It 'skips a tool that is already on the machine' {
+        # PowerShell 7 is running these tests, so pwsh resolves.
+        $result = Install-DeveloperTool -Name 'PowerShell 7' -WarningAction SilentlyContinue 6>$null
+        $result.Installed | Should-Be 0
+        $result.Skipped   | Should-Be 1
+    }
+}
+
+Describe 'Initialize-UpdateEverything' -Tag 'Unit' {
+
+    It 'is exported by the manifest' {
+        $manifest = Import-PowerShellDataFile `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\UpdateEverything.psd1')
+
+        $manifest.FunctionsToExport | Should-ContainCollection 'Initialize-UpdateEverything'
+    }
+
+    It 'takes every menu option as a -Choice' {
+        $set = (Get-Command Initialize-UpdateEverything).Parameters['Choice'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+
+        foreach ($key in 'Prerequisites', 'ScheduledTask', 'DeveloperTools', 'FirstRun') {
+            $set.ValidValues | Should-ContainCollection $key
+        }
+    }
+
+    # A session that cannot prompt would block on Read-Host until whatever is
+    # running it gives up.
+    It 'refuses to show a menu it cannot get an answer to' {
+        Mock Test-CanPrompt { $false }
+
+        $warnings = @()
+        Initialize-UpdateEverything -WarningVariable warnings -WarningAction SilentlyContinue
+
+        ($warnings -join ' ') | Should-MatchString 'interactive console'
+    }
+
+    It 'points at -Choice as the way through without a console' {
+        Mock Test-CanPrompt { $false }
+
+        $warnings = @()
+        Initialize-UpdateEverything -WarningVariable warnings -WarningAction SilentlyContinue
+
+        ($warnings -join ' ') | Should-MatchString '-Choice'
+    }
+
+    It 'does not reach the menu when -Choice is given' {
+        Mock Test-CanPrompt { $false }
+        Mock Invoke-SetupChoice { }
+
+        Initialize-UpdateEverything -Choice DeveloperTools -WarningAction SilentlyContinue
+
+        Should-Invoke Invoke-SetupChoice -ParameterFilter { $Key -eq 'DeveloperTools' }
+    }
+}
+
+Describe 'The setup menu loop' -Tag 'Unit' {
+
+    # Read-Host is mocked rather than piped. Piping makes Test-CanPrompt refuse
+    # the menu outright -- correctly, since a redirected session cannot answer --
+    # so the loop itself can only be reached with a mock.
+
+    BeforeEach {
+        Mock Test-CanPrompt { $true }
+        Mock Invoke-SetupChoice { }
+        Mock Write-Host { }
+    }
+
+    It 'exits on 5 without taking any option' {
+        Mock Read-Host { '5' }
+
+        Initialize-UpdateEverything
+
+        Should-NotInvoke Invoke-SetupChoice
+    }
+
+    It 'takes the option matching the number typed' {
+        $script:answers = @('3', '5')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        Initialize-UpdateEverything
+
+        Should-Invoke Invoke-SetupChoice -ParameterFilter { $Key -eq 'DeveloperTools' }
+    }
+
+    # A typo must not end the session or take an option nobody asked for.
+    It 'asks again after an answer that is not an option' {
+        $script:answers = @('99', 'x', '5')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        Initialize-UpdateEverything
+
+        Should-NotInvoke Invoke-SetupChoice
+        $script:next | Should-Be 3
+    }
+
+    # Setting a task up and then running for the first time is two answers, not
+    # two sessions.
+    It 'keeps offering the menu until told to stop' {
+        $script:answers = @('1', '4', '5')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        Initialize-UpdateEverything
+
+        Should-Invoke Invoke-SetupChoice -Times 2 -Exactly
+    }
+
+    It 'ignores whitespace around the answer' {
+        $script:answers = @('  2  ', '5')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        Initialize-UpdateEverything
+
+        Should-Invoke Invoke-SetupChoice -ParameterFilter { $Key -eq 'ScheduledTask' }
+    }
+}


### PR DESCRIPTION
Closes #19. Closes #21.

Built together because **#21's own text places the catalogue behind the menu** —
a catalogue nothing could reach would be dead code until #19 landed.

## The menu

```
UpdateEverything setup

  1. Run prerequisites only (PowerShell 7, notifications, gallery tooling)
  2. Set up a scheduled task
  3. Install developer tools
  4. Perform a full first run
  5. Exit

Choose [1-5]:
```

Typed numbers rather than arrow keys: no dependency, works over a remote session
and in a host with no cursor control, testable without simulating key events.
The loop repeats until Exit, because setting a task up and then running for the
first time is two answers rather than two sessions.

A session that cannot prompt is **refused** rather than left blocking on
`Read-Host`, and `-Choice` takes one option directly.

## The catalogue

Twelve tools. **Every winget Id was checked against `winget show --id <id>
--exact`** rather than written from memory, which changed two of them:

- `Python.PythonManager` does not exist — the Install Manager is
  `Python.PythonInstallManager`, which is also what the module's Python step
  drives
- there is no `pipx` package in winget at all, so it is not offered

PowerShell 7 carries `--installer-type wix`, for the same reason the update step
does.

```
 1. Git                installed  Version control
 2. Python             installed  Python, through the Install Manager this module updates
 3. Node.js LTS        installed  JavaScript runtime, with npm
 4. VS Code                       Editor
 5. Windows Terminal   installed  Terminal this module can set a default profile on
 ...
```

A tool already on PATH is marked and skipped — the update run covers it from
then on.

## The open decision, settled as recommended

**`-AllowInstall All` does not reach the catalogue.** `Install-DeveloperTool`
never reads the run's `-AllowInstall` at all; the person's *selection* is what is
passed to `Approve-Install` as the approved list, so a tool they chose does not
ask twice and a tool they did not choose cannot be installed.

`All` means "approve the components this update run needs" — six things, each a
prerequisite for updating something else. Widening it to a dozen developer tools
would turn an unattended scheduled task from a maintenance job into a
provisioning one, through a flag people already have in their task definitions.

A test asserts the file never mentions `$AllowInstall`, so this cannot drift back
by accident.

## Testing

621 tests, 0 failed (was 594). PSScriptAnalyzer clean over `src` under its
default rules.

The catalogue was rendered for real, and the refusal paths exercised. The loop
is tested with a mocked `Read-Host` rather than piped input — **piping makes
`Test-CanPrompt` refuse the menu outright**, which is correct behaviour and was
confirmed by trying it:

```
WARNING: The setup menu needs an interactive console, and this session cannot prompt.
WARNING: Pass -Choice to take one option directly, or run Update-Everything instead.
```

## Note on #20

Option 2 currently reports an existing task and points at
`Register-UpdateEverythingTask` / `Unregister-UpdateEverythingTask`. Discovering
and editing tasks from the menu is #20, which follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)