### PR TITLE
Explain the duplicated error in a transcript, rather than removing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,31 @@ The module writes logs to the first writable location among `%USERPROFILE%`,
 Many CLIs write ordinary progress to stderr, so a step earns `Warning` only when
 PowerShell itself raises an error record.
 
+### An error appears twice in the transcript
+
+One error, two identical blocks in `Update-Everything-<timestamp>.log`. **This is
+one error, not two.** The step log holds one copy and the summary counts one, so
+trust those; the count in `COMPLETED WITH ERRORS: <step> (N error record(s))` is
+right.
+
+PowerShell transcribes an error record when it is raised, whatever the pipeline
+then does with it, and transcribes it again when it is displayed. Both are the
+same error arriving by two routes.
+
+It is left alone deliberately. Measured, with a marker in the error text:
+
+| | console | transcript |
+|---|---|---|
+| as it is | **visible** | 2 |
+| error records kept out of the display | **nothing** | 1 |
+
+The raise-time transcript entry comes with no console rendering, so removing the
+duplicate would make every error invisible to whoever is watching the run. Two
+lines in a log is the cheaper problem.
+
+Only the error stream does this. Output, warnings, verbose and native stdout all
+appear once.
+
 ## Installing versus updating
 
 Updating something already installed needs no permission. Installing something

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2452,3 +2452,51 @@ remove: Access is denied.: "C:\...\WinGet\Packages\astral-sh.uv_...\uv.exe"
         $uv.Available | Should-Be '0.12.7'
     }
 }
+
+Describe 'Errors reach the person watching the run' -Tag 'Unit' {
+
+    # An error is transcribed twice: once when PowerShell raises it, once when
+    # the step pipeline displays it. Investigated under #49 and left alone, and
+    # this is the test that stops it being "tidied up" later.
+    #
+    # Measured, counting a marker in the error text:
+    #
+    #             console   transcript
+    #   as it is  visible       2
+    #   filtered  NOTHING       1
+    #
+    # The raise-time transcript entry comes with no console rendering, so
+    # dropping the displayed copy would make every error invisible to whoever is
+    # watching -- silently, and only noticed the next time somebody needed to see
+    # one. Two lines in a log is the cheaper problem.
+
+    BeforeEach {
+        $script:logDir = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $null = New-Item -ItemType Directory -Path $script:logDir -Force
+        $script:runStamp = 'err'
+        $script:isAdmin = $true
+        $script:Results = [System.Collections.Generic.List[object]]::new()
+        $script:TagFilter = @()
+        $script:ExcludeTagFilter = @()
+    }
+
+    It 'does not filter error records out of what it displays' {
+        $source = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Invoke-Step.ps1') -Raw
+
+        $source | Should-NotMatchString 'isnot \[System\.Management\.Automation\.ErrorRecord\]'
+    }
+
+    It 'writes the error text to the step log, which is the single-copy record' {
+        Invoke-Step -Name 'noisy' -Action { Write-Error 'SINGLECOPYMARKER' } 6>$null
+
+        $log = Get-Content (Join-Path $script:logDir 'noisy-err.log') -Raw
+        ([regex]::Matches($log, 'SINGLECOPYMARKER')).Count | Should-Be 1
+    }
+
+    It 'counts the error once, whatever the transcript shows' {
+        Invoke-Step -Name 'counted' -Action { Write-Error 'x' } 6>$null
+
+        $script:Results[0].Status | Should-Be 'Warning'
+    }
+}


### PR DESCRIPTION
Closes #49.

**No code change.** The investigation says the obvious fix is worse than the
problem, and this records why, in the README and in tests.

## Where the second copy comes from

Counting a marker in the error text:

| | transcript copies |
|---|---|
| `*>&1 \| Out-Host` — what `Invoke-Step` does | **2** |
| `*>&1 \| Out-Null` — nothing displayed | 1 |
| assigned, no pipeline | 1 |
| bare call, no redirect | 2 |

PowerShell transcribes an error record **when it is raised**, whatever the
pipeline then does with it, and transcribes it again **when it is displayed**.
The raise-time copy cannot be prevented from inside a step.

## Why the obvious fix is wrong

Keep error records out of the displayed pipeline and the transcript is tidy. This
is what that costs, measured by what reaches the console:

| | console | transcript |
|---|---|---|
| as it is | **visible** | 2 |
| error records filtered from the display | **nothing** | 1 |

The raise-time transcript entry comes with **no console rendering**. Filtering
would make every error invisible to whoever is watching a run — silently, and
noticed only the next time somebody needed to see one.

Two lines in a log is the cheaper problem.

## What ships instead

The README's log section now explains it, with the measurement, and says plainly
which record to trust: the step log holds one copy and the summary counts one.

Three tests stop this being "tidied up" by someone who sees the duplicate and not
the reason — that `Invoke-Step` does not filter error records out of what it
displays, that the step log holds exactly one copy, and that the error is counted
once.

## Testing

688 tests, 0 failed (was 685).

🤖 Generated with [Claude Code](https://claude.com/claude-code)