### PR TITLE
Say which version is running, and whether the gallery is ahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,26 @@ Update-Everything -Tag Python
 Update-Everything -ExcludeTag Python
 ```
 
+Every run opens by naming the version that produced it, so a transcript can be
+read against the code that made it:
+
+```
+Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
+UpdateEverything 1.2.0
+```
+
+The Inventory step then compares that against the gallery:
+
+```
+UpdateEverything 1.2.0 is running, which is the newest published version.
+```
+
+The comparison lives there rather than in the banner because it costs a network
+call, and `-ExcludeTag Inventory` turns it off for a scheduled run that does not
+want one. A gallery it could not reach says so rather than claiming currency, and
+a copy installed from GitHub — which is often *ahead* of the gallery — is never
+called out of date.
+
 `-Tag Inventory` reports what the machine has and updates nothing, which is the
 quickest way to see why a run skipped what it skipped:
 

--- a/src/Private/Format-SelfVersionStatus.ps1
+++ b/src/Private/Format-SelfVersionStatus.ps1
@@ -1,0 +1,62 @@
+function Format-SelfVersionStatus {
+    <#
+        .SYNOPSIS
+        One line saying how the running version compares to the published one.
+
+        .DESCRIPTION
+        The version that matters is the one *running*, which is not always the
+        highest installed: a session imported by path, or one that loaded before
+        an update replaced the files on disk, is running something else. So the
+        running version is passed in rather than looked up.
+
+        Three answers must not be confused with each other, and each has been a
+        wrong message somewhere before:
+
+          behind          the gallery is ahead, and -UpdateSelf will fetch it
+          ahead / equal   nothing to do
+          cannot tell     the gallery was not reachable
+
+        A copy PowerShellGet did not install -- one the GitHub installer placed,
+        for instance -- is frequently *ahead* of the gallery rather than behind,
+        so it is named separately and never called out of date.
+
+        .PARAMETER Running
+        The version of the module actually executing.
+
+        .PARAMETER Status
+        Get-GalleryModuleStatus output, or $null when it was not asked.
+
+        .EXAMPLE
+        Format-SelfVersionStatus -Running '1.1.0' -Status (Get-GalleryModuleStatus -Name UpdateEverything)
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [version] $Running,
+
+        [object] $Status
+    )
+
+    if (-not $Status -or -not $Status.Available) {
+        return "UpdateEverything $Running is running; the gallery could not be asked for a newer version."
+    }
+
+    $available = [version] $Status.Available
+
+    if ($Running -lt $available) {
+        $how = if ($Status.Installed -and -not $Status.Updatable) {
+            'This copy did not come from the gallery, so use "Install-Module UpdateEverything -Force", or -UpdateSelf -UpdateSelfSource Main to track the branch it came from.'
+        } else {
+            'Run with -UpdateSelf to install it.'
+        }
+        return "UpdateEverything $Running is running; $available is published. $how"
+    }
+
+    if ($Running -gt $available) {
+        # Normal for a clone or a GitHub install, and not a fault.
+        return "UpdateEverything $Running is running, ahead of the published $available."
+    }
+
+    return "UpdateEverything $Running is running, which is the newest published version."
+}

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -448,7 +448,19 @@
     #   0x8A150014 (-1978335212) APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND
     $WingetNothingToDo = @(-1978335189, -1978335212)
 
+    # The version that produced this log. Nothing else in a run said it, so a
+    # transcript could not be read against the code that made it -- a step that
+    # failed two releases ago looked identical to one failing now.
+    #
+    # The running version, from the module executing this, not the highest
+    # installed. A session imported by path, or one that loaded before an update
+    # replaced the files, is running something else.
+    $script:RunningVersion = $MyInvocation.MyCommand.Module.Version
+
     Write-Host "Maintenance run started $(Get-Date)  |  Admin: $isAdmin  |  Main Log: $mainLog" -ForegroundColor Green
+    if ($script:RunningVersion) {
+        Write-Host "UpdateEverything $script:RunningVersion" -ForegroundColor Green
+    }
 
     # ---------------------------------------------------------------------------
     # 1a. What this machine actually has
@@ -479,6 +491,17 @@
             Write-Output ''
             Write-Output "Not installed: $(($absent.Name | Sort-Object) -join ', ')"
             Write-Output 'Their steps report Skipped, which is the expected result rather than a fault.'
+        }
+
+        # The module's own version, compared against the gallery. Here rather than
+        # in the banner because it costs a network call: a scheduled run on a
+        # machine with no network should not pay a timeout before it starts, and
+        # -ExcludeTag Inventory already turns this off for one that does not want
+        # it.
+        if ($script:RunningVersion) {
+            Write-Output ''
+            Write-Output (Format-SelfVersionStatus -Running $script:RunningVersion `
+                -Status (Get-GalleryModuleStatus -Name 'UpdateEverything'))
         }
 
         # More than one executable of a name on PATH means the version above is

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2175,3 +2175,104 @@ Describe 'A step survives a caller who prefers Stop' -Tag 'Unit' {
         $script:Results[0].Status | Should-Be 'Warning'
     }
 }
+
+Describe 'Format-SelfVersionStatus' -Tag 'Unit' {
+
+    # Three answers that must not be confused, because each has been a wrong
+    # message somewhere before: behind, not behind, and could not tell.
+
+    BeforeAll {
+        $script:StatusOf = {
+            param($Installed, $Available, $Updatable = $true)
+            [pscustomobject]@{
+                Name        = 'UpdateEverything'
+                Installed   = if ($Installed) { [version] $Installed } else { $null }
+                Available   = if ($Available) { [version] $Available } else { $null }
+                Updatable   = $Updatable
+                NeedsUpdate = [bool] ($Installed -and $Available -and ([version]$Available -gt [version]$Installed))
+            }
+        }
+    }
+
+    It 'says the running version is current when it matches the gallery' {
+        $line = Format-SelfVersionStatus -Running '1.1.0' -Status (& $script:StatusOf '1.1.0' '1.1.0')
+        $line | Should-MatchString 'newest published'
+    }
+
+    It 'names both versions when the gallery is ahead' {
+        $line = Format-SelfVersionStatus -Running '1.1.0' -Status (& $script:StatusOf '1.1.0' '1.2.0')
+        $line | Should-MatchString '1\.1\.0'
+        $line | Should-MatchString '1\.2\.0'
+    }
+
+    It 'points at -UpdateSelf when the gallery is ahead' {
+        $line = Format-SelfVersionStatus -Running '1.1.0' -Status (& $script:StatusOf '1.1.0' '1.2.0')
+        $line | Should-MatchString '-UpdateSelf'
+    }
+
+    # A copy the GitHub installer placed is frequently ahead of the gallery, and
+    # Update-Module refuses it either way, so -UpdateSelf alone is wrong advice.
+    It 'gives a copy the gallery cannot move the advice that works' {
+        $line = Format-SelfVersionStatus -Running '1.1.0' -Status (& $script:StatusOf '1.1.0' '1.2.0' $false)
+        $line | Should-MatchString 'Install-Module UpdateEverything -Force'
+    }
+
+    # Normal for a clone or a GitHub install, and not a fault.
+    It 'does not call a version ahead of the gallery out of date' {
+        $line = Format-SelfVersionStatus -Running '1.2.0' -Status (& $script:StatusOf '1.2.0' '1.1.0')
+        $line | Should-MatchString 'ahead of the published'
+        $line | Should-NotMatchString 'is published'
+    }
+
+    # An offline run must not report currency it did not establish.
+    It 'says it could not tell when the gallery was unreachable' {
+        $line = Format-SelfVersionStatus -Running '1.1.0' -Status (& $script:StatusOf '1.1.0' $null)
+        $line | Should-MatchString 'could not be asked'
+        $line | Should-NotMatchString 'newest published'
+    }
+
+    It 'says the same when the gallery was never asked at all' {
+        $line = Format-SelfVersionStatus -Running '1.1.0' -Status $null
+        $line | Should-MatchString 'could not be asked'
+    }
+
+    # Running from a clone: a manifest version, nothing installed to compare.
+    It 'reports the running version even with nothing installed' {
+        $line = Format-SelfVersionStatus -Running '1.2.0' -Status (& $script:StatusOf $null '1.1.0' $false)
+        $line | Should-MatchString '1\.2\.0'
+    }
+}
+
+Describe 'A run says which version produced it' -Tag 'Static' {
+
+    BeforeAll {
+        $script:VersionSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    # The running module, not the highest installed. A session imported by path,
+    # or one that loaded before an update replaced the files on disk, is running
+    # something else -- and the log belongs to what ran.
+    It 'takes the version from the module actually executing' {
+        $script:VersionSource | Should-MatchString '\$MyInvocation\.MyCommand\.Module\.Version'
+    }
+
+    It 'prints it at the start, where the log is read from' {
+        $banner = $script:VersionSource.IndexOf('Maintenance run started')
+        $version = $script:VersionSource.IndexOf('Write-Host "UpdateEverything $script:RunningVersion"')
+
+        $version | Should-BeGreaterThan $banner
+        ($version - $banner) | Should-BeLessThan 400
+    }
+
+    # The banner costs nothing and happens always; the comparison costs a network
+    # call, so it lives where -ExcludeTag Inventory already turns it off.
+    It 'keeps the gallery lookup out of the startup path' {
+        $lookup = $script:VersionSource.IndexOf('Format-SelfVersionStatus')
+        $inventory = $script:VersionSource.IndexOf("Invoke-Step -Name 'Inventory'")
+        $selfStep = $script:VersionSource.IndexOf("Invoke-Step -Name 'UpdateEverything (self)'")
+
+        $lookup | Should-BeGreaterThan $inventory
+        $lookup | Should-BeLessThan $selfStep
+    }
+}


### PR DESCRIPTION
Closes #44.

## The gap was wider than reported

Nothing in a run said what version produced it. The banner carried the date, the
elevation state and the log path. The summary carried counts and the reboot
state. The only place a version was ever discussed was the
`UpdateEverything (self)` step — **which does not run without `-UpdateSelf`**.

So a transcript could not be read against the code that made it, and a step that
failed two releases ago looked identical to one failing now.

## What it does

```
Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
UpdateEverything 1.1.0
...
UpdateEverything 1.1.0 is running, which is the newest published version.
```

**The running version, not the highest installed.** A session imported by path,
or one that loaded before an update replaced the files on disk, is running
something else — and the log belongs to what ran.

**The comparison lives in the Inventory step, not the banner.** It costs a
network call: a scheduled run on a machine with no network should not pay a
timeout before it starts, and `-ExcludeTag Inventory` already turns off a step a
run does not want. That splits the free half from the expensive half instead of
choosing between them.

## Three answers that must not be confused

Each has been a wrong message somewhere before, so each has a test:

| State | Says |
|---|---|
| matches | `is running, which is the newest published version` |
| gallery ahead | `1.1.0 is running; 1.2.0 is published. Run with -UpdateSelf` |
| **running ahead** | `is running, ahead of the published 1.1.0` — never "out of date" |
| **not from the gallery** | points at `Install-Module -Force`, because `Update-Module` refuses it and `-UpdateSelf` alone would be wrong advice |
| **unreachable** | `the gallery could not be asked` — never silence, never currency it did not establish |

The third and fourth are not hypothetical: that is the state of the machine this
was reported from, and the one I verified 1.1.0 on an hour after publishing.

## Testing

664 tests, 0 failed (was 653). PSScriptAnalyzer clean over `src` under its
default rules.

Eight tests cover every branch of the message without touching the network, and
three static ones assert the version comes from the executing module, appears in
the banner, and keeps the gallery lookup out of the startup path.

Verified against a real run, shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)