### PR TITLE
Prepare 1.1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -497,5 +497,8 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.0.0 -m "1.0.0" && git push origin v1.0.0
+git tag -a v1.1.0 -m "1.1.0" && git push origin v1.1.0
 ```
+
+Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so
+one text serves the manifest, the gallery page and the release.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ into your own module path. No elevation, and it prints what it exported. Add
 `-Force` is in the command because the module installs into a folder named for
 its version, and the installer refuses to overwrite one that is already there.
 The version does not change with every commit, so a second install from `main`
-is an overwrite of `1.0.0` by `1.0.0` and stops without it. On a first install
+is an overwrite of a version by the same version, and stops without it. On a first install
 it does nothing; on every one after, it is what makes the line safe to paste
 again. Nothing is lost if it is interrupted: the installer stages the new copy
 and validates it before it replaces the old one.

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.0.0'
+    ModuleVersion     = '1.1.0'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -32,45 +32,56 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.0.0
+            ReleaseNotes = '# 1.1.0
 
-First release. Updates a Windows machine through every package manager and
-update channel it can find, running each as an isolated step so one failure
-does not stop the rest.
+Adds a setup menu, step selection by tag, and an inventory of what the machine
+actually has. Fixes three defects that shipped in 1.0.0.
 
-## Commands
+## Fixed
 
-* Update-Everything runs the update pass and returns a result object rather
-  than exiting, so calling it from a session does not end that session. A
-  scheduled task turns FailedCount into an exit code itself.
-* Register-UpdateEverythingTask, Get-UpdateEverythingTask and
-  Unregister-UpdateEverythingTask manage the scheduled task.
-* Test-PendingReboot reports whether Windows is waiting on a restart, and names
-  what is holding it.
+* -Cadence PatchTuesday could not register a task at all, on either edition.
+  Register-ScheduledTask will not accept a client-only monthly trigger, so the
+  task is now registered and its XML rewritten.
+* A caller whose session set $ErrorActionPreference to Stop got failed steps
+  from tools that write to stderr as a matter of course -- npm, winget, wsl.
+  Each step threw before reaching the exit-code check written to handle it.
+* The gallery tooling (NuGet provider, PowerShellGet, PSResourceGet) was
+  installed when missing and then never brought forward.
 
-## Consent
+## Selecting steps
 
-Nothing is installed for the first time without permission. -AllowInstall
-approves in advance; an interactive run asks and defaults to No; a
-non-interactive run declines and reports the step as skipped.
+-Tag and -ExcludeTag narrow a run. Both are accepted by
+Register-UpdateEverythingTask, so one machine can carry a daily task that skips
+a toolchain and a monthly one that updates only it -- for something pinned to a
+version another application depends on.
 
-## Running unelevated
+Tags: Windows, Microsoft, PowerShell, PackageManager, Python, Node, DotNet,
+Rust, Git, Self, Inventory.
 
-Elevation is checked before it is requested, so a standard user, a machine with
-UAC switched off, or an MSIX PowerShell that Windows will not run elevated each
-get an explanation instead of a UAC prompt that cannot succeed. -SkipElevation
-runs the steps that do not need administrator rights. Logging starts before the
-elevation decision, so a run that declines to start still leaves a log.
+## Initialize-UpdateEverything
 
-## Also in this release
+A setup menu: prerequisites, scheduled task, developer tools, or a full first
+run. Typed numbers, no new dependency. A first run now says it exists.
 
-* Optional toast notifications through BurntToast, including an urgent restart
-  notice that breaks through Focus Assist.
-* -UpdateSelf reinstalls the module from the main branch on GitHub.
-* Per-run step logs and transcripts, pruned by -LogRetentionDays.
-* Windows PowerShell 5.1 and PowerShell 7 are both supported. Parameters absent
-  from the PowerShellGet 1.0.0.1 that Windows ships are probed rather than
-  assumed.
+The developer-tools catalogue is the one exception to "this module updates, it
+does not install", and it is reachable only from the menu. -AllowInstall All
+does not reach it: All approves the components a run needs, and widening it to a
+dozen developer tools would turn an unattended task into a provisioning job.
+
+## Reporting
+
+* An Inventory step reports what is installed, at what version, and who owns it,
+  so a first run is not an unexplained column of skips. -Tag Inventory reports
+  and updates nothing.
+* The module pass says what moved rather than only that it finished.
+* Get-UpdateEverythingTask returns every task that runs this module, found by
+  what they run rather than by what they are called.
+
+## Also
+
+* -IncludePowerShellModules turns the module pass off.
+* -UpdateSelfSource takes Gallery or Main, and defaults to Gallery.
+* A package manager now runs before the toolchains it may own.
 '
         }
     }


### PR DESCRIPTION
Version raised to 1.1.0, and `ReleaseNotes` rewritten to describe *this* version.

```
UpdateEverything 1.1.0
Already on PSGallery at version 1.0.0.
All checks passed.

Staged UpdateEverything 1.1.0 — Files: 57
  Exports: Update-Everything, Initialize-UpdateEverything,
           Register-UpdateEverythingTask, Unregister-UpdateEverythingTask,
           Get-UpdateEverythingTask, Test-PendingReboot
```

## Also de-versioned two references that would age

The README explained `-Force` with *"an overwrite of `1.0.0` by `1.0.0`"* —
which stops being true at this release and says nothing the sentence needs.
CONTRIBUTING's tag example moves with the release it describes, and now also says
to reuse the manifest's notes for the GitHub release, so one text serves the
manifest, the gallery page and the release.

## Testing

652 tests, 0 failed. `Publish.ps1 -WhatIf` green.

The fresh-machine smoke test runs against `main` rather than a branch, so it
comes after this merges and before the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)