### PR TITLE
Point at the setup menu on the first run

### DIFF
--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -297,6 +297,13 @@
     $script:runStamp = '{0:yyyyMMdd-HHmmss}' -f (Get-Date)
     $mainLog  = Join-Path $logDir "Update-Everything-$runStamp.log"
 
+    # Asked before pruning and before the transcript is started, both of which
+    # would otherwise answer it wrongly: pruning can empty the directory on a
+    # machine that has simply not run in a while, and the transcript would find
+    # its own log and conclude the run had happened before.
+    $isFirstRun = -not @(Get-ChildItem -LiteralPath $logDir -Filter 'Update-Everything-*.log' `
+        -File -ErrorAction SilentlyContinue).Count
+
     # Step logs rotate per run rather than being appended to forever, so old ones
     # (and stale Terminal settings backups) are pruned by age instead.
     if ($LogRetentionDays -gt 0) {
@@ -1314,6 +1321,16 @@
         # unrequested one.
         Write-Host ''
         Write-Host 'Notifications: not requested. Pass -Notify for a toast when the run finishes.' -ForegroundColor DarkGray
+    }
+
+    # Said at the end rather than at the start: by here the run has shown what
+    # this machine has and has not, which is what makes the suggestion concrete.
+    # Once, and only on the first run -- a tool that repeats advice on every run
+    # teaches people to skim past its output.
+    if ($isFirstRun) {
+        Write-Host ''
+        Write-Host 'That was the first run on this machine. Initialize-UpdateEverything sets up a' -ForegroundColor Cyan
+        Write-Host 'schedule, installs the tools this then keeps updated, and asks before each one.' -ForegroundColor Cyan
     }
 
     Write-Host "Finished $(Get-Date). Detailed logs saved to: $logDir" -ForegroundColor Green

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2074,3 +2074,40 @@ Describe 'The setup menu loop' -Tag 'Unit' {
         Should-Invoke Invoke-SetupChoice -ParameterFilter { $Key -eq 'ScheduledTask' }
     }
 }
+
+Describe 'The first run points at the setup menu' -Tag 'Static' {
+
+    BeforeAll {
+        $script:FirstRunSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    It 'decides by looking for a previous transcript' {
+        $script:FirstRunSource | Should-MatchString "\`$isFirstRun = -not @\(Get-ChildItem"
+    }
+
+    # Both would answer it wrongly: pruning can empty the directory on a machine
+    # that has simply not run in a while, and the transcript would find its own
+    # log and conclude the run had happened before.
+    It 'asks before pruning and before the transcript starts' {
+        $decided = $script:FirstRunSource.IndexOf('$isFirstRun = -not')
+        $pruned  = $script:FirstRunSource.IndexOf('$cutoff = (Get-Date).AddDays')
+        $started = $script:FirstRunSource.IndexOf('Start-Transcript -Path $mainLog')
+
+        $decided | Should-BeGreaterThan -1
+        $decided | Should-BeLessThan $pruned
+        $decided | Should-BeLessThan $started
+    }
+
+    It 'names the command it is pointing at' {
+        $script:FirstRunSource | Should-MatchString 'Initialize-UpdateEverything sets up'
+    }
+
+    # A tool that repeats advice on every run teaches people to skim past its
+    # output, which costs more than the hint gains.
+    It 'says it once, and only when it is the first run' {
+        $mentions = [regex]::Matches($script:FirstRunSource, 'That was the first run')
+        $mentions.Count | Should-Be 1
+        $script:FirstRunSource | Should-MatchString 'if \(\$isFirstRun\)'
+    }
+}


### PR DESCRIPTION
Closes #22.

`Initialize-UpdateEverything` is only a feature to someone who read the README. A
first run now ends with one line naming it.

```
That was the first run on this machine. Initialize-UpdateEverything sets up a
schedule, installs the tools this then keeps updated, and asks before each one.
```

## Three decisions

**At the end, not the start.** By then the run has shown what this machine has
and has not, which is what makes the suggestion concrete rather than noise
before anything has happened.

**Once, and only on a first run.** A tool that repeats advice every run teaches
people to skim past its output, which costs more than the hint gains.

**Decided before pruning and before `Start-Transcript`.** Both would answer it
wrongly otherwise: pruning can empty the log directory on a machine that has
simply not run inside the retention window, and the transcript would find *its
own* log and conclude the run had happened before. A test asserts the ordering,
since it is the kind of thing a later edit moves without noticing.

## Testing

644 tests, 0 failed (was 640). PSScriptAnalyzer clean over `src` under its
default rules.

Verified against a real empty log directory rather than only in source:

```
--- run 1 in an empty log directory ---
That was the first run on this machine. Initialize-UpdateEverything sets up a
Finished 08/31/2026 18:00:22.

--- run 2, same directory ---
Finished 08/31/2026 18:00:25.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)