### PR TITLE
Update pip itself, and report it in the inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,35 @@ Self-update runs only for `Standalone` and `Unknown`. Anything it can pin on a
 manager, it skips, naming that manager in the reason. The summary says why
 rather than going quiet.
 
+### Python
+
+Four steps, and they cover different things:
+
+| Step | Updates |
+|---|---|
+| `Python (Install Manager)` | the Python runtimes |
+| `pip` | pip itself, for the interpreter on PATH |
+| `uv` | uv itself, and only when no package manager owns it |
+| `pipx packages` | isolated CLI applications |
+
+**Installed packages are deliberately left alone.** pip has no `upgrade-all`, and
+the usual recipe — list outdated, upgrade each — does not keep the dependency set
+consistent, because upgrading one package can silently downgrade another's
+dependency. That is the problem `pipx` and `uv` exist to solve by isolating, and
+both have their own steps.
+
+**An active virtual environment is never touched.** If `VIRTUAL_ENV` is set the
+step reports skipped and says so: those packages belong to whatever project made
+the environment, not to the machine.
+
+Only the interpreter that resolves on PATH is updated. Others the launcher knows
+about are named in the output and left alone — upgrading pip in every Python on a
+machine is a larger claim than a maintenance run should make on its own.
+
+pip is upgraded through `python -m pip`, never the bare `pip.exe`: on Windows pip
+cannot replace its own running executable, so the direct form fails on a locked
+file.
+
 ## Running without administrator rights
 
 The module checks whether it can elevate before it asks. An account outside the

--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -51,6 +51,7 @@ function Get-UpdateToolInventory {
             @{ Name = 'Python launcher'; Command = 'py';      VersionArgument = '--version' }
             @{ Name = 'Python manager';  Command = 'pymanager'; VersionArgument = '--version' }
             @{ Name = 'uv';              Command = 'uv';      VersionArgument = '--version' }
+            @{ Name = 'pip';             Command = 'pip';     VersionArgument = '--version' }
             @{ Name = 'pipx';            Command = 'pipx';    VersionArgument = '--version' }
             @{ Name = '.NET SDK';        Command = 'dotnet';  VersionArgument = '--version' }
             @{ Name = 'rustup';          Command = 'rustup';  VersionArgument = '--version' }

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -1097,6 +1097,62 @@
         }
     }
 
+    Invoke-Step -Name 'pip' -Tag 'Python' -Action {
+        # Never inside an active virtual environment. Its packages belong to
+        # whatever project made it, not to this machine, and it is both the
+        # easiest interpreter to reach from here and the worst one to change.
+        if ($env:VIRTUAL_ENV) {
+            Stop-StepAsSkipped -Reason "a virtual environment is active ($env:VIRTUAL_ENV), and its packages belong to that project rather than to this machine"
+        }
+
+        # Indexed rather than "| Select-Object -First 1": that halts the upstream
+        # pipeline, and inside a step action the transcript records the stop as a
+        # TerminatingError.
+        $found = @('py', 'python' | ForEach-Object {
+            Get-Command $_ -CommandType Application -ErrorAction SilentlyContinue
+        })
+        if (-not $found.Count) {
+            Stop-StepAsSkipped -Reason 'no Python interpreter is on PATH'
+        }
+        $interpreter = $found[0].Source
+
+        $version = (& $interpreter -m pip --version 2>&1 | Out-String).Trim()
+        $global:LASTEXITCODE = 0
+        if (-not $version -or $version -notmatch '^pip\s') {
+            Stop-StepAsSkipped -Reason "pip is not available to $interpreter"
+        }
+        Write-Output $version
+
+        # python -m pip, never the bare pip.exe. On Windows pip cannot replace
+        # its own running executable, so "pip install --upgrade pip" fails on a
+        # locked file; run through the interpreter and the exe is not running.
+        & $interpreter -m pip install --upgrade pip --disable-pip-version-check
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Could not upgrade pip for $interpreter (exit $LASTEXITCODE). pip's own message is in this step's log."
+            $global:LASTEXITCODE = 0
+        } else {
+            Write-Output ((& $interpreter -m pip --version 2>&1 | Out-String).Trim())
+            $global:LASTEXITCODE = 0
+        }
+
+        # Only this interpreter's pip. The others are named rather than touched:
+        # upgrading pip in every Python on a machine is a larger claim than a
+        # maintenance run should make on its own.
+        $others = @(py --list 2>&1 | Out-String -Stream | Where-Object { $_ -match '^\s*-V:' -and $_ -notmatch '\*' })
+        $global:LASTEXITCODE = 0
+        if ($others.Count) {
+            Write-Output ''
+            Write-Output "$($others.Count) other interpreter(s) are installed and were not changed:"
+            $others | ForEach-Object { Write-Output "  $($_.Trim())" }
+        }
+
+        # Installed packages are deliberately left alone. pip has no upgrade-all,
+        # and list-outdated-then-upgrade-each does not keep the dependency set
+        # consistent -- upgrading one package can silently downgrade another's
+        # dependency. That is the problem pipx and uv exist to avoid, and both
+        # have their own steps.
+    }
+
     Invoke-Step -Name 'pipx packages' -RequiresCommand 'pipx' -Tag 'Python' -Action {
         pipx upgrade-all
     }

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2500,3 +2500,82 @@ Describe 'Errors reach the person watching the run' -Tag 'Unit' {
         $script:Results[0].Status | Should-Be 'Warning'
     }
 }
+
+Describe 'The pip step' -Tag 'Static' {
+
+    BeforeAll {
+        $script:PipSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+
+        $script:PipStep = [regex]::Match($script:PipSource,
+            "(?s)Invoke-Step -Name 'pip'.*?\r?\n    \}").Value
+    }
+
+    It 'exists and is tagged Python' {
+        $script:PipStep | Should-NotBeEmptyString
+        $script:PipStep | Should-MatchString "-Tag 'Python'"
+    }
+
+    # An active virtualenv is the easiest interpreter to reach from a step and
+    # the worst one to change: its packages belong to whatever project made it.
+    It 'refuses to touch an active virtual environment' {
+        $script:PipStep | Should-MatchString '\$env:VIRTUAL_ENV'
+        $script:PipStep | Should-MatchString 'Stop-StepAsSkipped'
+    }
+
+    # On Windows pip cannot replace its own running executable, so
+    # "pip install --upgrade pip" fails on a locked file. Through the
+    # interpreter, the exe is not running. Same shape as the winget/uv failure
+    # that prompted this module's leftover reporting.
+    It 'upgrades through the interpreter, not the bare pip executable' {
+        $script:PipStep | Should-MatchString '-m pip install --upgrade pip'
+        $script:PipStep | Should-NotMatchString '(?m)^\s*pip install --upgrade'
+    }
+
+    # pip has no upgrade-all, and list-outdated-then-upgrade-each does not keep
+    # the dependency set consistent. That is the problem pipx and uv solve by
+    # isolating, and both have their own steps.
+    It 'does not try to upgrade installed packages' {
+        $script:PipStep | Should-NotMatchString 'list --outdated'
+        $script:PipStep | Should-NotMatchString 'freeze'
+    }
+
+    It 'names the other interpreters rather than changing them' {
+        $script:PipStep | Should-MatchString 'were not changed'
+    }
+
+    # No -RequiresCommand, because either py or python will do, so the step has
+    # to resolve its own tool and skip explicitly when neither is there.
+    It 'skips itself when no interpreter is present' {
+        $script:PipStep | Should-MatchString 'no Python interpreter is on PATH'
+    }
+
+    It 'skips itself when the interpreter has no pip' {
+        $script:PipStep | Should-MatchString 'pip is not available to'
+    }
+
+    It 'runs before pipx, which depends on a working Python' {
+        $pip  = $script:PipSource.IndexOf("Invoke-Step -Name 'pip'")
+        $pipx = $script:PipSource.IndexOf("Invoke-Step -Name 'pipx packages'")
+
+        $pip | Should-BeGreaterThan -1
+        $pip | Should-BeLessThan $pipx
+    }
+}
+
+Describe 'pip is in the inventory' -Tag 'Unit' {
+
+    It 'is one of the tools reported' {
+        $catalogue = @(Get-UpdateToolInventory -Catalogue @(
+            @{ Name = 'pip'; Command = 'pip'; VersionArgument = '--version' }))
+
+        $catalogue.Name | Should-Be 'pip'
+    }
+
+    It 'is in the real catalogue, so a machine with pip and no pipx says so' {
+        $source = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Get-UpdateToolInventory.ps1') -Raw
+
+        $source | Should-MatchString "Name = 'pip';"
+    }
+}


### PR DESCRIPTION
Closes #52.

pip appeared **nowhere** in `src` — not a step, not the inventory, not a
reference. Python got updated and Python *applications* got updated. pip, which
is how most people install Python things, got nothing.

## What it does

```
=== STARTING: pip ===
pip 26.2.1 from ...\pythoncore-3.14-64\Lib\site-packages\pip (python 3.14)
Requirement already satisfied: pip ... (26.2.1)
COMPLETED: pip (6.1 s)
```

Version reported either side, so the step says what happened rather than only
that it finished. pip is also in the Inventory now, so a machine with pip and no
pipx no longer stays silent about its Python tooling.

## Through `python -m pip`, never the bare `pip.exe`

On Windows pip **cannot replace its own running executable**, so
`pip install --upgrade pip` fails on a locked file. Run through the interpreter
and the exe is not running.

That is the same shape as the winget-on-uv failure that produced #48 — a package
manager unable to delete the file it is replacing. Worth encoding rather than
rediscovering.

## Three things it deliberately does not do

**Installed packages are left alone.** pip has no `upgrade-all`, and
list-outdated-then-upgrade-each does not keep the dependency set consistent:
upgrading one package can silently downgrade another's dependency. That is the
problem `pipx` and `uv` solve by isolating, and both already have their own steps.

**An active virtual environment is never touched** — the easiest interpreter to
reach from a step and the worst one to change:

```
SKIP  pip (a virtual environment is active (C:\some\project\.venv), and its
      packages belong to that project rather than to this machine)
```

**Only the interpreter on PATH is updated.** Others the launcher knows about are
named in the output and left alone. Upgrading pip in every Python on a machine is
a larger claim than a maintenance run should make on its own.

## Testing

698 tests, 0 failed (was 688). PSScriptAnalyzer clean over `src` under its
default rules.

Both paths exercised for real on this machine — the upgrade and the virtualenv
guard, shown above. Ten new tests, including that the step never reaches for
`list --outdated` or `freeze`, which is the change someone would make later
without knowing why it is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)