### PR TITLE
Let the sandbox shut itself down, so the next run can start

### DIFF
--- a/tests/FreshMachine/Invoke-FreshMachineTest.ps1
+++ b/tests/FreshMachine/Invoke-FreshMachineTest.ps1
@@ -91,8 +91,46 @@ function Close-Sandbox {
     $running = @(Get-Process -Name $script:SandboxProcessNames -ErrorAction SilentlyContinue)
     if ($running.Count -eq 0) { return }
 
-    $running | Stop-Process -Force -ErrorAction SilentlyContinue
+    Stop-SandboxProcess -Process $running
     Write-Host 'Sandbox closed.' -ForegroundColor DarkGray
+}
+
+function Stop-SandboxProcess {
+    <#
+        Waits for the sandbox to finish shutting itself down, and forces it
+        only if it does not.
+
+        The harness shuts the guest down when it has written its results, which
+        is the only clean way to close a sandbox: the host's session processes
+        have no main window, so there is nothing to ask politely from out here.
+
+        Forcing skips the shutdown, and vmmemWindowsSandbox then holds the
+        virtual machine's memory for as long as it likes -- measured at 26
+        minutes and 807MB on this machine, with no session process left to
+        explain it. The next run either waits for that or starts into it and
+        hangs, which is how this harness spent an evening failing for reasons
+        that had nothing to do with the module.
+    #>
+    param([Parameter(Mandatory)][object[]] $Process)
+
+    # No CloseMainWindow: these processes have no main window, so it does nothing
+    # and reports nothing. The sandbox shuts itself down instead, from inside, at
+    # the end of Start-Harness.ps1 -- which is the only clean way to close one and
+    # the only way its memory is released promptly. This waits for that to finish.
+    #
+    # A guest shutdown takes longer than it looks: the session processes on the
+    # host outlive it by a while. 60s was not enough and reported forcing on runs
+    # that had shut down cleanly.
+    $deadline = (Get-Date).AddSeconds(150)
+    while ((Get-Date) -lt $deadline) {
+        if (-not @(Get-Process -Name $script:SandboxProcessNames -ErrorAction SilentlyContinue).Count) { return }
+        Start-Sleep -Seconds 2
+    }
+
+    Write-Host '  the sandbox has not finished shutting down; forcing it.' -ForegroundColor DarkYellow
+    Write-Host '  the next run may have to wait for its memory to be released.' -ForegroundColor DarkYellow
+    Get-Process -Name $script:SandboxProcessNames -ErrorAction SilentlyContinue |
+        Stop-Process -Force -ErrorAction SilentlyContinue
 }
 
 $repoRoot   = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
@@ -146,8 +184,7 @@ $alreadyRunning = @(Get-Process -Name $script:SandboxProcessNames -ErrorAction S
 if ($alreadyRunning.Count -gt 0) {
     if ($CloseExistingSandbox) {
         Write-Host '  closing the sandbox that is already open...' -ForegroundColor DarkGray
-        $alreadyRunning | Stop-Process -Force -ErrorAction SilentlyContinue
-        Start-Sleep -Seconds 5
+        Stop-SandboxProcess -Process $alreadyRunning
         $stillThere = @(Get-Process -Name $script:SandboxProcessNames -ErrorAction SilentlyContinue)
         if ($stillThere.Count -gt 0) {
             $problems.Add('A Windows Sandbox is still running after being asked to close.')
@@ -156,6 +193,42 @@ if ($alreadyRunning.Count -gt 0) {
         $problems.Add(
             'A Windows Sandbox is already running, and Windows allows only one. ' +
             'Close it and try again, or pass -CloseExistingSandbox.')
+    }
+}
+
+# Then wait for the previous sandbox's memory to be released.
+#
+# The session processes going away is not the end of a sandbox.
+# vmmemWindowsSandbox holds the virtual machine's memory and the hypervisor
+# reclaims it on its own schedule, over a minute or more. Start a new sandbox
+# while that is still happening and it starts -- processes appear, no error --
+# and then never runs its logon command, so the run waits out its whole timeout
+# and reports a failure that belongs to the timing rather than to the module.
+#
+# Measured: two runs on one machine, 2m31s apart. The first passed. The second
+# left WindowsSandboxServer and WindowsSandboxRemoteSession alive for 25 minutes
+# with no logon breadcrumb written.
+#
+# vmmemWindowsSandbox by name, and never a bare vmmem: that one belongs to WSL
+# on any machine that has it, and waiting for it would wait forever.
+if (-not $problems.Count) {
+    $settleDeadline = (Get-Date).AddSeconds(180)
+    $announced = $false
+
+    while (@(Get-Process -Name 'vmmemWindowsSandbox' -ErrorAction SilentlyContinue).Count -gt 0) {
+        if ((Get-Date) -ge $settleDeadline) {
+            $problems.Add(
+                'A previous Windows Sandbox is still releasing its memory (vmmemWindowsSandbox) ' +
+                'after 3 minutes. Starting now would produce a sandbox that never runs its logon ' +
+                'command. Wait for it to finish, or reboot.')
+            break
+        }
+
+        if (-not $announced) {
+            Write-Host '  waiting for the previous sandbox to release its memory...' -ForegroundColor DarkGray
+            $announced = $true
+        }
+        Start-Sleep -Seconds 5
     }
 }
 

--- a/tests/FreshMachine/README.md
+++ b/tests/FreshMachine/README.md
@@ -86,6 +86,28 @@ The harness leaves `EnableLUA` at `1` and sets `ConsentPromptBehaviorAdmin` to
 passes, and the child starts with nobody at the keyboard. This happens inside
 the sandbox and is discarded with it; the host is untouched.
 
+## One at a time, with a gap
+
+Windows runs one sandbox at a time, and starting a second does nothing at all —
+no window, no error, no clue. The launcher refuses to start when one is already
+open, and `-CloseExistingSandbox` closes it first.
+
+Closing is not the end of it. `vmmemWindowsSandbox` holds the virtual machine's
+memory and the hypervisor reclaims it on its own schedule, over a minute or more
+after the session processes are gone. **A sandbox started during that window
+starts and then never runs its logon command** — processes appear, nothing is
+written to the mapped folder, and the run waits out its whole timeout reporting a
+failure that belongs to the timing.
+
+Measured here: two runs 2m31s apart. The first passed. The second left
+`WindowsSandboxServer` and `WindowsSandboxRemoteSession` alive for twenty-five
+minutes without writing `logon.txt`.
+
+So the launcher waits for `vmmemWindowsSandbox` to go before it starts, up to
+three minutes, and says why if it does not. It waits on that name and never on a
+bare `vmmem`, which belongs to WSL on any machine that has it and would never
+clear.
+
 ## Prerequisites
 
 Checked before anything is created, each with what to do about it:

--- a/tests/FreshMachine/Sandbox/Start-Harness.ps1
+++ b/tests/FreshMachine/Sandbox/Start-Harness.ps1
@@ -291,3 +291,17 @@ if ($failed.Count -gt 0) {
     [System.Text.UTF8Encoding]::new($false))
 
 Stop-Transcript | Out-Null
+
+# Shut the sandbox down from inside, which is the only clean way to close one.
+#
+# The host cannot: the session processes have no main window to close, so
+# CloseMainWindow does nothing and Stop-Process -Force is what is left. Forcing
+# skips the shutdown and vmmemWindowsSandbox then holds the virtual machine's
+# memory for as long as it likes -- measured at 26 minutes here -- which blocks
+# the next run.
+#
+# Everything above is already written to the mapped folder, which is host disk,
+# and the transcript is stopped. The delay is for the writes to land, not for
+# anything still to happen.
+Start-Sleep -Seconds 3
+Start-Process -FilePath 'shutdown.exe' -ArgumentList '/s', '/t', '0' -WindowStyle Hidden


### PR DESCRIPTION
Closes #24.

The launcher failed on repeat attempts, and the reason had nothing to do with the
sandbox configuration — which is where the search had been looking all evening.

## What is actually wrong

Windows Sandbox has **no clean shutdown from the host**. The session processes
carry no main window, so `CloseMainWindow` does nothing and `Stop-Process -Force`
is what remains.

Forcing skips the guest shutdown, and `vmmemWindowsSandbox` then holds the
virtual machine's memory indefinitely — **measured at 26 minutes and 807MB**,
with no session process left to explain it:

```
vmmemWindowsSandbox  pid 31064  started 18:18:38  age 26 min  807 MB
WindowsSandbox*      none
```

A sandbox started during that window *starts* — processes appear, no error — and
never runs its logon command. The run then waits out its whole timeout and
reports a failure belonging to the timing.

## The fix

**The harness shuts the guest down itself** once results are written. That is the
only clean way to close a sandbox, and memory is released immediately instead of
held.

The launcher also waits for a previous sandbox's memory before starting, and says
so rather than starting into it. It waits on `vmmemWindowsSandbox` **by name and
never on a bare `vmmem`** — that one belongs to WSL on any machine that has it,
and waiting for it would wait forever. On this machine it has been running since
the previous day.

## The earlier theory was wrong in both directions

This issue was filed saying Sandbox had been degraded by force-kills and needed a
reboot. Two runs on one boot, 2m31s apart: **the first passed, the second hung.**
So neither a reboot nor a degraded machine explained it.

Worse, a reboot *would have appeared to fix it* — rebooting releases the pinned
memory. That would have closed this issue on a coincidence.

## Verified by the thing that had never worked

Two consecutive runs, both passed, both `FailedCount=0`, with
`vmmemWindowsSandbox` gone immediately after each:

```
=== RUN A ===                          === RUN B, immediately after ===
FailedCount=0                          FailedCount=0
Fresh-machine test passed.             Fresh-machine test passed.
3 check(s) could not run                3 check(s) could not run

vmmemWindowsSandbox: gone already
```

That `FailedCount=0` is worth its own note: it was **1** before, from the WSL step
failing on a machine without WSL. That is #40, which this harness found and which
no development machine could have shown — which is the entire argument for the
harness existing.

## Testing

652 tests, 0 failed. Launcher and harness lint clean against the repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)