### PR TITLE
Add a self-elevation test that runs on a real machine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -492,6 +492,10 @@ Before publishing:
 - Run the [fresh-machine smoke test](tests/FreshMachine/README.md). It is not
   part of `test.ps1`, it needs a hypervisor and several minutes, and it belongs
   before a release rather than before a commit.
+- Run the [self-elevation test](tests/Elevation/README.md) if the release touches
+  elevation. It needs one click on a UAC prompt, which is why it is not in
+  `test.ps1` either, and it covers the one path the fresh-machine test reports
+  `N/A` for.
 
 Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:

--- a/tests/Elevation/Invoke-ElevatedHandoff.ps1
+++ b/tests/Elevation/Invoke-ElevatedHandoff.ps1
@@ -1,0 +1,100 @@
+#Requires -Version 5.1
+
+<#
+    .SYNOPSIS
+    Runs Update-Everything unelevated and records what the handoff did.
+
+    .DESCRIPTION
+    Records facts and judges nothing. Invoke-ElevationTest.ps1 reads the JSON and
+    decides what passed, so that the two halves can be read separately and this
+    one can be run by hand when something needs looking at.
+
+    The one thing it must be is unelevated. Update-Everything only reaches
+    Invoke-SelfElevation when the session is not already an administrator, which
+    is why every test of that path on a development machine has been vacuous.
+
+    Transcripts are identified by taking the directory listing before and after
+    rather than by predicting names. The elevated child computes its own run
+    stamp in its own process, and the environment does not reliably cross a
+    ShellExecute elevation boundary, so anything this process assumes about the
+    child's paths would be a guess.
+
+    .PARAMETER ResultPath
+    Where to write the JSON.
+
+    .EXAMPLE
+    Invoke-ElevatedHandoff.ps1 -ResultPath C:\out\handoff.json
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $ResultPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$record = [ordered]@{
+    Started            = (Get-Date).ToString('o')
+    User               = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+    Elevated           = $null
+    Host               = $PSVersionTable.PSVersion.ToString()
+    LogDirectory       = $null
+    TranscriptsBefore  = @()
+    TranscriptsAfter   = @()
+    Ran                = $null
+    ResultElevated     = $null
+    Reason             = $null
+    FailedCount        = $null
+    Error              = $null
+    Finished           = $null
+}
+
+try {
+    $record.Elevated = ([Security.Principal.WindowsPrincipal] `
+        [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+            [Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    Import-Module UpdateEverything -Force -ErrorAction Stop
+
+    # The same directory the module will choose, worked out the same way it does.
+    $logDir = Join-Path $env:USERPROFILE 'UpdateLogs'
+    $record.LogDirectory = $logDir
+
+    if (Test-Path -LiteralPath $logDir) {
+        $record.TranscriptsBefore = @(Get-ChildItem -LiteralPath $logDir -Filter 'Update-Everything-*.log' -File |
+            ForEach-Object { $_.Name })
+    }
+
+    # -Tag Inventory keeps the elevated child's work to seconds. Elevation is
+    # decided before any step runs, so the selection does not change whether the
+    # handoff happens -- only how long the child takes once it has.
+    #
+    # -LogRetentionDays 0 so the pruning cannot remove a transcript this test is
+    # about to count.
+    $result = Update-Everything -Tag Inventory -LogRetentionDays 0
+
+    $record.Ran            = $result.Ran
+    $record.ResultElevated = $result.Elevated
+    $record.Reason         = $result.Reason
+    $record.FailedCount    = $result.FailedCount
+
+    if (Test-Path -LiteralPath $logDir) {
+        $record.TranscriptsAfter = @(Get-ChildItem -LiteralPath $logDir -Filter 'Update-Everything-*.log' -File |
+            ForEach-Object { $_.Name })
+    }
+} catch {
+    $record.Error = $_.Exception.Message
+} finally {
+    $record.Finished = (Get-Date).ToString('o')
+
+    $parent = Split-Path $ResultPath -Parent
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        $null = New-Item -ItemType Directory -Path $parent -Force
+    }
+
+    [System.IO.File]::WriteAllText(
+        $ResultPath,
+        ([pscustomobject] $record | ConvertTo-Json -Depth 5),
+        [System.Text.UTF8Encoding]::new($false))
+}

--- a/tests/Elevation/Invoke-ElevationTest.ps1
+++ b/tests/Elevation/Invoke-ElevationTest.ps1
@@ -1,0 +1,280 @@
+#Requires -Version 5.1
+
+<#
+    .SYNOPSIS
+    Tests the self-elevation handoff on this machine, with one click from you.
+
+    .DESCRIPTION
+    The one thing the fresh-machine test cannot cover. Windows Sandbox ships with
+    UAC off, so it has no split token, RunLevel Limited cannot produce an
+    unelevated child, and Update-Everything never reaches self-elevation at all.
+    Development machines and CI runners are already administrators, so the
+    relaunch is never attempted there either.
+
+    This machine has UAC on. The only thing standing between here and real
+    coverage is that the prompt needs a person, so this asks for one click rather
+    than changing the machine's UAC settings to avoid it.
+
+    Nothing here is changed and nothing is left behind: no registry values, no
+    installs, and the scheduled task used to drop privileges is removed whether
+    the run succeeds or fails.
+
+    .PARAMETER TimeoutMinutes
+    How long to wait for the run, including the time you take to answer the
+    prompt. Default: 10.
+
+    .PARAMETER KeepOutput
+    Leave the result JSON and transcripts in place afterwards.
+
+    .EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\Elevation\Invoke-ElevationTest.ps1
+
+    .NOTES
+    Not part of test.ps1. Pester discovers *.Tests.ps1 only, and this one needs a
+    person at the keyboard.
+#>
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 60)]
+    [int] $TimeoutMinutes = 10,
+
+    [switch] $KeepOutput
+)
+
+$ErrorActionPreference = 'Stop'
+
+$script:Checks = [System.Collections.Generic.List[object]]::new()
+
+function Add-Check {
+    param([string] $Name, [bool] $Passed, [string] $Detail)
+    $script:Checks.Add([pscustomobject]@{ Name = $Name; Status = $(if ($Passed) { 'PASS' } else { 'FAIL' }); Passed = $Passed; Detail = $Detail })
+}
+
+function Add-NotApplicable {
+    # A third state, for the same reason the fresh-machine test has one: a check
+    # that could not run neither passed nor failed, and reporting it as a failure
+    # says the module is broken when the machine simply could not ask.
+    param([string] $Name, [string] $Reason)
+    $script:Checks.Add([pscustomobject]@{ Name = $Name; Status = 'N/A'; Passed = $null; Detail = $Reason })
+}
+
+Write-Host ''
+Write-Host 'Self-elevation test' -ForegroundColor Cyan
+Write-Host ''
+
+# --- prerequisites -----------------------------------------------------------
+
+$problems = [System.Collections.Generic.List[string]]::new()
+
+$policy = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+$values = Get-ItemProperty -LiteralPath $policy -ErrorAction SilentlyContinue
+$enableLua = if ($values -and $values.PSObject.Properties.Name -contains 'EnableLUA') { $values.EnableLUA } else { $null }
+$consent = if ($values -and $values.PSObject.Properties.Name -contains 'ConsentPromptBehaviorAdmin') { $values.ConsentPromptBehaviorAdmin } else { $null }
+
+Write-Host "  EnableLUA=$enableLua ConsentPromptBehaviorAdmin=$consent" -ForegroundColor DarkGray
+
+if ($enableLua -ne 1) {
+    $problems.Add("UAC is off (EnableLUA=$enableLua). With no split token there is nothing to elevate from, " +
+        'and this test would measure the refusal rather than the handoff.')
+}
+
+if (-not (Get-Module UpdateEverything -ListAvailable)) {
+    $problems.Add('UpdateEverything is not installed. Install-Module UpdateEverything -Scope CurrentUser')
+}
+
+if ($problems.Count) {
+    Write-Host ''
+    Write-Warning 'Cannot run the elevation test here:'
+    foreach ($p in $problems) { Write-Warning "  $p" }
+    return [pscustomobject]@{ Ran = $false; Passed = $false; Reason = ($problems -join ' ') }
+}
+
+# --- an unelevated session to run it from ------------------------------------
+
+$amAdmin = ([Security.Principal.WindowsPrincipal] `
+    [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator)
+
+$outputPath = Join-Path ([System.IO.Path]::GetTempPath()) ('UE-Elevation-{0:yyyyMMdd-HHmmss}' -f (Get-Date))
+$null = New-Item -ItemType Directory -Path $outputPath -Force
+$resultFile = Join-Path $outputPath 'handoff.json'
+$payload = Join-Path $PSScriptRoot 'Invoke-ElevatedHandoff.ps1'
+
+Write-Host ''
+Write-Host '  A UAC prompt will appear. Answer Yes.' -ForegroundColor Yellow
+Write-Host '  That click is the thing being tested, and is why this is not unattended.' -ForegroundColor DarkGray
+Write-Host ''
+
+$taskName = 'UpdateEverything-ElevationTest'
+$usedTask = $false
+
+try {
+    if ($amAdmin) {
+        # A scheduled task at RunLevel Limited is how an elevated session starts
+        # a genuinely unelevated child of the same user. Without it this test
+        # would run as an administrator and measure nothing, which is exactly how
+        # the relaunch shipped broken in the first place.
+        $usedTask = $true
+        Write-Host '  this session is elevated, so dropping privileges through a scheduled task...' -ForegroundColor DarkGray
+
+        $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
+            -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$payload`" -ResultPath `"$resultFile`""
+        $principal = New-ScheduledTaskPrincipal `
+            -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) `
+            -LogonType Interactive `
+            -RunLevel Limited
+
+        Register-ScheduledTask -TaskName $taskName -Action $action -Principal $principal -Force | Out-Null
+        Start-ScheduledTask -TaskName $taskName
+    } else {
+        Write-Host '  this session is not elevated, so running here directly...' -ForegroundColor DarkGray
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $payload -ResultPath $resultFile
+    }
+
+    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+    $announced = $false
+    while (-not (Test-Path -LiteralPath $resultFile) -and (Get-Date) -lt $deadline) {
+        if (-not $announced) {
+            Write-Host '  waiting for the run to finish...' -ForegroundColor DarkGray
+            $announced = $true
+        }
+        Start-Sleep -Seconds 3
+    }
+} finally {
+    if ($usedTask) {
+        Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+    }
+}
+
+if (-not (Test-Path -LiteralPath $resultFile)) {
+    Write-Host ''
+    Write-Warning "No result after $TimeoutMinutes minute(s). If the UAC prompt was declined or never appeared, that is why."
+    return [pscustomobject]@{ Ran = $false; Passed = $false; Reason = 'the unelevated run never wrote its result'; OutputPath = $outputPath }
+}
+
+$run = Get-Content -LiteralPath $resultFile -Raw | ConvertFrom-Json
+
+# --- what happened -----------------------------------------------------------
+
+Write-Host ''
+Write-Host '== Results ==' -ForegroundColor Cyan
+
+Add-Check -Name 'UAC is on, so elevation is real' -Passed ($enableLua -eq 1) -Detail "EnableLUA=$enableLua"
+
+Add-Check -Name 'the run started without administrator rights' -Passed (-not $run.Elevated) `
+    -Detail "elevated=$($run.Elevated), as $($run.User)"
+
+if ($run.Error) {
+    Add-Check -Name 'the run completed without throwing' -Passed $false -Detail $run.Error
+} else {
+    Add-Check -Name 'the run completed without throwing' -Passed $true
+}
+
+# Update-Everything hands off and returns Ran=$false with Elevated=$true. Ran
+# being true would mean it decided to carry on unelevated instead, which is a
+# different code path and not the one under test.
+$handedOff = ($run.Ran -eq $false -and $run.ResultElevated -eq $true)
+
+# A third possibility, and reporting it as a plain failure was misleading on the
+# first machine this ran on. Test-ElevationCapability can refuse before any
+# prompt appears, and then nothing downstream happened -- so three checks fail
+# and none of them says why.
+#
+# Whether a refusal is correct depends on something this harness cannot settle:
+# a genuine standard user should be refused, and an account elevated through a
+# privilege-management broker should not, and both look identical from here.
+# So it is reported as its own outcome, with the module's reason, for a person
+# to judge.
+$refused = ($run.Ran -eq $false -and $run.ResultElevated -ne $true -and
+            $run.Reason -and $run.Reason -notmatch 'exit code')
+
+if ($refused) {
+    Add-NotApplicable -Name 'it elevated rather than carrying on unelevated' `
+        -Reason "the module declined to attempt elevation: $($run.Reason)"
+    Add-NotApplicable -Name 'the parent reported the elevated exit code' `
+        -Reason 'no elevation was attempted'
+} else {
+    Add-Check -Name 'it elevated rather than carrying on unelevated' -Passed $handedOff `
+        -Detail "Ran=$($run.Ran) Elevated=$($run.ResultElevated)"
+
+    $reasonNamesExit = [bool] ($run.Reason -and $run.Reason -match 'exit code')
+    Add-Check -Name 'the parent reported the elevated exit code' -Passed $reasonNamesExit -Detail $run.Reason
+}
+
+$countIsNumber = ($null -ne $run.FailedCount) -and ($run.FailedCount -is [int] -or $run.FailedCount -is [long])
+Add-Check -Name 'FailedCount came back as a number' -Passed $countIsNumber -Detail "FailedCount=$($run.FailedCount)"
+
+# The check this whole harness exists for. One transcript means the elevated
+# child died before it could log -- which is exactly how the relaunch parse error
+# presented, and why it reached a user's laptop.
+$before = @($run.TranscriptsBefore)
+$after = @($run.TranscriptsAfter)
+$new = @($after | Where-Object { $_ -notin $before })
+
+if ($refused) {
+    Add-NotApplicable -Name 'both the parent and the elevated child left a transcript' `
+        -Reason "$($new.Count) transcript(s); there is no second one because no child was started"
+} else {
+    Add-Check -Name 'both the parent and the elevated child left a transcript' -Passed ($new.Count -ge 2) `
+        -Detail "$($new.Count) new transcript(s): $($new -join ', ')"
+}
+
+# The child's own transcript should reach a summary, which proves it ran rather
+# than merely starting.
+$reachedSummary = $false
+if (-not $refused -and $new.Count -ge 2 -and $run.LogDirectory) {
+    foreach ($name in $new) {
+        $path = Join-Path $run.LogDirectory $name
+        if (Test-Path -LiteralPath $path) {
+            $text = Get-Content -LiteralPath $path -Raw -ErrorAction SilentlyContinue
+            if ($text -match 'SUMMARY') { $reachedSummary = $true; break }
+        }
+    }
+    Add-Check -Name 'the elevated run reached its summary' -Passed $reachedSummary
+} else {
+    Add-NotApplicable -Name 'the elevated run reached its summary' `
+        -Reason 'there was no second transcript to read'
+}
+
+# --- report ------------------------------------------------------------------
+
+Write-Host ''
+foreach ($check in $script:Checks) {
+    $colour = switch ($check.Status) { 'PASS' { 'Green' } 'FAIL' { 'Red' } default { 'DarkYellow' } }
+    Write-Host ("  [{0,-4}] {1}" -f $check.Status, $check.Name) -ForegroundColor $colour
+    if ($check.Detail) { Write-Host "         $($check.Detail)" -ForegroundColor DarkGray }
+}
+
+$failed = @($script:Checks | Where-Object { $_.Status -eq 'FAIL' })
+$notCovered = @($script:Checks | Where-Object { $_.Status -eq 'N/A' })
+
+Write-Host ''
+if ($failed.Count) {
+    Write-Host "Elevation test FAILED: $($failed.Count) check(s)." -ForegroundColor Red
+} elseif ($notCovered.Count) {
+    Write-Host "Elevation test passed, with $($notCovered.Count) check(s) this machine could not make." -ForegroundColor DarkYellow
+} else {
+    Write-Host 'Elevation test passed. The self-elevation handoff works on this machine.' -ForegroundColor Green
+}
+
+if ($refused) {
+    Write-Host ''
+    Write-Host '  NOTE: the handoff was NOT exercised. The module declined to attempt' -ForegroundColor DarkYellow
+    Write-Host '        elevation, and whether that was right depends on this account.' -ForegroundColor DarkYellow
+    Write-Host '        An account elevated through a privilege-management broker is not' -ForegroundColor DarkYellow
+    Write-Host '        in the local Administrators group and can still elevate.' -ForegroundColor DarkYellow
+}
+
+Write-Host "Output: $outputPath" -ForegroundColor DarkGray
+
+if (-not $KeepOutput -and -not $failed.Count) {
+    Remove-Item -LiteralPath $outputPath -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+[pscustomobject]@{
+    Ran        = $true
+    Passed     = ($failed.Count -eq 0)
+    NotCovered = $notCovered.Count
+    Checks     = $script:Checks.ToArray()
+    OutputPath = $outputPath
+}

--- a/tests/Elevation/README.md
+++ b/tests/Elevation/README.md
@@ -1,0 +1,83 @@
+# Self-elevation test
+
+Runs `Update-Everything` **without administrator rights** on this machine, and
+checks that the elevated child starts, runs, and leaves its own transcript.
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\Elevation\Invoke-ElevationTest.ps1
+```
+
+A UAC prompt appears and you answer it. That click is why this is not part of
+`test.ps1`.
+
+## Why it exists
+
+The one thing nothing else covers.
+
+| Where | Why the handoff is never reached |
+|---|---|
+| Development machines | already an administrator, so `Test-IsAdministrator` returns true |
+| `windows-latest` CI | same |
+| Windows Sandbox | ships with `EnableLUA=0`; no split token, so `RunLevel Limited` cannot make an unelevated child |
+
+The relaunch command shipped unable to parse, and every non-elevated run hit it —
+which is to say every ordinary first run. It reached a laptop because no test
+could reach the code.
+
+## What it checks
+
+- UAC is on, so elevation means something
+- The run really started **without** administrator rights
+- It elevated rather than carrying on unelevated
+- The parent reported the child's exit code
+- `FailedCount` came back as a number
+- **Two transcripts.** The parent's, recording the handoff, and the elevated
+  child's own. One means the child died before it could log, which is precisely
+  how the relaunch parse error presented
+- The elevated run reached its summary, so it ran rather than merely started
+
+## What it changes
+
+Nothing. No registry values, no installs, and the scheduled task used to drop
+privileges is removed whether the run succeeds or fails.
+
+Notably it does **not** set `ConsentPromptBehaviorAdmin` to 0. The Sandbox
+harness does that inside a disposable machine; doing it to a real one to save a
+click would be trading a person's security settings for convenience.
+
+## Running it from an elevated session
+
+It handles that. A scheduled task at `RunLevel Limited` is how an elevated
+session starts a genuinely unelevated child of the same user — without it the
+test would run as an administrator and measure nothing, which is exactly how the
+relaunch shipped broken.
+
+## When the module declines to elevate
+
+Reported as `N/A` with the module's own reason, not as a failure, because whether
+a refusal is correct depends on the account and this harness cannot settle it:
+
+- A genuine standard user **should** be refused
+- An account elevated through a **privilege-management broker** — BeyondTrust,
+  CyberArk EPM, Admin By Request and others — is *not* in the local
+  Administrators group and can still elevate
+
+Both look identical from here. The first run of this test hit the second case on
+a corporate laptop: not a member of the group, `Avecto Defendpoint Service`
+running, and elevated sessions working all day. See the issue linked from the
+run's note.
+
+## Coverage, honestly
+
+Together with `tests/FreshMachine`, the three defects that motivated a harness at
+all are covered:
+
+| Defect | Covered by |
+|---|---|
+| The elevated relaunch did not parse | **this test** |
+| The documented install required `pwsh` | fresh-machine |
+| The documented install worked exactly once | fresh-machine |
+
+An unattended version needs a VM that boots with UAC on and a checkpoint restored
+between runs — Hyper-V, a Windows image, and a machine willing to host it. This
+one needs a click, and gets the same answer today.

--- a/tests/FreshMachine/README.md
+++ b/tests/FreshMachine/README.md
@@ -70,9 +70,10 @@ and a suite that cries wolf is one people stop reading. They now report `N/A`
 with the reason, the run still passes, and the summary says how many checks it
 could not make.
 
-Real elevation coverage needs a VM that can boot with UAC on — a Hyper-V
-checkpoint restored between runs. That is a heavier harness than this one and
-has not been built.
+Real elevation coverage is now in [`tests/Elevation`](../Elevation/README.md),
+which runs on a real machine with UAC on and asks for one click. An *unattended*
+version still needs a VM that can boot with UAC on — a Hyper-V checkpoint
+restored between runs — and that has not been built.
 
 ## The UAC part
 


### PR DESCRIPTION
The one path nothing covered.

| Where | Why the handoff is never reached |
|---|---|
| Development machines | already an administrator |
| `windows-latest` CI | same |
| Windows Sandbox | `EnableLUA=0`; no split token, so `RunLevel Limited` cannot make an unelevated child |

That is how a relaunch command that did not parse reached a laptop: every
non-elevated run hit it, and no test could reach the code.

## Attended, deliberately

This machine has UAC on, so the only thing missing was a person to answer the
prompt. It asks for **one click** rather than setting `ConsentPromptBehaviorAdmin`
to 0 on a real machine — the Sandbox harness does that inside a *disposable*
machine, where it costs nothing.

It changes nothing and leaves nothing behind. Started from an elevated session it
drops privileges through a scheduled task at `RunLevel Limited` and removes the
task either way; without that it would run as an administrator and measure
nothing, which is the original bug.

The check that matters is **two transcripts** — the parent's recording the
handoff, and the elevated child's own. One means the child died before it could
log, which is precisely how the parse error presented.

## Its first run found a defect, and not the one it was looking for

The module refused to attempt elevation:

> This account is not a member of the local Administrators group, so Windows will
> not grant elevation.

True, and **irrelevant on this machine**:

```
local Administrators : kronberb2026\Administrator, kronberb2026\WorldWT
I am a direct member : False
this session elevated: True
Avecto Defendpoint Service : Running
```

A privilege-management broker grants elevation without group membership — and
per application, which also explains why `pwsh` can elevate here and `cmd`
cannot. Filed as #55.

## The harness earned a refinement on that first run

Reporting a refusal as a plain failure was misleading: three checks failed and
none said why. A refusal is now its own outcome with the module's reason
attached, because whether it is *correct* depends on the account — a genuine
standard user should be refused, a broker-managed one should not, and they look
identical from outside.

```
Elevation test passed, with 4 check(s) this machine could not make.

  NOTE: the handoff was NOT exercised. The module declined to attempt
        elevation, and whether that was right depends on this account.
```

## Coverage

With this, all three defects that motivated a harness are covered:

| Defect | Covered by |
|---|---|
| The elevated relaunch did not parse | **this test** |
| The documented install required `pwsh` | fresh-machine |
| The documented install worked exactly once | fresh-machine |

An *unattended* version still needs Hyper-V, a Windows image, and a checkpoint
restored between runs. This one needs a click and gets the same answer today.

## Testing

698 tests, 0 failed. Harness lint clean against the repo settings. Run twice on
this machine — once to find the refusal, once to confirm it reports it properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)