### PR TITLE
Stop logging a TerminatingError for an answer that was expected

### DIFF
--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -54,17 +54,34 @@ function Get-GalleryModuleStatus {
         $updatable = [bool] (Get-InstalledModule -Name $Name -ErrorAction SilentlyContinue)
     }
 
+    # SilentlyContinue and a check, not Stop and a catch. A module the gallery
+    # does not have, and a gallery that cannot be reached, are both ordinary
+    # answers here rather than faults -- and Start-Transcript records a
+    # terminating error whether or not it is caught, so throwing for either would
+    # put "TerminatingError(Find-Module)" in a run log where nothing went wrong.
+    # Since the self-version check calls this on every run, that would be every
+    # run on a machine with no network.
     $available = $null
+    $found = $null
     try {
-        $found = Find-Module -Name $Name -Repository PSGallery -ErrorAction Stop
+        # The catch is a backstop, not the mechanism. SilentlyContinue keeps the
+        # ordinary answers -- no such module, gallery unreachable -- from
+        # throwing at all, which is what keeps them out of the transcript. A
+        # genuinely terminating failure still exists and still has to not take
+        # the step with it.
+        $found = Find-Module -Name $Name -Repository PSGallery -ErrorAction SilentlyContinue
+    } catch {
+        Write-Verbose "Asking the gallery about ${Name} failed outright: $($_.Exception.Message)"
+    }
 
+    if ($found) {
         # Find-Module returns the version as a string on some PowerShellGet
         # versions and a [version] on others, and a prerelease carries a suffix
         # that [version] cannot parse. Trim the suffix and let the cast decide.
         $raw = "$($found.Version)" -replace '-.*$', ''
         if ($raw) { $available = [version] $raw }
-    } catch {
-        Write-Verbose "Could not ask the gallery about ${Name}: $($_.Exception.Message)"
+    } else {
+        Write-Verbose "The gallery had no answer for ${Name}; it may be absent or unreachable."
     }
 
     [pscustomobject]@{

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -819,18 +819,25 @@
             Write-Output 'No NuGet package provider is present; the Trust PSGallery step reports why.'
         } else {
             $current = $nuget[0].Version
+
+            # SilentlyContinue and a check, not Stop and a catch. PowerShell 7
+            # registers no provider bootstrap source, so this cannot be answered
+            # there at all -- the normal, healthy case on half the supported
+            # hosts. Start-Transcript records a terminating error whether or not
+            # it is caught, so throwing for the expected answer puts
+            # "TerminatingError(Find-PackageProvider)" in the middle of a step
+            # that went on to report the right thing.
+            #
+            # Test-PendingReboot carries the same lesson about Get-ItemProperty.
             $newest = $null
             try {
-                $candidates = @(Find-PackageProvider -Name NuGet -ErrorAction Stop |
+                $candidates = @(Find-PackageProvider -Name NuGet -ErrorAction SilentlyContinue |
                     Sort-Object Version -Descending)
                 if ($candidates.Count) { $newest = $candidates[0].Version }
             } catch {
-                # PowerShell 7 registers no provider bootstrap source, so this
-                # cannot be answered there at all and fails with "No match was
-                # found". Windows PowerShell answers it. Neither is a fault, and
-                # the provider that is present keeps working either way, so the
-                # detail goes to the verbose stream rather than the summary.
-                Write-Verbose "Could not ask for the newest NuGet provider: $($_.Exception.Message)"
+                # A backstop for a hard failure. The ordinary answer no longer
+                # throws, which is the point.
+                Write-Verbose "Asking for the newest NuGet provider failed outright: $($_.Exception.Message)"
             }
 
             if (-not $newest) {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2276,3 +2276,42 @@ Describe 'A run says which version produced it' -Tag 'Static' {
         $lookup | Should-BeLessThan $selfStep
     }
 }
+
+Describe 'An expected answer does not throw' -Tag 'Static' {
+
+    # Start-Transcript records a terminating error whether or not it is caught,
+    # so throwing for an outcome that is expected puts a TerminatingError line in
+    # a run log where nothing went wrong. Reported from a 1.1.0 run:
+    #
+    #   PS>TerminatingError(Find-PackageProvider): "...No match was found for
+    #   the specified search criteria and package name 'NuGet'."
+    #
+    # The step went on to report the right thing. Test-PendingReboot already
+    # carried this lesson about Get-ItemProperty, and the gallery work repeated
+    # it. These two lookups have an expected empty answer on supported hosts:
+    # Find-PackageProvider cannot answer at all on PowerShell 7, and Find-Module
+    # is asked about modules that may not be published.
+
+    BeforeAll {
+        $script:LookupSources = @{
+            'Update-Everything.ps1'      = Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+            'Get-GalleryModuleStatus.ps1' = Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Get-GalleryModuleStatus.ps1') -Raw
+        }
+    }
+
+    It 'does not ask Find-PackageProvider to throw for an empty answer' {
+        $script:LookupSources['Update-Everything.ps1'] |
+            Should-NotMatchString 'Find-PackageProvider[^\r\n]*-ErrorAction Stop'
+    }
+
+    It 'does not ask Find-Module to throw for an empty answer' {
+        $script:LookupSources['Get-GalleryModuleStatus.ps1'] |
+            Should-NotMatchString 'Find-Module[^\r\n]*-ErrorAction Stop'
+    }
+
+    # SilentlyContinue only suppresses non-terminating errors, so a hard network
+    # failure still throws and still must not take the step with it.
+    It 'still guards <_> against a hard failure' -ForEach @('Update-Everything.ps1', 'Get-GalleryModuleStatus.ps1') {
+        $script:LookupSources[$_] | Should-MatchString 'failed outright'
+    }
+}


### PR DESCRIPTION
Closes #46.

A 1.1.0 run on a Windows 365 VM reported `Gallery tooling` as `OK` and put this
in the middle of it:

```
PS>TerminatingError(Find-PackageProvider): "...No match was found for the
specified search criteria and package name 'NuGet'."
```

Nothing went wrong. `Find-PackageProvider` cannot answer on PowerShell 7, which
registers no provider bootstrap source, and the step handled that and said so.
But **`Start-Transcript` records a terminating error whether or not it is
caught**, so asking for the expected answer with `-ErrorAction Stop` put a fault
in a log where there was none.

## A repeat of a documented mistake

`Test-PendingReboot` already carries this lesson, written when the same thing
happened with `Get-ItemProperty`. The gallery work repeated it.

## The fix, and the shape that matters

Both lookups use `SilentlyContinue` and check the result. **The `try`/`catch`
stays as a backstop rather than the mechanism** — `SilentlyContinue` suppresses
only *non-terminating* errors, so a hard network failure still throws and still
must not take the step with it. That distinction is the whole reason this is not
simply "delete the catch", and a test asserts both halves.

## The second one matters more

`Get-GalleryModuleStatus` had the same shape, and the self-version check added in
#44 calls it on **every run**. So every run on a machine with no network would
have logged one of these, starting from 1.2.0.

## Testing

668 tests, 0 failed (was 664). PSScriptAnalyzer clean over `src` under its
default rules.

Verified against a real run — no `TerminatingError` anywhere in the output, and
the step reports exactly what it did before:

```
=== STARTING: Gallery tooling ===
NuGet package provider 3.0.0.1 is installed; no newer version could be looked up on this host.
PowerShellGet 2.2.5 shipped with this host and is not behind the gallery; leaving it alone.
Microsoft.PowerShell.PSResourceGet 1.2.0 shipped with this host and is not behind the gallery; leaving it alone.
COMPLETED: Gallery tooling (2.9 s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)