### PR TITLE
Find, add, replace and remove scheduled tasks from the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ other runs. Check with `Get-ExecutionPolicy -List`.
 | `Update-Everything` | Runs the update pass and returns a result object |
 | `Initialize-UpdateEverything` | Setup menu: prerequisites, scheduled task, developer tools, first run |
 | `Register-UpdateEverythingTask` | Registers the scheduled task. Needs elevation |
-| `Get-UpdateEverythingTask` | Reports the registered task, or nothing if there is none |
+| `Get-UpdateEverythingTask` | Reports every task that runs this module, or nothing if there are none |
 | `Unregister-UpdateEverythingTask` | Removes the task |
 | `Test-PendingReboot` | Reports whether Windows is waiting on a restart, and why |
 
@@ -142,6 +142,27 @@ wants:
 ```powershell
 Initialize-UpdateEverything -Choice DeveloperTools
 ```
+
+### Scheduled tasks
+
+Option 2 lists what is already registered and offers to add another, replace
+one, or remove one.
+
+**Another task, not another trigger.** Every trigger on a task runs the same
+action, so two triggers cannot express "everything but Python daily, only Python
+weekly" — which is the reason for wanting a second run at all. Something pinned
+to a version another application depends on wants its own schedule, not the one
+that keeps everything else current:
+
+```powershell
+Register-UpdateEverythingTask -TaskName 'Update-Everything' -ExcludeTag Python -Cadence Daily
+Register-UpdateEverythingTask -TaskName 'Update-Everything-Python' -Tag Python -Cadence Weekly
+```
+
+`Get-UpdateEverythingTask` finds all of them, **by what they run rather than by
+what they are called**. A task renamed by hand is still this module's task, and a
+task called `Update-Everything` that runs something else is not — which matters,
+because removing it because of its name would be destructive.
 
 ### Developer tools
 

--- a/src/Private/Invoke-SetupChoice.ps1
+++ b/src/Private/Invoke-SetupChoice.ps1
@@ -39,25 +39,7 @@ function Invoke-SetupChoice {
                 -IncludePowerShellModules $false
         }
 
-        'ScheduledTask' {
-            Write-Host ''
-            if (Get-UpdateEverythingTask) {
-                Write-Host 'A scheduled task is already registered:' -ForegroundColor Yellow
-                Get-UpdateEverythingTask | Format-Table -AutoSize | Out-Host
-                Write-Host 'Use Register-UpdateEverythingTask to replace it, or Unregister-UpdateEverythingTask to remove it.' -ForegroundColor DarkGray
-                return
-            }
-
-            Write-Host 'Registering a weekly task that runs as you, elevated, with notifications.' -ForegroundColor Cyan
-            Write-Host 'Registering a scheduled task needs administrator rights.' -ForegroundColor DarkGray
-            Write-Host ''
-
-            try {
-                Register-UpdateEverythingTask -Cadence Weekly -Notify $true -ErrorAction Stop
-            } catch {
-                Write-Warning "Could not register the task: $($_.Exception.Message)"
-            }
-        }
+        'ScheduledTask' { Invoke-TaskSetup }
 
         'DeveloperTools' {
             $catalogue = @(Get-DeveloperToolCatalogue)

--- a/src/Private/Invoke-TaskSetup.ps1
+++ b/src/Private/Invoke-TaskSetup.ps1
@@ -1,0 +1,89 @@
+function Invoke-TaskSetup {
+    <#
+        .SYNOPSIS
+        The scheduled-task option of the setup menu.
+
+        .DESCRIPTION
+        Lists what is already registered and offers to add another, replace one,
+        or remove one.
+
+        Another *task*, not another trigger. Every trigger on a task runs the
+        same action, so two triggers cannot express "everything but Python
+        daily, only Python monthly" -- which is the reason for wanting a second
+        run at all. Something pinned to a version another application depends on
+        wants its own schedule, not the one that keeps everything else current.
+
+        Split out from Invoke-SetupChoice so the submenu can be tested on its
+        own.
+
+        .EXAMPLE
+        Invoke-TaskSetup
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of a console maintenance tool. This runs from an interactive menu, not inside a step.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Reached only from the setup menu, and every branch states what it will do and asks before doing it. Register and Unregister carry their own ShouldProcess.')]
+    [CmdletBinding()]
+    [OutputType([void])]
+    param()
+
+    $existing = @(Get-UpdateEverythingTask)
+
+    Write-Host ''
+    if (-not $existing.Count) {
+        Write-Host 'No scheduled task is registered yet.' -ForegroundColor Cyan
+        Write-Host 'Registering a weekly run, as you, elevated, with notifications.' -ForegroundColor Cyan
+        Write-Host 'This needs administrator rights.' -ForegroundColor DarkGray
+        Write-Host ''
+
+        try {
+            Register-UpdateEverythingTask -Cadence Weekly -Notify $true -ErrorAction Stop
+        } catch {
+            Write-Warning "Could not register the task: $($_.Exception.Message)"
+        }
+        return
+    }
+
+    Write-Host "$($existing.Count) task(s) already registered:" -ForegroundColor Cyan
+    for ($i = 0; $i -lt $existing.Count; $i++) {
+        $task = $existing[$i]
+        Write-Host ("  {0,2}. {1,-32} {2,-10} next {3}" -f ($i + 1), $task.TaskName, $task.State, $task.NextRun)
+    }
+
+    Write-Host ''
+    Write-Host '  1. Add another task, with its own schedule and its own steps'
+    Write-Host '  2. Replace one'
+    Write-Host '  3. Remove one'
+    Write-Host '  4. Back'
+    Write-Host ''
+
+    switch ((Read-Host 'Choose [1-4]').Trim()) {
+
+        '1' { New-TaskFromPrompt }
+
+        '2' {
+            $chosen = Select-TaskFromList -Task $existing -Prompt 'Replace which'
+            if (-not $chosen) { return }
+
+            Write-Host "Replacing '$($chosen.TaskName)'. Its current schedule and steps are discarded." -ForegroundColor Yellow
+            New-TaskFromPrompt -DefaultName $chosen.TaskName -Replace
+        }
+
+        '3' {
+            $chosen = Select-TaskFromList -Task $existing -Prompt 'Remove which'
+            if (-not $chosen) { return }
+
+            $answer = (Read-Host "Remove '$($chosen.TaskName)'? [y/N]").Trim()
+            if ($answer -notmatch '^(y|yes)$') {
+                Write-Host '  Left alone.' -ForegroundColor DarkGray
+                return
+            }
+
+            try {
+                Unregister-UpdateEverythingTask -TaskName $chosen.TaskName -TaskPath $chosen.TaskPath -Confirm:$false -ErrorAction Stop
+            } catch {
+                Write-Warning "Could not remove the task: $($_.Exception.Message)"
+            }
+        }
+
+        default { return }
+    }
+}

--- a/src/Private/New-TaskFromPrompt.ps1
+++ b/src/Private/New-TaskFromPrompt.ps1
@@ -1,0 +1,103 @@
+function New-TaskFromPrompt {
+    <#
+        .SYNOPSIS
+        Asks for a task's name, cadence and steps, then registers it.
+
+        .DESCRIPTION
+        The steps are the point. A second task exists because it runs with
+        different parameters: "everything but Python, daily" alongside "only
+        Python, weekly", for a toolchain something else depends on being held
+        steady. That is why this asks for tags rather than only a schedule.
+
+        Blank answers take the defaults, so a person who only wants a second
+        weekly run presses Enter four times.
+
+        .PARAMETER DefaultName
+        Offered as the default name. Replacing a task passes its current name.
+
+        .PARAMETER Replace
+        Overwrite a task of the same name rather than refusing.
+
+        .EXAMPLE
+        New-TaskFromPrompt
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of a console maintenance tool. This runs from an interactive menu, not inside a step.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Every value is asked for and echoed back before Register-UpdateEverythingTask is called, and that carries its own ShouldProcess.')]
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [string] $DefaultName,
+        [switch] $Replace
+    )
+
+    $tags = @('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python',
+              'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')
+
+    if (-not $DefaultName) {
+        # Update-Everything, then Update-Everything-2 and up. Named after what
+        # it is rather than after what it does, because what it does can change.
+        $taken = @(Get-UpdateEverythingTask).TaskName
+        $DefaultName = 'Update-Everything'
+        $n = 2
+        while ($taken -contains $DefaultName) {
+            $DefaultName = "Update-Everything-$n"
+            $n++
+        }
+    }
+
+    Write-Host ''
+    $name = (Read-Host "Task name [$DefaultName]").Trim()
+    if (-not $name) { $name = $DefaultName }
+
+    # PatchTuesday is deliberately not offered. It is a documented cadence and it
+    # cannot register: the monthly trigger is built as a client-only CIM instance
+    # that Register-ScheduledTask refuses. See issue #36. Offering a choice that
+    # fails would be worse than offering fewer.
+    $cadences = @('Daily', 'Weekly')
+
+    $cadence = (Read-Host 'Cadence: Daily or Weekly [Weekly]').Trim()
+    if (-not $cadence) { $cadence = 'Weekly' }
+    if ($cadence -notin $cadences) {
+        Write-Warning "'$cadence' is not one of: $($cadences -join ', '). Nothing was registered."
+        return
+    }
+
+    Write-Host ''
+    Write-Host "Steps are chosen by tag: $($tags -join ', ')" -ForegroundColor DarkGray
+    Write-Host 'Blank means every step.' -ForegroundColor DarkGray
+
+    $include = @((Read-Host 'Only these tags, comma separated [all]') -split ',' |
+        ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    $exclude = @((Read-Host 'Except these tags, comma separated [none]') -split ',' |
+        ForEach-Object { $_.Trim() } | Where-Object { $_ })
+
+    $unknown = @($include + $exclude | Where-Object { $_ -notin $tags })
+    if ($unknown.Count) {
+        Write-Warning "Not a tag: $($unknown -join ', '). Nothing was registered."
+        return
+    }
+
+    $describe = @("$cadence")
+    if ($include) { $describe += "only $($include -join ', ')" }
+    if ($exclude) { $describe += "excluding $($exclude -join ', ')" }
+
+    Write-Host ''
+    Write-Host "Registering '$name': $($describe -join ', ')." -ForegroundColor Cyan
+    Write-Host 'This needs administrator rights.' -ForegroundColor DarkGray
+
+    $arguments = @{
+        TaskName    = $name
+        Cadence     = $cadence
+        Notify      = $true
+        ErrorAction = 'Stop'
+    }
+    if ($include) { $arguments.Tag = $include }
+    if ($exclude) { $arguments.ExcludeTag = $exclude }
+    if ($Replace) { $arguments.Force = $true }
+
+    try {
+        Register-UpdateEverythingTask @arguments
+    } catch {
+        Write-Warning "Could not register the task: $($_.Exception.Message)"
+    }
+}

--- a/src/Private/Select-TaskFromList.ps1
+++ b/src/Private/Select-TaskFromList.ps1
@@ -1,0 +1,39 @@
+function Select-TaskFromList {
+    <#
+        .SYNOPSIS
+        Asks which of the listed tasks to act on, and returns it.
+
+        .DESCRIPTION
+        Returns nothing when the answer is blank or is not one of the numbers
+        shown, so a caller treats "no answer" and "bad answer" the same way:
+        do nothing. A menu that acted on a mistyped number would be worse than
+        one that asked again.
+
+        .EXAMPLE
+        Select-TaskFromList -Task $tasks -Prompt 'Remove which'
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of a console maintenance tool. This runs from an interactive menu, not inside a step.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]] $Task,
+
+        [Parameter(Mandatory)]
+        [string] $Prompt
+    )
+
+    if (-not $Task.Count) { return }
+
+    $answer = (Read-Host "$Prompt [1-$($Task.Count)], or blank to go back").Trim()
+    if (-not $answer) { return }
+
+    $index = 0
+    if (-not [int]::TryParse($answer, [ref] $index) -or $index -lt 1 -or $index -gt $Task.Count) {
+        Write-Host "  '$answer' is not one of the numbers listed." -ForegroundColor Yellow
+        return
+    }
+
+    $Task[$index - 1]
+}

--- a/src/Public/Get-UpdateEverythingTask.ps1
+++ b/src/Public/Get-UpdateEverythingTask.ps1
@@ -4,17 +4,29 @@ function Get-UpdateEverythingTask {
         Reports the registered Update-Everything scheduled task.
 
     .DESCRIPTION
-        Returns nothing when no such task exists, so it can be tested with an if.
+        With no -TaskName, returns every task on this machine that runs this
+        module, however it was named. One machine can carry several: a daily run
+        that skips a toolchain and a monthly one that updates only that
+        toolchain, which is what -Tag and -ExcludeTag are for.
+
+        They are found by what they run rather than by what they are called. A
+        task renamed by hand is still this module's task, and a task called
+        Update-Everything that runs something else is not.
+
+        Returns nothing when there are none, so it can be tested with an if.
         Needs no elevation.
 
     .PARAMETER TaskName
-        Name of the scheduled task. Default: Update-Everything.
+        One task, by exact name. Without it, every task that runs this module.
 
     .PARAMETER TaskPath
         Task Scheduler folder. Default: \ (the root).
 
     .EXAMPLE
         Get-UpdateEverythingTask
+
+    .EXAMPLE
+        Get-UpdateEverythingTask -TaskName 'Update-Everything-Python'
 
     .EXAMPLE
         if (-not (Get-UpdateEverythingTask)) { 'not scheduled' }
@@ -27,27 +39,46 @@ function Get-UpdateEverythingTask {
     [OutputType([pscustomobject])]
     param(
         [ValidateNotNullOrEmpty()]
-        [string] $TaskName = 'Update-Everything',
+        [string] $TaskName,
 
         [ValidateNotNullOrEmpty()]
         [string] $TaskPath = '\'
     )
 
-    $task = Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
-    if (-not $task) { return }
+    $tasks = if ($TaskName) {
+        @(Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue)
+    } else {
+        # Found by what they run, not by what they are called. Every task this
+        # module registers imports the module by manifest path and calls the
+        # function, so the arguments carry both.
+        @(Get-ScheduledTask -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.Actions | Where-Object {
+                    $_.Arguments -and $_.Arguments -match 'UpdateEverything\.psd1' -and
+                    $_.Arguments -match 'Update-Everything'
+                }
+            })
+    }
 
-    $info = Get-ScheduledTaskInfo -InputObject $task
+    foreach ($task in $tasks) {
+        if (-not $task) { continue }
 
-    [pscustomobject]@{
-        PSTypeName  = 'UpdateEverything.Task'
-        TaskName    = $task.TaskName
-        TaskPath    = $task.TaskPath
-        State       = [string] $task.State
-        RunsAs      = $task.Principal.UserId
-        RunLevel    = [string] $task.Principal.RunLevel
-        LogonType   = [string] $task.Principal.LogonType
-        Command     = ($task.Actions[0].Execute + ' ' + $task.Actions[0].Arguments).Trim()
-        LastRun     = Format-LastRunResult -LastRunTime $info.LastRunTime -LastTaskResult $info.LastTaskResult
-        NextRun     = $info.NextRunTime
+        # By name rather than -InputObject. -InputObject takes a CimInstance, so
+        # the task object has to survive a type conversion that a test cannot
+        # produce; the name and path identify it just as well.
+        $info = Get-ScheduledTaskInfo -TaskName $task.TaskName -TaskPath $task.TaskPath -ErrorAction SilentlyContinue
+
+        [pscustomobject]@{
+            PSTypeName  = 'UpdateEverything.Task'
+            TaskName    = $task.TaskName
+            TaskPath    = $task.TaskPath
+            State       = [string] $task.State
+            RunsAs      = $task.Principal.UserId
+            RunLevel    = [string] $task.Principal.RunLevel
+            LogonType   = [string] $task.Principal.LogonType
+            Command     = ($task.Actions[0].Execute + ' ' + $task.Actions[0].Arguments).Trim()
+            LastRun     = Format-LastRunResult -LastRunTime $info.LastRunTime -LastTaskResult $info.LastTaskResult
+            NextRun     = $info.NextRunTime
+        }
     }
 }

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -447,3 +447,199 @@ Describe 'Get-PowerShellHostPath' -Tag 'Unit' {
         Get-PowerShellHostPath | Should-MatchString 'powershell\.exe$'
     }
 }
+
+Describe 'Finding every task this module registered' -Tag 'Unit' {
+
+    # Found by what they run, not by what they are called. A machine can carry
+    # several: a daily run that skips a toolchain and a monthly one that updates
+    # only that toolchain, which is what -Tag and -ExcludeTag are for.
+
+    BeforeAll {
+        $script:MakeTask = {
+            param($Name, $Arguments)
+            [pscustomobject]@{
+                TaskName  = $Name
+                TaskPath  = '\'
+                State     = 'Ready'
+                Principal = [pscustomobject]@{ UserId = 'me'; RunLevel = 'Highest'; LogonType = 'Interactive' }
+                Actions   = @([pscustomobject]@{ Execute = 'pwsh.exe'; Arguments = $Arguments })
+            }
+        }
+
+        $script:Ours = "-NoProfile -Command `"Import-Module 'C:\M\UpdateEverything\1.0.0\UpdateEverything.psd1' -Force; exit (Update-Everything -Notify).FailedCount`""
+        $script:Theirs = '-NoProfile -Command "Write-Host hello"'
+    }
+
+    BeforeEach {
+        # Task Scheduler reports a never-run task with the 1899 sentinel rather
+        # than a null, and Format-LastRunResult takes a [datetime].
+        Mock Get-ScheduledTaskInfo {
+            [pscustomobject]@{
+                LastRunTime    = [datetime]'1899-12-30'
+                LastTaskResult = 267011
+                NextRunTime    = [datetime]'2026-09-07 03:00'
+            }
+        }
+    }
+
+    It 'returns every task that runs this module' {
+        Mock Get-ScheduledTask {
+            @(
+                & $script:MakeTask 'Update-Everything' $script:Ours
+                & $script:MakeTask 'Update-Everything-Python' $script:Ours
+            )
+        }
+
+        @(Get-UpdateEverythingTask) | Should-BeCollection -Count 2
+    }
+
+    # A task called Update-Everything that runs something else is not this
+    # module's, and removing it because of its name would be destructive.
+    It 'ignores a task that only shares the name' {
+        Mock Get-ScheduledTask {
+            @(& $script:MakeTask 'Update-Everything' $script:Theirs)
+        }
+
+        Get-UpdateEverythingTask | Should-BeNull
+    }
+
+    # A task renamed by hand is still this module's task.
+    It 'finds one that was renamed' {
+        Mock Get-ScheduledTask {
+            @(& $script:MakeTask 'Nightly maintenance' $script:Ours)
+        }
+
+        (Get-UpdateEverythingTask).TaskName | Should-Be 'Nightly maintenance'
+    }
+
+    It 'returns nothing when none are registered' {
+        Mock Get-ScheduledTask { @() }
+
+        Get-UpdateEverythingTask | Should-BeNull
+    }
+
+    It 'still takes one by exact name' {
+        Mock Get-ScheduledTask { @(& $script:MakeTask 'Update-Everything-Python' $script:Ours) } `
+            -ParameterFilter { $TaskName -eq 'Update-Everything-Python' }
+
+        (Get-UpdateEverythingTask -TaskName 'Update-Everything-Python').TaskName |
+            Should-Be 'Update-Everything-Python'
+    }
+}
+
+Describe 'Select-TaskFromList' -Tag 'Unit' {
+
+    BeforeAll {
+        $script:Two = @(
+            [pscustomobject]@{ TaskName = 'one' }
+            [pscustomobject]@{ TaskName = 'two' }
+        )
+    }
+
+    It 'returns the task at the number typed' {
+        Mock Read-Host { '2' }
+        (Select-TaskFromList -Task $script:Two -Prompt 'x').TaskName | Should-Be 'two'
+    }
+
+    It 'returns nothing for a blank answer' {
+        Mock Read-Host { '' }
+        Select-TaskFromList -Task $script:Two -Prompt 'x' | Should-BeNull
+    }
+
+    # Acting on a mistyped number would be worse than asking again.
+    It 'returns nothing for a number that is not listed' {
+        Mock Read-Host { '9' }
+        Mock Write-Host { }
+        Select-TaskFromList -Task $script:Two -Prompt 'x' | Should-BeNull
+    }
+
+    It 'returns nothing for an answer that is not a number' {
+        Mock Read-Host { 'both' }
+        Mock Write-Host { }
+        Select-TaskFromList -Task $script:Two -Prompt 'x' | Should-BeNull
+    }
+
+    It 'returns nothing when there is nothing to choose from' {
+        Select-TaskFromList -Task @() -Prompt 'x' | Should-BeNull
+    }
+}
+
+Describe 'Adding a second task' -Tag 'Unit' {
+
+    # A second task, not a second trigger. Every trigger on a task runs the same
+    # action, so two triggers cannot express "everything but Python daily, only
+    # Python monthly" -- which is the reason for wanting a second run at all.
+
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Register-UpdateEverythingTask { }
+        Mock Get-UpdateEverythingTask { @([pscustomobject]@{ TaskName = 'Update-Everything' }) }
+    }
+
+    It 'suggests a name that is not already taken' {
+        $script:answers = @('', '', '', '')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        New-TaskFromPrompt
+
+        Should-Invoke Register-UpdateEverythingTask -ParameterFilter { $TaskName -eq 'Update-Everything-2' }
+    }
+
+    It 'passes the tags through, which is the whole point of a second task' {
+        $script:answers = @('Update-Everything-Python', 'Daily', 'Python', '')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        New-TaskFromPrompt
+
+        Should-Invoke Register-UpdateEverythingTask -ParameterFilter {
+            $TaskName -eq 'Update-Everything-Python' -and $Cadence -eq 'Daily' -and $Tag -contains 'Python'
+        }
+    }
+
+    It 'passes an exclusion through' {
+        $script:answers = @('daily-task', 'Daily', '', 'Python')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        New-TaskFromPrompt
+
+        Should-Invoke Register-UpdateEverythingTask -ParameterFilter { $ExcludeTag -contains 'Python' }
+    }
+
+    # PatchTuesday is a real cadence of Register-UpdateEverythingTask and is not
+    # offered here, because it cannot register at all -- see issue #36. Catching
+    # it here turns a binding failure into a sentence.
+    It 'refuses a cadence it does not offer' {
+        $script:answers = @('x', 'PatchTuesday', '', '')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        New-TaskFromPrompt -WarningAction SilentlyContinue
+
+        Should-NotInvoke Register-UpdateEverythingTask
+    }
+
+    # A tag outside the set selects nothing, so the task would run an empty pass
+    # every month and report success.
+    It 'refuses a tag that is not a real tag' {
+        $script:answers = @('x', 'Weekly', 'Pythonn', '')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        New-TaskFromPrompt -WarningAction SilentlyContinue
+
+        Should-NotInvoke Register-UpdateEverythingTask
+    }
+
+    It 'replaces rather than refusing when told to' {
+        $script:answers = @('', 'Weekly', '', '')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+
+        New-TaskFromPrompt -DefaultName 'Update-Everything' -Replace
+
+        Should-Invoke Register-UpdateEverythingTask -ParameterFilter { $Force }
+    }
+}


### PR DESCRIPTION
Closes #20.

## Discovery

`Get-UpdateEverythingTask` took one task by exact name. It now returns **every**
task that runs this module, found by *what they run* rather than by what they are
called.

That direction matters: a task renamed by hand is still this module's task, and a
task called `Update-Everything` that runs something else is not. Getting it
backwards would have the menu offer to remove somebody else's task.

## The menu

Lists what is registered, then offers to add another, replace one, or remove one.

**Another task, not another trigger.** Every trigger on a task runs the same
action, so two triggers cannot express "everything but Python daily, only Python
weekly" — which is the reason for wanting a second run at all. That is why the
prompt asks for tags and not only a schedule.

Removing asks for confirmation by name, and a mistyped number selects nothing
rather than acting on the wrong task.

## Two things found by running it

**`Get-ScheduledTaskInfo -InputObject` takes a `CimInstance`**, which no test can
produce — three tests failed on the type conversion before reaching their
assertions. The lookup now goes by name and path: same answer, testable.

**`-Cadence PatchTuesday` cannot register a task at all**, on either edition:

```
Cannot bind argument to parameter 'Trigger', because PSTypeNames of the
argument do not match the PSTypeName required by the parameter:
Microsoft.Management.Infrastructure.CimInstance#MSFT_TaskTrigger.
```

That is a **pre-existing defect in shipped 1.0.0**, in code this PR does not
touch. The unit test never noticed because it asserts the trigger object's
properties — which are all correct — and never passes it to
`Register-ScheduledTask`. The bug lives in the join between two things that are
each fine.

Filed as #36 rather than patched here, because a real fix means registering from
XML or driving the COM API. I tried the type-name workaround three ways; it gets
past binding and then fails one layer deeper with a bare `Type mismatch`.

The menu offers **Daily and Weekly only**. Offering a cadence that fails would be
worse than offering fewer.

## Testing

640 tests, 0 failed (was 624). PSScriptAnalyzer clean over `src` under its
default rules.

Verified end to end against the real Task Scheduler — two tasks registered with
different steps, both found by discovery carrying their own arguments, both
removed again:

```
--- two tasks, different steps, the scenario #20 exists for ---
Registered '\UE-Test-Daily'.
Registered '\UE-Test-Python'.
--- discovery found ---
count: 2
  UE-Test-Daily    -ExcludeTag 'Python'
  UE-Test-Python   -Tag 'Python'
--- cleanup ---
remaining: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)