### PR TITLE
Attempt elevation for an account outside the Administrators group

### DIFF
--- a/src/Private/Test-ElevationCapability.ps1
+++ b/src/Private/Test-ElevationCapability.ps1
@@ -1,8 +1,37 @@
-﻿function Test-ElevationCapability {
-    # Decides, before anything is attempted, whether this run can become
-    # Administrator -- so the script can explain itself instead of raising a UAC
-    # prompt that cannot succeed, or hanging on one that never appears.
+function Test-ElevationCapability {
+    <#
+        .SYNOPSIS
+        Decides, before anything is attempted, whether this run can become
+        Administrator.
+
+        .DESCRIPTION
+        Returns IsElevated, CanElevate, Reason, and Caution.
+
+        Only two things refuse outright, and both are certain rather than
+        probable: UAC switched off, and a packaged PowerShell with no MSI build
+        beside it. In each case Windows will not grant elevation to anybody, so
+        raising a prompt would waste a person's time and then report the failure
+        as though they had declined it.
+
+        Not being in the local Administrators group is a Caution, not a refusal.
+        It used to be a refusal, and that was wrong on any machine running a
+        privilege-management broker -- BeyondTrust, CyberArk EPM, Admin By
+        Request and others -- where the account is deliberately not in the group
+        and elevates anyway, often per application. Measured on one such laptop:
+        not a member, Avecto Defendpoint running, elevated sessions working all
+        day, and this function refusing to try.
+
+        The harm is lopsided. Refusing wrongly makes the module unusable and says
+        something untrue about the machine. Attempting wrongly costs one prompt
+        that fails, which Invoke-SelfElevation already reports well and
+        Get-ElevationPolicyNote already explains.
+
+        .EXAMPLE
+        $elevation = Test-ElevationCapability
+        if (-not $elevation.CanElevate) { Write-Warning $elevation.Reason }
+    #>
     [CmdletBinding()]
+    [OutputType([pscustomobject])]
     param()
 
     if (Test-IsAdministrator) {
@@ -10,16 +39,7 @@
             IsElevated = $true
             CanElevate = $true
             Reason     = 'Already running as Administrator.'
-        }
-    }
-
-    # Only a definite $false blocks the run. $null means "could not tell", and
-    # guessing wrong here would refuse to run for a legitimate administrator.
-    if ((Test-AdministratorGroupMember) -eq $false) {
-        return [pscustomobject]@{
-            IsElevated = $false
-            CanElevate = $false
-            Reason     = 'This account is not a member of the local Administrators group, so Windows will not grant elevation. An administrator has to run the script, or use -SkipElevation to run the steps that do not need admin.'
+            Caution    = $null
         }
     }
 
@@ -28,14 +48,14 @@
             IsElevated = $false
             CanElevate = $false
             Reason     = 'UAC (EnableLUA) is disabled, so this session cannot request elevation. Sign in with an elevated session, or use -SkipElevation.'
+            Caution    = $null
         }
     }
 
     # An MSIX PowerShell cannot be elevated at all: Windows does not run packaged
     # apps elevated, and the app execution alias that also reaches it is a
-    # zero-byte reparse point rather than a program. Saying so here is this
-    # function's whole purpose -- otherwise the run raises a UAC prompt that
-    # cannot succeed and reports the failure as though the user had declined it.
+    # zero-byte reparse point rather than a program. This one is a genuine
+    # certainty -- it does not depend on who is asking -- so it still refuses.
     # The MSI build, if it is installed alongside, can elevate, and
     # Invoke-SelfElevation relaunches through it.
     if ((Test-PackagedProcess) -and -not (Test-Path -LiteralPath (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'))) {
@@ -43,12 +63,22 @@
             IsElevated = $false
             CanElevate = $false
             Reason     = 'This session is the MSIX build of PowerShell (the Store and winget default), and Windows does not run packaged apps elevated. Install the MSI build with "winget install --id Microsoft.PowerShell --exact --source winget --installer-type wix", start an elevated session yourself, or use -SkipElevation.'
+            Caution    = $null
         }
+    }
+
+    # A definite "not in the group" is worth saying and not worth refusing over.
+    # $null means it could not be determined at all, which was never grounds for
+    # anything.
+    $caution = $null
+    if ((Test-AdministratorGroupMember) -eq $false) {
+        $caution = 'This account is not in the local Administrators group, so the prompt may be refused. Machines using a privilege-management broker elevate without that membership, so it is worth attempting. If it fails, -SkipElevation runs the steps that do not need admin.'
     }
 
     [pscustomobject]@{
         IsElevated = $false
         CanElevate = $true
         Reason     = 'Elevation can be requested.'
+        Caution    = $caution
     }
 }

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -329,6 +329,11 @@
         # script raises a UAC prompt a standard user can never satisfy, and reports
         # the refusal as though the user had declined it.
         $elevation = Test-ElevationCapability
+
+        # Said before the attempt, so that a prompt which is then refused reads
+        # as the thing that was warned about rather than as a surprise.
+        if ($elevation.Caution) { Write-Warning $elevation.Caution }
+
         if (-not $elevation.CanElevate) {
             Write-Warning "Cannot run elevated: $($elevation.Reason)"
             Write-Warning 'Nothing has been changed. Re-run with -SkipElevation to run the steps that do not need administrator rights.'

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1051,23 +1051,51 @@ Describe 'Test-ElevationCapability' -Tag 'Unit','Security' {
         }
     }
 
-    Context 'A standard user who cannot elevate at all' {
+    Context 'An account that is not in the local Administrators group' {
+
+        # This used to refuse, and it was wrong on any machine running a
+        # privilege-management broker -- BeyondTrust, CyberArk EPM, Admin By
+        # Request -- where the account is deliberately not in the group and
+        # elevates anyway. Measured on one: not a member, Avecto Defendpoint
+        # running, elevated sessions working all day, and the module refusing to
+        # try. Refusing wrongly makes it unusable; attempting wrongly costs one
+        # prompt that is already reported well.
 
         BeforeEach {
             Mock Test-IsAdministrator { $false }
             Mock Test-AdministratorGroupMember { $false }
+            Mock Test-UacEnabled { $true }
+            Mock Test-PackagedProcess { $false }
         }
 
-        It 'refuses rather than raising a prompt that cannot succeed' {
-            (Test-ElevationCapability).CanElevate | Should-BeFalse
+        It 'attempts elevation rather than refusing' {
+            (Test-ElevationCapability).CanElevate | Should-BeTrue
         }
 
-        It 'explains that the account is not an administrator' {
-            (Test-ElevationCapability).Reason | Should-MatchString 'not a member of the local Administrators group'
+        It 'warns that the prompt may be refused' {
+            (Test-ElevationCapability).Caution | Should-MatchString 'may be refused'
+        }
+
+        It 'says why attempting is still worth it' {
+            (Test-ElevationCapability).Caution | Should-MatchString 'privilege-management broker'
         }
 
         It 'points at -SkipElevation as the way forward' {
-            (Test-ElevationCapability).Reason | Should-MatchString 'SkipElevation'
+            (Test-ElevationCapability).Caution | Should-MatchString 'SkipElevation'
+        }
+    }
+
+    Context 'The caution reaches the person running it' {
+
+        It 'is written as a warning before elevation is attempted' {
+            $source = Get-Content `
+                (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+
+            $warned = $source.IndexOf('if ($elevation.Caution) { Write-Warning $elevation.Caution }')
+            $attempt = $source.IndexOf('Invoke-SelfElevation -BoundParameters')
+
+            $warned | Should-BeGreaterThan -1
+            $warned | Should-BeLessThan $attempt
         }
     }
 


### PR DESCRIPTION
Closes #55.

`Test-ElevationCapability` refused when the account was not in the local
Administrators group, telling the user Windows would not grant elevation. **That
is false on any machine running a privilege-management broker** — BeyondTrust,
CyberArk EPM, Admin By Request — where the account is deliberately not in the
group and elevates anyway, often per application.

Measured on the laptop this was found on:

```
local Administrators : kronberb2026\Administrator, kronberb2026\WorldWT
I am a direct member : False
this session elevated: True
Avecto Defendpoint Service : Running
```

Not a member. Elevating all day. The module refusing to try.

The same broker also explains why `pwsh` can elevate there and `cmd` cannot —
which an earlier search for a registry policy could never have found, because
there is no such policy.

## The harm is lopsided

| | Cost |
|---|---|
| Refusing wrongly | the module is unusable, with a message that is untrue |
| Attempting wrongly | one prompt that fails, already reported well |

So group membership is now a **Caution, not a refusal**, written as a warning
*before* the attempt so a prompt that is then refused reads as the thing that was
warned about rather than a surprise.

**The two genuine certainties still refuse**: UAC switched off, and a packaged
PowerShell with no MSI build beside it. Neither depends on who is asking. The
order changed with it — the certain checks come first, since the group check
returning early is what let it shadow them.

## Verified by the thing it fixes

The elevation harness reported the refusal before this change. Now:

```
[PASS] UAC is on, so elevation is real
[PASS] the run started without administrator rights
[PASS] the run completed without throwing
[PASS] it elevated rather than carrying on unelevated   Ran=False Elevated=True
[PASS] the parent reported the elevated exit code       exit code 0
[PASS] FailedCount came back as a number                FailedCount=0
[PASS] both the parent and the elevated child left a transcript
       2 new transcript(s)
[PASS] the elevated run reached its summary

Elevation test passed. The self-elevation handoff works on this machine.
NotCovered : 0
```

**That is the first end-to-end verification of the self-elevation handoff.** Two
transcripts — the check that would have caught the relaunch parse error before it
reached anyone.

## Testing

700 tests, 0 failed (was 698). PSScriptAnalyzer clean over `src` under its
default rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)