### PR TITLE
Prepare 1.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -497,7 +497,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.1.0 -m "1.1.0" && git push origin v1.1.0
+git tag -a v1.2.0 -m "1.2.0" && git push origin v1.2.0
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.1.0'
+    ModuleVersion     = '1.2.0'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -32,57 +32,60 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.1.0
+            ReleaseNotes = '# 1.2.0
 
-Adds a setup menu, step selection by tag, and an inventory of what the machine
-actually has. Fixes three defects that shipped in 1.0.0.
+A run now says what version produced it, names the packages winget could not
+upgrade, and updates pip. Most of this came from reading two logs off a real
+machine.
+
+## A run says what it is
+
+The banner names the running version, and the Inventory step compares it against
+the gallery. Nothing in a run said this before, so a transcript could not be read
+against the code that made it -- a step that failed two releases ago looked
+identical to one failing now.
+
+## winget failures name themselves
+
+"winget upgrade --all" returns one exit code for the whole pass. The step now
+reports which packages are still out of date and separates two outcomes that
+need different answers:
+
+  Still out of date after this run:
+    astral-sh.uv 0.11.19 -> 0.12.7  (the install failed; a file was in use,
+                                     so close the program and run again)
+
+  Not upgradable on this machine, and expected to stay that way:
+    Cisco.CiscoWebexMeetings 45.6.4 -> 45.6.4.8  (winget listed it and did not
+                                     attempt it)
+
+The step is marked Warning only for packages winget actually attempted. One it
+declined is not a fault of the run.
+
+## pip
+
+A new step upgrades pip itself, through python -m pip -- on Windows pip cannot
+replace its own running executable, so the direct form fails on a locked file.
+pip is also in the inventory now.
+
+Installed packages are left alone, and an active virtual environment is never
+touched. Those packages belong to whatever project made it.
 
 ## Fixed
 
-* -Cadence PatchTuesday could not register a task at all, on either edition.
-  Register-ScheduledTask will not accept a client-only monthly trigger, so the
-  task is now registered and its XML rewritten.
-* A caller whose session set $ErrorActionPreference to Stop got failed steps
-  from tools that write to stderr as a matter of course -- npm, winget, wsl.
-  Each step threw before reaching the exit-code check written to handle it.
-* The gallery tooling (NuGet provider, PowerShellGet, PSResourceGet) was
-  installed when missing and then never brought forward.
+* The gallery tooling step logged "TerminatingError(Find-PackageProvider)" for a
+  lookup it handled correctly. Start-Transcript records a terminating error
+  whether or not it is caught, so an expected empty answer no longer throws.
 
-## Selecting steps
+## Documented rather than fixed
 
--Tag and -ExcludeTag narrow a run. Both are accepted by
-Register-UpdateEverythingTask, so one machine can carry a daily task that skips
-a toolchain and a monthly one that updates only it -- for something pinned to a
-version another application depends on.
-
-Tags: Windows, Microsoft, PowerShell, PackageManager, Python, Node, DotNet,
-Rust, Git, Self, Inventory.
-
-## Initialize-UpdateEverything
-
-A setup menu: prerequisites, scheduled task, developer tools, or a full first
-run. Typed numbers, no new dependency. A first run now says it exists.
-
-The developer-tools catalogue is the one exception to "this module updates, it
-does not install", and it is reachable only from the menu. -AllowInstall All
-does not reach it: All approves the components a run needs, and widening it to a
-dozen developer tools would turn an unattended task into a provisioning job.
-
-## Reporting
-
-* An Inventory step reports what is installed, at what version, and who owns it,
-  so a first run is not an unexplained column of skips. -Tag Inventory reports
-  and updates nothing.
-* The module pass says what moved rather than only that it finished.
-* Get-UpdateEverythingTask returns every task that runs this module, found by
-  what they run rather than by what they are called.
-
-## Also
-
-* -IncludePowerShellModules turns the module pass off.
-* -UpdateSelfSource takes Gallery or Main, and defaults to Gallery.
-* A package manager now runs before the toolchains it may own.
+An error appears twice in a run transcript. It is one error: the step log holds
+one copy and the summary counts one. PowerShell transcribes an error when it is
+raised and again when it is displayed, and removing the second copy would make
+errors invisible on the console. The README explains it and says which record to
+trust.
 '
+
         }
     }
 }


### PR DESCRIPTION
Version raised to 1.2.0, `ReleaseNotes` rewritten to describe this version, and
CONTRIBUTING's tag example moved with it.

```
UpdateEverything 1.2.0
Already on PSGallery at version 1.1.0.
All checks passed.

Staged UpdateEverything 1.2.0 — Files: 60
  Exports: Update-Everything, Initialize-UpdateEverything,
           Register-UpdateEverythingTask, Unregister-UpdateEverythingTask,
           Get-UpdateEverythingTask, Test-PendingReboot
```

## What is in it

| | |
|---|---|
| #44 | A run says which version produced it, and whether the gallery is ahead |
| #46 | Gallery tooling no longer logs a `TerminatingError` for a lookup it handles |
| #48 | winget failures name the packages, and separate "failed" from "declined" |
| #49 | The transcript double-render, documented rather than removed |
| #52 | pip is updated and reported |

**Four of the five came from reading two logs off a real machine**, not from the
plan. Worth saying, because it is the argument for looking at real output.

## Testing

698 tests, 0 failed. `Publish.ps1 -WhatIf` green.

The fresh-machine smoke test runs against `main` rather than a branch, so it
comes after this merges and before the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)