### PR TITLE
Make PatchTuesday able to register a task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -441,6 +441,12 @@ longer exists. Assert both ways.
   The suite fails until both exist.
 - New behaviour tested through the AST or a mock, not by running it. If testing
   it requires elevating, installing, or rebooting, it is being tested wrong.
+  The one exception is tagged `Integration`, and it exists because a mock cannot
+  catch a defect that lives *between* two things: `-Cadence PatchTuesday` shipped
+  in 1.0.0 unable to register a task at all, while the unit test asserting the
+  trigger object's properties passed, because nothing handed that object to
+  `Register-ScheduledTask`. Reach for this only when the failure is provably
+  invisible from either side, and leave the test able to skip when it cannot run.
 - No new `exit` in `src`, no `$ErrorActionPreference` in `src`, no empty
   `catch`.
 - Comments state facts about the code, not its history. The story of the change

--- a/src/Private/New-TaskFromPrompt.ps1
+++ b/src/Private/New-TaskFromPrompt.ps1
@@ -6,7 +6,7 @@ function New-TaskFromPrompt {
         .DESCRIPTION
         The steps are the point. A second task exists because it runs with
         different parameters: "everything but Python, daily" alongside "only
-        Python, weekly", for a toolchain something else depends on being held
+        Python, monthly", for a toolchain something else depends on being held
         steady. That is why this asks for tags rather than only a schedule.
 
         Blank answers take the defaults, so a person who only wants a second
@@ -49,13 +49,11 @@ function New-TaskFromPrompt {
     $name = (Read-Host "Task name [$DefaultName]").Trim()
     if (-not $name) { $name = $DefaultName }
 
-    # PatchTuesday is deliberately not offered. It is a documented cadence and it
-    # cannot register: the monthly trigger is built as a client-only CIM instance
-    # that Register-ScheduledTask refuses. See issue #36. Offering a choice that
-    # fails would be worse than offering fewer.
-    $cadences = @('Daily', 'Weekly')
+    # PatchTuesday is the monthly one: the third Wednesday, a week after
+    # Microsoft ships, so the patches have settled.
+    $cadences = @('Daily', 'Weekly', 'PatchTuesday')
 
-    $cadence = (Read-Host 'Cadence: Daily or Weekly [Weekly]').Trim()
+    $cadence = (Read-Host 'Cadence: Daily, Weekly, or PatchTuesday for monthly [Weekly]').Trim()
     if (-not $cadence) { $cadence = 'Weekly' }
     if ($cadence -notin $cadences) {
         Write-Warning "'$cadence' is not one of: $($cadences -join ', '). Nothing was registered."

--- a/src/Private/New-UpdateTaskTrigger.ps1
+++ b/src/Private/New-UpdateTaskTrigger.ps1
@@ -39,28 +39,23 @@
             return New-ScheduledTaskTrigger -Weekly -DaysOfWeek $DayOfWeek -At $At @extra
         }
         'PatchTuesday' {
-            # Third Wednesday of every month. Bitmasks, not names:
-            #   DaysOfWeek   Sunday=1, Monday=2, Tuesday=4, Wednesday=8, ...
-            #   WeeksOfMonth first=1, second=2, third=4, fourth=8
-            #   MonthsOfYear 4095 = all twelve
+            # A weekly trigger on the right weekday and time, which
+            # Register-UpdateEverythingTask converts to "the third Wednesday of
+            # every month" through Set-MonthlyDayOfWeekTrigger once the task
+            # exists.
+            #
+            # It is not built here because it cannot be. Register-ScheduledTask
+            # takes a CimInstance#MSFT_TaskTrigger, and a client-only
+            # MSFT_TaskMonthlyDOWTrigger is not one: it lacks the type name, and
+            # adding the name by hand passes binding only to fail a layer deeper
+            # with "Type mismatch". Rewriting the registered task's XML is the
+            # way through, and that needs a registered task.
             $start = Get-NthDayOfWeek -Year $At.Year -Month $At.Month `
                 -DayOfWeek ([System.DayOfWeek]::Wednesday) -Occurrence 3
             $start = $start.Date.Add($At.TimeOfDay)
 
-            $property = @{
-                DaysOfWeek    = 8
-                WeeksOfMonth  = 4
-                MonthsOfYear  = 4095
-                StartBoundary = $start.ToString('s')
-                Enabled       = $true
-            }
-            if ($RandomDelayMinutes -gt 0) {
-                # The CIM class wants an ISO 8601 duration.
-                $property['RandomDelay'] = 'PT{0}M' -f $RandomDelayMinutes
-            }
-
-            return New-CimInstance -ClassName MSFT_TaskMonthlyDOWTrigger `
-                -Namespace 'Root/Microsoft/Windows/TaskScheduler' -ClientOnly -Property $property
+            return New-ScheduledTaskTrigger -Weekly `
+                -DaysOfWeek ([System.DayOfWeek]::Wednesday) -At $start @extra
         }
     }
 }

--- a/src/Private/Set-MonthlyDayOfWeekTrigger.ps1
+++ b/src/Private/Set-MonthlyDayOfWeekTrigger.ps1
@@ -1,0 +1,74 @@
+function Set-MonthlyDayOfWeekTrigger {
+    <#
+        .SYNOPSIS
+        Converts a registered task's trigger to "the Nth <weekday> of every
+        month", by rewriting its XML.
+
+        .DESCRIPTION
+        Register-ScheduledTask has no way to accept a monthly day-of-week
+        trigger. New-ScheduledTaskTrigger offers Once, Daily, Weekly, Startup and
+        Logon and nothing else, and a client-only MSFT_TaskMonthlyDOWTrigger
+        built with New-CimInstance is refused: it carries no
+        CimInstance#MSFT_TaskTrigger type name, and inserting one by hand gets
+        past parameter binding only to fail a layer deeper with "Type mismatch".
+
+        So the task is registered with an ordinary weekly trigger first, and its
+        exported XML is rewritten and registered again. Task Scheduler accepts
+        from XML what the cmdlets cannot express.
+
+        The namespace is declared on the fragment rather than left to the parent.
+        Elements assigned through InnerXml do not inherit the document's default
+        namespace, and Task Scheduler rejects the result with "The task XML
+        contains an element or attribute from an unexpected namespace".
+
+        .PARAMETER Occurrence
+        Which one in the month: 1 to 4, or 5 for the last.
+
+        .EXAMPLE
+        Set-MonthlyDayOfWeekTrigger -TaskName Update-Everything -TaskPath '\' `
+            -Start (Get-Date '03:00') -DayOfWeek Wednesday -Occurrence 3
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Called only by Register-UpdateEverythingTask, immediately after it registered the task and inside its own ShouldProcess. A second confirmation for finishing one registration would be noise.')]
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $TaskName,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $TaskPath,
+        [Parameter(Mandatory)][datetime] $Start,
+        [Parameter(Mandatory)][System.DayOfWeek] $DayOfWeek,
+        [Parameter(Mandatory)][ValidateRange(1, 5)][int] $Occurrence,
+        [ValidateRange(0, 1440)][int] $RandomDelayMinutes = 0
+    )
+
+    $xml = [xml](Export-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath)
+    $uri = $xml.DocumentElement.NamespaceURI
+
+    $manager = New-Object System.Xml.XmlNamespaceManager($xml.NameTable)
+    $manager.AddNamespace('t', $uri)
+
+    $triggers = $xml.SelectSingleNode('//t:Triggers', $manager)
+    if (-not $triggers) { throw "The exported XML for '$TaskName' has no Triggers element." }
+
+    $months = (@('January', 'February', 'March', 'April', 'May', 'June', 'July',
+                 'August', 'September', 'October', 'November', 'December') |
+        ForEach-Object { "<$_ />" }) -join ''
+
+    # ISO 8601, the same form the CIM class wants. A [TimeSpan] rendered as
+    # "00:15:00" is rejected as incorrectly formatted.
+    $delay = if ($RandomDelayMinutes -gt 0) { "<RandomDelay>PT${RandomDelayMinutes}M</RandomDelay>" } else { '' }
+
+    $triggers.InnerXml =
+        "<CalendarTrigger xmlns='$uri'>" +
+        "<StartBoundary>$($Start.ToString('s'))</StartBoundary>" +
+        '<Enabled>true</Enabled>' +
+        '<ScheduleByMonthDayOfWeek>' +
+        "<Weeks><Week>$Occurrence</Week></Weeks>" +
+        "<DaysOfWeek><$DayOfWeek /></DaysOfWeek>" +
+        "<Months>$months</Months>" +
+        '</ScheduleByMonthDayOfWeek>' +
+        $delay +
+        '</CalendarTrigger>'
+
+    $null = Register-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath `
+        -Xml $xml.OuterXml -Force -ErrorAction Stop
+}

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -214,6 +214,16 @@
         -Force `
         -ErrorAction Stop
 
+    # The monthly cadence is finished here rather than in the trigger, because
+    # Register-ScheduledTask cannot be given a monthly day-of-week trigger at
+    # all. The task is registered weekly above and its XML rewritten now. See
+    # Set-MonthlyDayOfWeekTrigger for why that is the only way through.
+    if ($Cadence -eq 'PatchTuesday') {
+        Set-MonthlyDayOfWeekTrigger -TaskName $TaskName -TaskPath $TaskPath `
+            -Start $trigger.StartBoundary -DayOfWeek ([System.DayOfWeek]::Wednesday) `
+            -Occurrence 3 -RandomDelayMinutes $RandomDelayMinutes
+    }
+
     Write-Host ''
     Write-Host "Registered '$fullTaskName'." -ForegroundColor Green
     Write-Host "  Schedule : $(Get-CadenceDescription -Cadence $Cadence -DayOfWeek $DayOfWeek -At $At)"

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -131,27 +131,20 @@ Describe 'New-UpdateTaskTrigger' -Tag 'Unit' {
 
     Context 'PatchTuesday' {
 
-        # New-ScheduledTaskTrigger has no monthly parameter set, so this one is
-        # built from the CIM class by hand and is the most likely to break.
-        It 'builds a monthly day-of-week trigger' {
+        # This used to assert a hand-built MSFT_TaskMonthlyDOWTrigger, and every
+        # assertion passed while the cadence could not register a task at all:
+        # Register-ScheduledTask refuses a client-only instance of that class.
+        # The monthly shape is now asserted where it is actually applied, by the
+        # Integration tests at the end of this file.
+        It 'returns a trigger Register-ScheduledTask will accept' {
             $trigger = New-UpdateTaskTrigger -Cadence PatchTuesday -DayOfWeek Wednesday -At '12:00'
-            $trigger.CimClass.CimClassName | Should-Be 'MSFT_TaskMonthlyDOWTrigger'
+            $trigger.PSObject.TypeNames |
+                Should-ContainCollection 'Microsoft.Management.Infrastructure.CimInstance#MSFT_TaskTrigger'
         }
 
         It 'targets Wednesday' {
             $trigger = New-UpdateTaskTrigger -Cadence PatchTuesday -DayOfWeek Wednesday -At '12:00'
             $trigger.DaysOfWeek | Should-Be 8
-        }
-
-        It 'targets the third week' {
-            $trigger = New-UpdateTaskTrigger -Cadence PatchTuesday -DayOfWeek Wednesday -At '12:00'
-            # first=1, second=2, third=4, fourth=8
-            $trigger.WeeksOfMonth | Should-Be 4
-        }
-
-        It 'runs in every month of the year' {
-            $trigger = New-UpdateTaskTrigger -Cadence PatchTuesday -DayOfWeek Wednesday -At '12:00'
-            $trigger.MonthsOfYear | Should-Be 4095
         }
 
         It 'starts on a Wednesday' {
@@ -608,11 +601,11 @@ Describe 'Adding a second task' -Tag 'Unit' {
         Should-Invoke Register-UpdateEverythingTask -ParameterFilter { $ExcludeTag -contains 'Python' }
     }
 
-    # PatchTuesday is a real cadence of Register-UpdateEverythingTask and is not
-    # offered here, because it cannot register at all -- see issue #36. Catching
-    # it here turns a binding failure into a sentence.
+    # Monthly is the obvious guess and is not one of the names: the monthly
+    # cadence here is PatchTuesday. Catching it turns a binding failure into a
+    # sentence.
     It 'refuses a cadence it does not offer' {
-        $script:answers = @('x', 'PatchTuesday', '', '')
+        $script:answers = @('x', 'Monthly', '', '')
         $script:next = 0
         Mock Read-Host { $script:answers[$script:next++] }
 
@@ -641,5 +634,65 @@ Describe 'Adding a second task' -Tag 'Unit' {
         New-TaskFromPrompt -DefaultName 'Update-Everything' -Replace
 
         Should-Invoke Register-UpdateEverythingTask -ParameterFilter { $Force }
+    }
+}
+
+Describe 'Every cadence can actually register a task' -Tag 'Integration' {
+
+    # This registers real scheduled tasks and removes them again, which
+    # CONTRIBUTING otherwise rules out. The exception is documented there, and
+    # this is the case that earned it: PatchTuesday shipped in 1.0.0 unable to
+    # register at all, and every unit test passed the whole time.
+    #
+    # New-UpdateTaskTrigger's output was asserted and was correct. Nothing
+    # handed it to Register-ScheduledTask, which is the only place it was
+    # refused -- the bug lived in the join between two things that were each
+    # fine, and only a real registration crosses that join.
+
+    # BeforeDiscovery, not BeforeAll: -Skip: is evaluated while Pester is
+    # discovering tests, which is before any BeforeAll has run. Setting it there
+    # leaves $script:CanRegister null and skips the tests on a machine that could
+    # have run them.
+    BeforeDiscovery {
+        $script:CanRegister = ([Security.Principal.WindowsPrincipal] `
+            [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+                [Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+
+    BeforeAll {
+        $script:TestTaskName = 'UpdateEverything-PesterCadence'
+    }
+
+    AfterEach {
+        Unregister-ScheduledTask -TaskName $script:TestTaskName -Confirm:$false -ErrorAction SilentlyContinue
+    }
+
+    It 'registers a <_> task' -ForEach @('Daily', 'Weekly', 'PatchTuesday') -Skip:(-not $script:CanRegister) {
+        $cadence = $_
+
+        # Not wrapped in an assertion about throwing: if it throws, the test
+        # fails with the actual message, which is more use than "expected not to
+        # throw". This is how the cadence bug would have announced itself.
+        Register-UpdateEverythingTask -TaskName $script:TestTaskName -Cadence $cadence `
+            -Notify $false -Confirm:$false -ErrorAction Stop 6>$null | Out-Null
+
+        Get-ScheduledTask -TaskName $script:TestTaskName -ErrorAction SilentlyContinue |
+            Should-NotBeNull
+    }
+
+    # Week 3, Wednesday, all twelve months. Registering is not enough on its own:
+    # the weekly trigger it starts from would also register cleanly, and would
+    # then run every week instead of every month.
+    It 'gives PatchTuesday a monthly day-of-week trigger, not the weekly one it started as' -Skip:(-not $script:CanRegister) {
+        Register-UpdateEverythingTask -TaskName $script:TestTaskName -Cadence PatchTuesday `
+            -Notify $false -Confirm:$false -ErrorAction Stop 6>$null | Out-Null
+
+        $xml = [xml](Export-ScheduledTask -TaskName $script:TestTaskName)
+        $schedule = $xml.Task.Triggers.CalendarTrigger.ScheduleByMonthDayOfWeek
+
+        $schedule | Should-NotBeNull
+        $schedule.Weeks.Week | Should-Be '3'
+        @($schedule.DaysOfWeek.ChildNodes).Name | Should-Be 'Wednesday'
+        @($schedule.Months.ChildNodes) | Should-BeCollection -Count 12
     }
 }


### PR DESCRIPTION
Closes #36.

One of the three documented cadences had never worked, on either edition. Shipped
that way in 1.0.0.

```
Cannot bind argument to parameter 'Trigger', because PSTypeNames of the
argument do not match the PSTypeName required by the parameter:
Microsoft.Management.Infrastructure.CimInstance#MSFT_TaskTrigger.
```

## What does not work

`Register-ScheduledTask` takes a `CimInstance#MSFT_TaskTrigger`, and a
client-only `MSFT_TaskMonthlyDOWTrigger` is not one. Inserting the type name by
hand gets **past binding** and then fails a layer deeper with a bare `Type
mismatch`. Tried three ways:

| Attempt | Result |
|---|---|
| short `#MSFT_TaskTrigger` | binds, then `Type mismatch` |
| namespaced `#Root/.../MSFT_TaskTrigger` | does not bind |
| both | binds, then `Type mismatch` |

## What does

Task Scheduler accepts from XML what the cmdlets cannot express. The task is
registered with an ordinary weekly trigger on the right weekday and time, and
`Set-MonthlyDayOfWeekTrigger` rewrites its exported XML and registers it again.

One detail worth the comment it got: **the namespace is declared on the
fragment**, not left to the parent. Elements assigned through `InnerXml` do not
inherit the document's default namespace, and Task Scheduler answers that with
*"The task XML contains an element or attribute from an unexpected namespace"*.
That was the first attempt's failure.

## Why the tests missed it, and what changed

The unit test asserted the trigger's `DaysOfWeek`, `WeeksOfMonth` and
`MonthsOfYear`. All of it was correct. Nothing handed the object to
`Register-ScheduledTask`, which is the only place it was refused — **the defect
lived in the join between two things that were each fine.**

Those assertions are replaced by one that the trigger is a type
`Register-ScheduledTask` accepts, and the monthly shape is asserted where it is
actually applied: an `Integration`-tagged test that registers a real task, reads
its XML back, and removes it.

That is the exception CONTRIBUTING otherwise rules out, so the exception is now
written down there with this as the case that earned it.

**Also fixed in those tests:** `-Skip:` is evaluated during *discovery*, before
any `BeforeAll` runs, so computing the condition in `BeforeAll` left it null and
skipped all four on a machine that could have run them. It is in
`BeforeDiscovery` now — caught because the first run reported `Skipped: 4` on an
elevated session.

## Testing

647 tests, 0 failed (was 644). PSScriptAnalyzer clean over `src` under its
default rules. No leftover scheduled tasks after the run.

All three cadences registered against the real Task Scheduler:

```
Daily          OK   CalendarTrigger
Weekly         OK   CalendarTrigger
PatchTuesday   OK   week 3, Wednesday, months 12
```

## Note

The cadence is called PatchTuesday and fires on the **third Wednesday** — a week
after Microsoft ships, so patches have settled. That is deliberate and was
already commented, but the name still misleads. Worth renaming or documenting
where a user sees it; not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)