### PR TITLE
Name a privilege broker when elevation fails

### DIFF
--- a/src/Private/Get-ElevationPolicyNote.ps1
+++ b/src/Private/Get-ElevationPolicyNote.ps1
@@ -1,4 +1,4 @@
-﻿function Get-ElevationPolicyNote {
+function Get-ElevationPolicyNote {
     <#
         .SYNOPSIS
         Explains, from policy, why an elevation attempt was refused.
@@ -16,7 +16,7 @@
         machine. Naming the value that did it turns the same failure into
         something someone can take to whoever manages the policy.
 
-        The values that explain a failure:
+        The registry values that explain a failure:
 
           ConsentPromptBehaviorUser = 0     a standard user's request is denied
                                             outright; no prompt is ever shown
@@ -24,8 +24,20 @@
                                             signature may elevate
           EnableLUA = 0                     there is no consent prompt to answer
 
-        Returns nothing when none of them is set restrictively, so a caller can
-        append the result and say nothing extra on an ordinary machine.
+        A privilege-management broker is also named when one is running.
+        Nothing it does appears in the registry at all: it can deny an elevation,
+        or allow one application and refuse another, without leaving a value
+        behind. Without this, a refusal on such a machine produced no note --
+        which reads as "no policy is interfering" when one just did.
+
+        Recognising brokers by service name means keeping a list of vendors, and
+        that would be the wrong trade for a decision -- the next vendor would be
+        missed and a capable machine turned away. It is the right trade for an
+        explanation: a missing entry costs a sentence, and nothing is decided
+        either way.
+
+        Returns nothing when nothing restrictive is found, so a caller can append
+        the result and say nothing extra on an ordinary machine.
 
         .EXAMPLE
         $note = Get-ElevationPolicyNote
@@ -35,27 +47,58 @@
     [OutputType([string])]
     param()
 
+    $notes = [System.Collections.Generic.List[string]]::new()
+
     $policy = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
 
     # One read, then look for the values on the object. Asking for a named value
     # that is absent throws, and Start-Transcript records the throw even when it
     # is caught -- which reads as a fault in a log where nothing went wrong.
     $values = Get-ItemProperty -LiteralPath $policy -ErrorAction SilentlyContinue
-    if (-not $values) { return }
 
-    $names = $values.PSObject.Properties.Name
-    $notes = [System.Collections.Generic.List[string]]::new()
+    if ($values) {
+        $names = $values.PSObject.Properties.Name
 
-    if ($names -contains 'EnableLUA' -and $values.EnableLUA -eq 0) {
-        $notes.Add('UAC is switched off (EnableLUA is 0), so there is no consent prompt to answer.')
+        if ($names -contains 'EnableLUA' -and $values.EnableLUA -eq 0) {
+            $notes.Add('UAC is switched off (EnableLUA is 0), so there is no consent prompt to answer.')
+        }
+
+        if ($names -contains 'ConsentPromptBehaviorUser' -and $values.ConsentPromptBehaviorUser -eq 0) {
+            $notes.Add('Policy denies elevation requests from standard users outright (ConsentPromptBehaviorUser is 0), so a standard user is never prompted.')
+        }
+
+        if ($names -contains 'ValidateAdminCodeSignatures' -and $values.ValidateAdminCodeSignatures -eq 1) {
+            $notes.Add('Policy allows only executables with a validated signature to elevate (ValidateAdminCodeSignatures is 1).')
+        }
     }
 
-    if ($names -contains 'ConsentPromptBehaviorUser' -and $values.ConsentPromptBehaviorUser -eq 0) {
-        $notes.Add('Policy denies elevation requests from standard users outright (ConsentPromptBehaviorUser is 0), so a standard user is never prompted.')
+    # Vendor-identifying names rather than a bare "privilege", which matches
+    # unrelated services and would send someone to their IT department over
+    # nothing.
+    $brokerPatterns = @(
+        '*defendpoint*', '*avecto*', '*beyondtrust*', '*privilege management*',
+        '*adminbyrequest*', '*admin by request*', '*cyberark*',
+        '*arellia*', '*thycotic*', '*delinea*'
+    )
+
+    $broker = $null
+    try {
+        $running = @(Get-Service -ErrorAction SilentlyContinue | Where-Object { $_.Status -eq 'Running' })
+        foreach ($service in $running) {
+            foreach ($pattern in $brokerPatterns) {
+                if ($service.Name -like $pattern -or $service.DisplayName -like $pattern) {
+                    $broker = $service.DisplayName
+                    break
+                }
+            }
+            if ($broker) { break }
+        }
+    } catch {
+        Write-Verbose "Could not enumerate services to look for a privilege broker: $($_.Exception.Message)"
     }
 
-    if ($names -contains 'ValidateAdminCodeSignatures' -and $values.ValidateAdminCodeSignatures -eq 1) {
-        $notes.Add('Policy allows only executables with a validated signature to elevate (ValidateAdminCodeSignatures is 1).')
+    if ($broker) {
+        $notes.Add("A privilege-management broker is running on this machine ($broker). Those grant or deny elevation per application and leave nothing in the registry, so it may have refused this one even though the policy values above look permissive.")
     }
 
     if ($notes.Count -eq 0) { return }

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -834,6 +834,15 @@ Describe 'Get-ElevationPolicyNote' -Tag 'Unit','Security' {
     # because Test-AdministratorGroupMember already answers $null when a
     # filtered token hides the Administrators SID.
 
+    BeforeEach {
+        # No broker, so these test the registry path alone. Without this the
+        # three "says nothing" tests pass or fail depending on what is running on
+        # the machine -- they were silently host-dependent until a privilege
+        # broker was added to what this function looks at, and then failed on the
+        # first machine that had one.
+        Mock Get-Service { @() }
+    }
+
     It 'says nothing on a machine with no restrictive policy' {
         Mock Get-ItemProperty { [pscustomobject]@{ EnableLUA = 1; ConsentPromptBehaviorAdmin = 2 } }
         Get-ElevationPolicyNote | Should-BeNull
@@ -2605,5 +2614,87 @@ Describe 'pip is in the inventory' -Tag 'Unit' {
             (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Get-UpdateToolInventory.ps1') -Raw
 
         $source | Should-MatchString "Name = 'pip';"
+    }
+}
+
+Describe 'Get-ElevationPolicyNote names a privilege broker' -Tag 'Unit' {
+
+    # A broker can deny an elevation, or allow one application and refuse
+    # another, without leaving anything in the registry. Before this, a refusal
+    # on such a machine produced no note at all -- which reads as "no policy is
+    # interfering" when one just did.
+    #
+    # Recognising vendors by service name would be the wrong trade for a
+    # decision: the next vendor would be missed and a capable machine turned
+    # away. It is the right trade for an explanation, where a missing entry costs
+    # a sentence and decides nothing.
+
+    BeforeEach {
+        # Nothing restrictive in the registry, so only the broker can produce a
+        # note. That is the case this exists for.
+        Mock Get-ItemProperty { [pscustomobject]@{ EnableLUA = 1; ConsentPromptBehaviorAdmin = 2 } }
+    }
+
+    It 'names <_> when its service is running' -ForEach @(
+        'Avecto Defendpoint Service'
+        'BeyondTrust Privilege Management'
+        'CyberArk Endpoint Privilege Manager'
+        'AdminByRequest'
+    ) {
+        $display = $_
+        Mock Get-Service { @([pscustomobject]@{ Name = 'svc'; DisplayName = $display; Status = 'Running' }) }
+
+        Get-ElevationPolicyNote | Should-MatchString ([regex]::Escape($display))
+    }
+
+    It 'says a broker leaves nothing in the registry' {
+        Mock Get-Service { @([pscustomobject]@{ Name = 'defendpoint'; DisplayName = 'Avecto Defendpoint Service'; Status = 'Running' }) }
+
+        Get-ElevationPolicyNote | Should-MatchString 'leave nothing in the registry'
+    }
+
+    It 'ignores a broker service that is not running' {
+        Mock Get-Service { @([pscustomobject]@{ Name = 'defendpoint'; DisplayName = 'Avecto Defendpoint Service'; Status = 'Stopped' }) }
+
+        Get-ElevationPolicyNote | Should-BeNull
+    }
+
+    # "privilege" alone matches unrelated services, and a false positive here
+    # sends somebody to their IT department over nothing.
+    It 'does not match a service that merely contains the word privilege' {
+        Mock Get-Service { @([pscustomobject]@{ Name = 'SeprivilegeHelper'; DisplayName = 'Some Privilege Helper'; Status = 'Running' }) }
+
+        Get-ElevationPolicyNote | Should-BeNull
+    }
+
+    It 'says nothing on a machine with neither policy nor broker' {
+        Mock Get-Service { @([pscustomobject]@{ Name = 'Spooler'; DisplayName = 'Print Spooler'; Status = 'Running' }) }
+
+        Get-ElevationPolicyNote | Should-BeNull
+    }
+
+    It 'still reports a restrictive registry value with no broker present' {
+        Mock Get-ItemProperty { [pscustomobject]@{ ConsentPromptBehaviorUser = 0 } }
+        Mock Get-Service { @() }
+
+        Get-ElevationPolicyNote | Should-MatchString 'ConsentPromptBehaviorUser'
+    }
+
+    It 'reports both when both are present' {
+        Mock Get-ItemProperty { [pscustomobject]@{ ConsentPromptBehaviorUser = 0 } }
+        Mock Get-Service { @([pscustomobject]@{ Name = 'x'; DisplayName = 'Avecto Defendpoint Service'; Status = 'Running' }) }
+
+        $note = Get-ElevationPolicyNote
+        $note | Should-MatchString 'ConsentPromptBehaviorUser'
+        $note | Should-MatchString 'Avecto'
+    }
+
+    # Enumerating services can fail on a locked-down machine, and an explanation
+    # that throws is worse than one that is missing.
+    It 'survives being unable to enumerate services' {
+        Mock Get-Service { throw 'access denied' }
+        Mock Get-ItemProperty { [pscustomobject]@{ ConsentPromptBehaviorUser = 0 } }
+
+        Get-ElevationPolicyNote | Should-MatchString 'ConsentPromptBehaviorUser'
     }
 }


### PR DESCRIPTION
Follow-on from #55, and the loose end noted there.

A privilege-management broker can deny an elevation — or allow one application
and refuse another — **without leaving anything in the registry**.
`Get-ElevationPolicyNote` reads registry values, so on such a machine a refusal
produced *no note at all*, which reads as "no policy is interfering" when one
just had.

That machine exists. It is the laptop this was found on, and the same broker is
why `pwsh` can elevate there and `cmd` cannot. An earlier search for a registry
policy explaining the cmd restriction found nothing — correctly, because there is
nothing to find.

## The distinction from #55

Recognising vendors by service name means keeping a list. That is the **wrong
trade for a decision**: the next vendor would be missed and a capable machine
turned away, which is exactly the bug #57 just fixed.

It is the **right trade for an explanation**: a missing entry costs a sentence
and decides nothing.

The patterns are vendor-identifying rather than a bare `*privilege*`, which
matches unrelated services — a false positive here sends somebody to their IT
department over nothing, and there is a test for that.

## On the real machine

```
Policy on this machine may be the cause: Policy denies elevation requests from
standard users outright (ConsentPromptBehaviorUser is 0), so a standard user is
never prompted. A privilege-management broker is running on this machine (Avecto
Defendpoint Service). Those grant or deny elevation per application and leave
nothing in the registry, so it may have refused this one even though the policy
values above look permissive.
```

## A test-quality problem this exposed

Three existing tests were **silently host-dependent**. They mocked the registry
and let the real `Get-Service` run, so they passed only on a machine without a
broker — and failed on the first one that had one. They now mock it to an empty
set, which is what they always meant.

Worth noting because they were green for months while depending on a fact about
the machine.

## Testing

711 tests, 0 failed (was 700). PSScriptAnalyzer clean over `src` under its
default rules. Verified against the real machine, shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)