### PR TITLE
Name the packages winget left behind, and say which are worth acting on

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,30 @@ nothing. It never installs a tool just to make a step possible.
 So the answer comes in two halves. Some products it updates by name. For the
 rest, a package manager's own inventory decides.
 
+### When winget leaves something behind
+
+`winget upgrade --all` returns one exit code for the whole pass, so a partial
+failure used to say only that *something* did not upgrade. The step now names
+them, and separates the two cases:
+
+```
+Still out of date after this run:
+  astral-sh.uv 0.11.19 -> 0.12.7  (the install failed; a file was in use,
+                                   so close the program and run again)
+
+Not upgradable on this machine, and expected to stay that way:
+  Cisco.CiscoWebexMeetings 45.6.4 -> 45.6.4.8  (winget listed it and did not
+                                   attempt it, usually because the newer
+                                   package does not apply to this system)
+```
+
+The distinction matters. The first is worth doing something about; the second
+will not change until the vendor ships a package that applies, and reporting it
+as a failure on every run is how people learn to skim past the ones that are.
+
+**The step is only marked `Warning` for packages winget actually attempted.** One
+it declined is not a fault of the run and does not colour it.
+
 ### Products updated by name
 
 | Product | How it updates |

--- a/src/Private/Get-WingetLeftover.ps1
+++ b/src/Private/Get-WingetLeftover.ps1
@@ -1,0 +1,95 @@
+function Get-WingetLeftover {
+    <#
+        .SYNOPSIS
+        Works out which packages an upgrade pass left behind, and why.
+
+        .DESCRIPTION
+        "winget upgrade --all" returns one exit code for the whole pass, so a
+        partial failure says only that something did not upgrade. This says
+        which, and separates two outcomes that need different answers from the
+        person reading it:
+
+          Attempted   winget tried and the install failed. Worth retrying, and
+                      often fixable -- a package whose executable is running
+                      cannot be replaced until it is closed.
+
+          Skipped     winget listed it and never tried. Usually "a newer package
+                      version is available in a configured source, but it does
+                      not apply to your system or requirements", which is
+                      permanent until the vendor ships something that applies.
+                      Reporting that as a failure every run teaches people to
+                      ignore the ones that are not.
+
+        Attempted is decided by winget's own "Found <name> [<id>]" line, which it
+        writes when it begins a package. Nothing else in the output is reliable:
+        the rest is localised prose.
+
+        .PARAMETER Before
+        The upgrade table from before the pass.
+
+        .PARAMETER After
+        The upgrade table from after it.
+
+        .PARAMETER Output
+        What the pass printed, for deciding attempted from skipped.
+
+        .EXAMPLE
+        Get-WingetLeftover -Before $before -After $after -Output $captured
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [object[]] $Before = @(),
+        [object[]] $After = @(),
+        [string] $Output
+    )
+
+    $stillListed = @($After | Where-Object { $_.Id })
+    if (-not $stillListed.Count) { return }
+
+    foreach ($package in $stillListed) {
+        # Compared against the same listing style it came from, so a truncated
+        # Id matches a truncated Id.
+        $wasListed = [bool] @($Before | Where-Object { $_.Id -eq $package.Id }).Count
+
+        # Only count it as attempted when winget named it. A substring search of
+        # the whole output would match the upgrade table itself, which lists
+        # every package including the ones never tried.
+        $attempted = $false
+        $reason = $null
+
+        if ($Output -and $package.Id) {
+            $marker = [regex]::Escape($package.Id)
+            if ($Output -match "\[$marker\]") {
+                $attempted = $true
+
+                # winget says "Access is denied" when it cannot replace a file,
+                # which on Windows almost always means the executable is running.
+                # That is the one failure a person can act on immediately, so it
+                # is worth naming rather than leaving in the step log.
+                if ($Output -match '(?i)access is denied') {
+                    $reason = 'the install failed; a file was in use, so close the program and run again'
+                } else {
+                    $reason = 'the install failed'
+                }
+            }
+        }
+
+        if (-not $attempted) {
+            $reason = if ($wasListed) {
+                'winget listed it and did not attempt it, usually because the newer package does not apply to this system'
+            } else {
+                'it appeared during this run'
+            }
+        }
+
+        [pscustomobject]@{
+            Name      = $package.Name
+            Id        = $package.Id
+            Version   = $package.Version
+            Available = $package.Available
+            Attempted = $attempted
+            Reason    = $reason
+        }
+    }
+}

--- a/src/Private/Get-WingetUpgradeTable.ps1
+++ b/src/Private/Get-WingetUpgradeTable.ps1
@@ -1,0 +1,88 @@
+function Get-WingetUpgradeTable {
+    <#
+        .SYNOPSIS
+        Parses the table winget prints for available upgrades.
+
+        .DESCRIPTION
+        Returns one object per row, with whatever the columns held. The columns
+        are found from the header's word positions rather than by name, because
+        winget localises its headers -- "Name" and "Id" are English, and the
+        table is not.
+
+        The row of dashes under the header is the anchor. It is the one line in
+        winget's output that is the same in every language.
+
+        Ids arrive truncated when the console is narrower than the table, and
+        that is left alone rather than repaired. This exists to compare one
+        listing against another, and two listings truncated the same way compare
+        correctly. An Id that reads "Microsoft.VisualStudio..." is also still
+        recognisable to the person reading it, which is the other half of the
+        job.
+
+        Returns nothing when the text holds no table, which is the ordinary case
+        when everything is up to date.
+
+        .PARAMETER Text
+        winget's output, as captured.
+
+        .EXAMPLE
+        Get-WingetUpgradeTable -Text (winget upgrade --include-unknown | Out-String)
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $Text
+    )
+
+    if (-not $Text) { return }
+
+    $lines = $Text -split '\r?\n'
+
+    # The separator is a run of dashes on its own. Anything shorter than a few
+    # characters is not it -- some locales underline other things.
+    $separator = -1
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match '^-{8,}\s*$') { $separator = $i; break }
+    }
+    if ($separator -lt 1) { return }
+
+    $header = $lines[$separator - 1]
+
+    # Column starts: every position where a non-space follows a space, plus the
+    # first character. Fixed-width, so a row is sliced at the same offsets.
+    $starts = [System.Collections.Generic.List[int]]::new()
+    for ($i = 0; $i -lt $header.Length; $i++) {
+        if ($header[$i] -ne ' ' -and ($i -eq 0 -or $header[$i - 1] -eq ' ')) {
+            $starts.Add($i)
+        }
+    }
+    if ($starts.Count -lt 2) { return }
+
+    foreach ($line in $lines[($separator + 1)..($lines.Count - 1)]) {
+        # The table ends at the first blank line. What follows is winget's own
+        # summary, which is localised and is not a row.
+        if (-not $line -or -not $line.Trim()) { break }
+
+        # A row shorter than the second column start is not a row.
+        if ($line.Length -le $starts[1]) { continue }
+
+        $fields = for ($c = 0; $c -lt $starts.Count; $c++) {
+            $from = $starts[$c]
+            if ($from -ge $line.Length) { '' ; continue }
+
+            $to = if ($c + 1 -lt $starts.Count) { [Math]::Min($starts[$c + 1], $line.Length) } else { $line.Length }
+            $line.Substring($from, $to - $from).Trim()
+        }
+
+        $fields = @($fields)
+
+        [pscustomobject]@{
+            Name      = $fields[0]
+            Id        = if ($fields.Count -gt 1) { $fields[1] } else { '' }
+            Version   = if ($fields.Count -gt 2) { $fields[2] } else { '' }
+            Available = if ($fields.Count -gt 3) { $fields[3] } else { '' }
+        }
+    }
+}

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -599,8 +599,18 @@
     }
 
     Invoke-Step -Name 'winget (all sources)' -RequiresCommand 'winget' -Tag 'Windows', 'PackageManager' -Action {
+        # Accumulated and passed through in one pass, rather than captured and
+        # echoed afterwards. A winget upgrade can run for minutes and the console
+        # should show it happening.
+        #
+        # The upgrade table winget prints first is the "before" list, so no extra
+        # call is needed for it.
+        $captured = [System.Collections.Generic.List[string]]::new()
+
         winget upgrade --all --include-unknown --silent `
-            --accept-source-agreements --accept-package-agreements --disable-interactivity
+            --accept-source-agreements --accept-package-agreements --disable-interactivity 2>&1 |
+            ForEach-Object { $captured.Add("$_"); $_ }
+
         $code = $LASTEXITCODE
         $global:LASTEXITCODE = 0
 
@@ -609,7 +619,53 @@
         # running) failing while the rest upgrade fine. Report the code instead of
         # failing the run over it; Write-Error marks the step 'Warning'.
         if ($code -ne 0 -and $WingetNothingToDo -notcontains $code) {
-            Write-Error ('winget upgrade --all returned {0} (0x{0:X8}); one or more packages may not have upgraded.' -f $code)
+
+            # Which ones, and whether anything can be done about them. The exit
+            # code says only that something did not upgrade, and a person then
+            # has to read the step log to find out what -- or, as happened,
+            # notice across two runs that one package never moves.
+            $text = $captured -join "`n"
+            $before = @(Get-WingetUpgradeTable -Text $text)
+            $after = @(Get-WingetUpgradeTable -Text (
+                winget upgrade --include-unknown --disable-interactivity 2>&1 | Out-String))
+            $global:LASTEXITCODE = 0
+
+            $leftover = @(Get-WingetLeftover -Before $before -After $after -Output $text)
+
+            $attempted = @($leftover | Where-Object { $_.Attempted })
+            $skipped = @($leftover | Where-Object { -not $_.Attempted })
+
+            if ($attempted.Count) {
+                Write-Output ''
+                Write-Output 'Still out of date after this run:'
+                foreach ($package in $attempted) {
+                    Write-Output ("  {0} {1} -> {2}  ({3})" -f $package.Id, $package.Version, $package.Available, $package.Reason)
+                }
+            }
+
+            # Written as information rather than as a problem. These do not
+            # change until the vendor ships something that applies, so a person
+            # who reads them as failures learns to skim past the ones that are.
+            if ($skipped.Count) {
+                Write-Output ''
+                Write-Output 'Not upgradable on this machine, and expected to stay that way:'
+                foreach ($package in $skipped) {
+                    Write-Output ("  {0} {1} -> {2}  ({3})" -f $package.Id, $package.Version, $package.Available, $package.Reason)
+                }
+            }
+
+            # The error, and so the Warning status, is raised only for something
+            # that was actually tried. A package winget declined is not a fault
+            # of this run and must not colour it.
+            if ($attempted.Count) {
+                Write-Error ('winget could not upgrade {0} package(s): {1}. Exit code {2} (0x{2:X8}).' -f
+                    $attempted.Count, (($attempted.Id) -join ', '), $code)
+            } elseif (-not $leftover.Count) {
+                Write-Error ('winget upgrade --all returned {0} (0x{0:X8}); one or more packages may not have upgraded.' -f $code)
+            } else {
+                Write-Output ''
+                Write-Output 'Nothing this run could have upgraded was left behind.'
+            }
         } elseif ($code -ne 0) {
             Write-Output 'winget reports nothing left to upgrade.'
         }

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2315,3 +2315,140 @@ Describe 'An expected answer does not throw' -Tag 'Static' {
         $script:LookupSources[$_] | Should-MatchString 'failed outright'
     }
 }
+
+Describe 'Get-WingetUpgradeTable' -Tag 'Unit' {
+
+    # The sample is the real table from a Windows 365 VM, which is where the
+    # reporting gap was noticed. winget localises its headers and truncates the
+    # Id column to the console width, so the parser anchors on the row of dashes
+    # and takes column positions from the header's word starts -- neither of
+    # which depends on the language.
+
+    BeforeAll {
+        $script:RealTable = @'
+Name                 Id                       Version Available Source
+----------------------------------------------------------------------
+Cisco Webex Meetings Cisco.CiscoWebexMeetings 45.6.4  45.6.4.8  winget
+uv                   astral-sh.uv             0.11.19 0.12.7    winget
+2 upgrades available.
+'@
+    }
+
+    It 'finds both rows' {
+        @(Get-WingetUpgradeTable -Text $script:RealTable) | Should-BeCollection -Count 2
+    }
+
+    It 'reads the ids' {
+        $ids = @(Get-WingetUpgradeTable -Text $script:RealTable).Id
+        $ids | Should-ContainCollection 'astral-sh.uv'
+        $ids | Should-ContainCollection 'Cisco.CiscoWebexMeetings'
+    }
+
+    It 'reads the installed and available versions' {
+        $uv = @(Get-WingetUpgradeTable -Text $script:RealTable) | Where-Object { $_.Id -eq 'astral-sh.uv' }
+        $uv.Version   | Should-Be '0.11.19'
+        $uv.Available | Should-Be '0.12.7'
+    }
+
+    It 'keeps a name that contains spaces in one piece' {
+        $webex = @(Get-WingetUpgradeTable -Text $script:RealTable) | Where-Object { $_.Id -like 'Cisco*' }
+        $webex.Name | Should-Be 'Cisco Webex Meetings'
+    }
+
+    # "2 upgrades available." is winget's own summary, localised, and not a row.
+    It 'stops at the blank line rather than reading the summary as a package' {
+        @(Get-WingetUpgradeTable -Text $script:RealTable).Id | Should-NotContainCollection '2'
+    }
+
+    # The header row is the only part of the table that is English here. Anchor
+    # on the dashes and the column positions, and a German or Japanese console
+    # parses the same.
+    It 'parses a table whose headers are not English' {
+        $localised = @'
+Name                 Kennung                  Version Verfuegbar Quelle
+-----------------------------------------------------------------------
+uv                   astral-sh.uv             0.11.19 0.12.7     winget
+'@
+        (Get-WingetUpgradeTable -Text $localised).Id | Should-Be 'astral-sh.uv'
+    }
+
+    It 'returns nothing when there is no table' {
+        Get-WingetUpgradeTable -Text 'No installed package found matching input criteria.' | Should-BeNull
+    }
+
+    It 'returns nothing for empty input' {
+        Get-WingetUpgradeTable -Text '' | Should-BeNull
+        Get-WingetUpgradeTable -Text $null | Should-BeNull
+    }
+}
+
+Describe 'Get-WingetLeftover' -Tag 'Unit' {
+
+    # The two outcomes that need different answers. From the run this came from:
+    # uv was attempted and failed on a file in use, Webex was listed and never
+    # attempted because the newer package does not apply to that system. One
+    # exit code covered both.
+
+    BeforeAll {
+        $script:Before = @(
+            [pscustomobject]@{ Name = 'Cisco Webex Meetings'; Id = 'Cisco.CiscoWebexMeetings'; Version = '45.6.4'; Available = '45.6.4.8' }
+            [pscustomobject]@{ Name = 'uv'; Id = 'astral-sh.uv'; Version = '0.11.19'; Available = '0.12.7' }
+        )
+
+        # Trimmed from the real transcript. The "Found ... [id]" line is what
+        # winget writes when it begins a package, and is the only reliable
+        # signal that one was attempted.
+        $script:Output = @'
+Cisco Webex Meetings Cisco.CiscoWebexMeetings 45.6.4  45.6.4.8  winget
+uv                   astral-sh.uv             0.11.19 0.12.7    winget
+2 upgrades available.
+(1/1) Found uv [astral-sh.uv] Version 0.12.7
+Successfully verified installer hash
+Starting package install...
+An unexpected error occurred while executing the command:
+remove: Access is denied.: "C:\...\WinGet\Packages\astral-sh.uv_...\uv.exe"
+'@
+    }
+
+    It 'reports both packages that are still listed' {
+        @(Get-WingetLeftover -Before $script:Before -After $script:Before -Output $script:Output) |
+            Should-BeCollection -Count 2
+    }
+
+    It 'marks the one winget named as attempted' {
+        $uv = @(Get-WingetLeftover -Before $script:Before -After $script:Before -Output $script:Output) |
+            Where-Object { $_.Id -eq 'astral-sh.uv' }
+        $uv.Attempted | Should-BeTrue
+    }
+
+    # Webex appears in the upgrade table inside the same output, so a plain
+    # substring search would call it attempted. Only the "[id]" marker counts.
+    It 'does not mistake a table row for an attempt' {
+        $webex = @(Get-WingetLeftover -Before $script:Before -After $script:Before -Output $script:Output) |
+            Where-Object { $_.Id -eq 'Cisco.CiscoWebexMeetings' }
+        $webex.Attempted | Should-BeFalse
+    }
+
+    It 'names a file in use as something the reader can act on' {
+        $uv = @(Get-WingetLeftover -Before $script:Before -After $script:Before -Output $script:Output) |
+            Where-Object { $_.Id -eq 'astral-sh.uv' }
+        $uv.Reason | Should-MatchString 'in use'
+    }
+
+    It 'says a skipped package is expected to stay that way' {
+        $webex = @(Get-WingetLeftover -Before $script:Before -After $script:Before -Output $script:Output) |
+            Where-Object { $_.Id -eq 'Cisco.CiscoWebexMeetings' }
+        $webex.Reason | Should-MatchString 'does not apply'
+    }
+
+    It 'reports nothing when everything upgraded' {
+        Get-WingetLeftover -Before $script:Before -After @() -Output $script:Output | Should-BeNull
+    }
+
+    It 'carries the versions through for the report' {
+        $uv = @(Get-WingetLeftover -Before $script:Before -After $script:Before -Output $script:Output) |
+            Where-Object { $_.Id -eq 'astral-sh.uv' }
+        $uv.Version   | Should-Be '0.11.19'
+        $uv.Available | Should-Be '0.12.7'
+    }
+}


### PR DESCRIPTION
Closes #48.

`winget upgrade --all` returns one exit code for the whole pass, so a partial
failure said only that *something* did not upgrade. Finding out which meant
opening the step log. Noticing that one package **never** moves meant comparing
runs by hand — which is how this was reported.

## What it says now

Run against the reported machine's real output:

```
Still out of date after this run:
  astral-sh.uv 0.11.19 -> 0.12.7  (the install failed; a file was in use,
                                   so close the program and run again)

Not upgradable on this machine, and expected to stay that way:
  Cisco.CiscoWebexMeetings 45.6.4 -> 45.6.4.8  (winget listed it and did not
                                   attempt it, usually because the newer
                                   package does not apply to this system)
```

Both findings from an evening's investigation, in the run that produced them.

## The distinction is the point

| | |
|---|---|
| **attempted** | winget tried, the install failed. Often fixable — commonest cause is a running executable that cannot be replaced |
| **skipped** | winget listed it and never tried. Permanent until the vendor ships a package that applies |

Reporting the second as a failure on every run is how people learn to skim past
the first. **The step now raises its error only for packages actually
attempted** — one winget declined is not a fault of the run and no longer
colours it.

## Two things that needed care

**Attempted is decided by winget's own `Found <name> [<id>]` line.** A substring
search would have called Webex attempted, because its id appears in the upgrade
table inside the same output. There is a test for exactly that.

**The table parser anchors on the row of dashes** and takes column positions from
the header's word starts, because winget localises its headers — `Name` and `Id`
are English, the table is not. There is a test with German headers. Truncated ids
are left truncated rather than repaired: this compares one listing against
another, and two listings truncated the same way compare correctly.

Output is accumulated and passed through in one pass rather than captured and
echoed, so a winget upgrade that runs for minutes still shows the console what it
is doing.

## Three things this deliberately does not do

Each ruled out by measurement rather than argument:

**No scope splitting.** Measured here: 154 packages unfiltered against 116
user-scope and 99 machine-scope. Most would be attempted twice and two
(`Microsoft.VCLibs.Desktop.14`) would be attempted never. Losing coverage to gain
context is a bad trade.

**No elevation handling.** The failure reproduces identically elevated and
unelevated, so the per-user-portable theory is dead and none of the
`RunLevel Limited` machinery is needed.

**No retry.** Whatever holds a file on a given machine is that machine's
business. Naming the package is the fix.

## Testing

685 tests, 0 failed (was 668). PSScriptAnalyzer clean over `src` under its
default rules. The live path re-run on this machine, where nothing needs
upgrading, still reports `OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)