### PR TITLE
Stop a caller's ErrorActionPreference from failing a step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,17 @@ session, which is not the module's to change. `Install.ps1`, `Publish.ps1` and
 `test.ps1` do set it, because they own their session. The pre-PR checklist
 rejects it in `src`.
 
+`Invoke-Step` is the one exception, and it runs the other way: it sets
+`Continue`, **function-locally**, before invoking a step action. A caller who
+prefers `Stop` makes a native command's stderr terminating, and these steps drive
+tools that write to stderr as a matter of course — npm its deprecation notices,
+winget its progress, `wsl` its "not installed" message. Each such step then threw
+before reaching the exit-code check written to handle precisely that, so the
+run's result depended on a preference set outside it. A function-local assignment
+cannot reach the caller's session, which is what the rule protects; a `global:`
+or `script:` one can, and a separate test rejects those everywhere including
+there.
+
 **`Set-StrictMode -Version Latest` — not in the module.** It makes reading a
 missing property fatal, and the module has to probe for optional keys in
 Windows Terminal's `settings.json`, where they are frequently absent. Turning

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -60,6 +60,19 @@
     Write-StepLog -Path $stepLog -Message "STARTING $Name"
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
 
+    # Function-local, so the caller's session is untouched -- which is the point
+    # of the rule against setting this in a module, and is not what this does.
+    #
+    # A caller that prefers Stop makes a native command's stderr terminating, and
+    # most of these steps drive tools that write to stderr as a matter of course:
+    # npm its deprecation notices, winget its progress, wsl its "not installed"
+    # message. Every one of those steps then throws before reaching the exit-code
+    # check written to handle exactly that case, so the run's result depends on a
+    # preference set outside it.
+    #
+    # Non-terminating errors still reach $stepOutput and are still counted below.
+    $ErrorActionPreference = 'Continue'
+
     try {
         # Reset so a cmdlet-only step can't inherit a stale exit code from an earlier native command
         $global:LASTEXITCODE = 0

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -246,7 +246,17 @@ Describe 'Module source layout' -Tag 'Static','Module' {
     # scope whether or not that was wanted. The per-call -ErrorAction Stop next to
     # the try/catch is the version that only affects the call it is on.
     # Install.ps1, Publish.ps1 and test.ps1 do set it. They own their session.
+    #
+    # Invoke-Step is the documented exception, and only for a function-local
+    # assignment. It sets Continue before invoking a step action, in the other
+    # direction: a caller that prefers Stop makes a native command's stderr
+    # terminating, and most steps drive tools that write to stderr routinely, so
+    # each would throw before reaching the exit-code check written to handle it.
+    # A function-local assignment cannot reach the caller's session, which is what
+    # this rule protects.
     It 'never assigns $ErrorActionPreference, which belongs to the caller' {
+        $localAllowed = 'Invoke-Step.ps1'
+
         $offenders = foreach ($file in Get-ChildItem (Join-Path $script:ModuleRoot 'Public'), (Join-Path $script:ModuleRoot 'Private') -Filter *.ps1) {
             $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref] $null, [ref] $null)
             foreach ($assignment in $ast.FindAll({
@@ -255,11 +265,33 @@ Describe 'Module source layout' -Tag 'Static','Module' {
                         $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
                         $node.Left.VariablePath.UserPath -match '^(global:|script:)?ErrorActionPreference$'
                     }, $true)) {
+
+                $scoped = $assignment.Left.VariablePath.UserPath -match '^(global:|script:)'
+                if (-not $scoped -and $file.Name -eq $localAllowed) { continue }
+
                 "$($file.Name):$($assignment.Extent.StartLineNumber)"
             }
         }
 
         $offenders | Should-BeNull -Because "these change the importing session's preference:`n$($offenders -join "`n")"
+    }
+
+    # The allowance above is for a function-local assignment only. A global: or
+    # script: one leaks to the caller wherever it is written, including here.
+    It 'never assigns it at global or script scope, not even where local is allowed' {
+        $offenders = foreach ($file in Get-ChildItem (Join-Path $script:ModuleRoot 'Public'), (Join-Path $script:ModuleRoot 'Private') -Filter *.ps1) {
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref] $null, [ref] $null)
+            foreach ($assignment in $ast.FindAll({
+                        param($node)
+                        $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                        $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                        $node.Left.VariablePath.UserPath -match '^(global:|script:)ErrorActionPreference$'
+                    }, $true)) {
+                "$($file.Name):$($assignment.Extent.StartLineNumber)"
+            }
+        }
+
+        $offenders | Should-BeNull
     }
 
     # A catch that swallows in silence is indistinguishable from one that never

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2111,3 +2111,67 @@ Describe 'The first run points at the setup menu' -Tag 'Static' {
         $script:FirstRunSource | Should-MatchString 'if \(\$isFirstRun\)'
     }
 }
+
+Describe 'A step survives a caller who prefers Stop' -Tag 'Unit' {
+
+    # Found by the fresh-machine smoke test, which is the first thing to run this
+    # module from a session that sets ErrorActionPreference = Stop, on a machine
+    # where WSL genuinely is not installed:
+    #
+    #   PS>TerminatingError(wsl.exe): "...ErrorActionPreference... is set to
+    #   Stop: The Windows Subsystem for Linux is not installed."
+    #   WARNING: FAILED: WSL kernel
+    #
+    # The step is written to handle exactly that machine and never got the
+    # chance: wsl writes to stderr, Stop makes a native command's stderr
+    # terminating, and the throw beat the exit-code check. npm, winget and dotnet
+    # all write to stderr routinely, so this was never only about WSL.
+
+    BeforeEach {
+        $script:logDir = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $null = New-Item -ItemType Directory -Path $script:logDir -Force
+        $script:runStamp = 'eap'
+        $script:isAdmin = $true
+        $script:Results = [System.Collections.Generic.List[object]]::new()
+        $script:TagFilter = @()
+        $script:ExcludeTagFilter = @()
+    }
+
+    It 'reports a native command by its exit code, not by its stderr' {
+        $ErrorActionPreference = 'Stop'
+
+        Invoke-Step -Name 'noisy' -Action {
+            & cmd.exe /c 'echo something on stderr 1>&2 & exit 0'
+        } 6>$null
+
+        $script:Results[0].Status | Should-Be 'OK'
+    }
+
+    It 'still fails a step whose command exits non-zero' {
+        $ErrorActionPreference = 'Stop'
+
+        Invoke-Step -Name 'broken' -Action {
+            & cmd.exe /c 'echo bad 1>&2 & exit 3'
+        } 6>$null
+
+        $script:Results[0].Status | Should-Be 'Failed'
+    }
+
+    # The preference is set inside Invoke-Step's own scope. If it leaked, the
+    # caller would silently stop getting terminating errors it asked for.
+    It 'leaves the caller preference alone' {
+        $ErrorActionPreference = 'Stop'
+
+        Invoke-Step -Name 'quiet' -Action { 'x' } 6>$null
+
+        $ErrorActionPreference | Should-Be 'Stop'
+    }
+
+    It 'still counts a PowerShell error record as a warning' {
+        $ErrorActionPreference = 'Stop'
+
+        Invoke-Step -Name 'writes-error' -Action { Write-Error 'a real one' } 6>$null
+
+        $script:Results[0].Status | Should-Be 'Warning'
+    }
+}


### PR DESCRIPTION
Closes #40.

Found by the fresh-machine smoke test — the first thing to run this module from a
session that sets `$ErrorActionPreference = 'Stop'`, on a machine where WSL
genuinely is not installed:

```
=== STARTING: WSL kernel ===
PS>TerminatingError(wsl.exe): "...ErrorActionPreference... is set to Stop:
The Windows Subsystem for Linux is not installed."
WARNING: FAILED: WSL kernel
```

The step is written to handle exactly that machine:

```powershell
wsl --status
if ($LASTEXITCODE -ne 0) {
    $global:LASTEXITCODE = 0
    Write-Output 'wsl.exe is present but WSL is not installed or enabled; skipping.'
    return
}
```

It never got the chance. `wsl` writes to stderr, `Stop` makes a native command's
stderr *terminating*, and the throw beat the exit-code check.

## It was never only about WSL

npm writes deprecation notices to stderr as a matter of course, winget writes
progress there, `dotnet --version` writes its error there when there is no SDK.
Every one of those steps checks its exit code carefully, and **none of those
checks ran if the caller happened to prefer `Stop`** — a common thing to have in
a profile. The result of a run depended on a preference set outside it.

## The fix

`Invoke-Step` sets `Continue` as a **function-local** variable before invoking
the action.

That is not what the rule against setting this in a module forbids. The rule
protects the *caller's* session, and a function-local assignment cannot reach it
— which is now enforced rather than trusted: the existing guard allows a local
assignment in that one file, and **a second test rejects `global:` and `script:`
everywhere, including there**.

Non-terminating errors still reach `$stepOutput` and are still counted, so a
`Write-Error` in a step still reports `Warning`. There is a test for that too,
since it is the thing this change could plausibly have broken.

## Testing

652 tests, 0 failed (was 647). PSScriptAnalyzer clean over `src` under its
default rules.

Four new tests drive a real native command that writes to stderr, with
`ErrorActionPreference = 'Stop'` set in the enclosing scope: exit 0 reports `OK`,
exit 3 still reports `Failed`, the caller's preference is unchanged afterwards,
and a `Write-Error` still reports `Warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)