### PR TITLE
Prepare 1.2.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -501,7 +501,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.2.0 -m "1.2.0" && git push origin v1.2.0
+git tag -a v1.2.1 -m "1.2.1" && git push origin v1.2.1
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.2.0'
+    ModuleVersion     = '1.2.1'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -32,58 +32,40 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.2.0
+            ReleaseNotes = '# 1.2.1
 
-A run now says what version produced it, names the packages winget could not
-upgrade, and updates pip. Most of this came from reading two logs off a real
-machine.
+One fix, and it matters on managed machines: UpdateEverything refused to elevate
+on any machine using a privilege-management broker.
 
-## A run says what it is
+## Elevation is attempted rather than refused
 
-The banner names the running version, and the Inventory step compares it against
-the gallery. Nothing in a run said this before, so a transcript could not be read
-against the code that made it -- a step that failed two releases ago looked
-identical to one failing now.
+Test-ElevationCapability treated "not a member of the local Administrators
+group" as proof that Windows would not grant elevation. That is false wherever a
+privilege-management broker is in use -- BeyondTrust, CyberArk EPM, Admin By
+Request -- because the account is deliberately not in the group and elevates
+anyway, often per application.
 
-## winget failures name themselves
+On such a machine the module was unusable: it refused before raising a prompt,
+and told the user something untrue about their computer.
 
-"winget upgrade --all" returns one exit code for the whole pass. The step now
-reports which packages are still out of date and separates two outcomes that
-need different answers:
+Group membership is now a caution rather than a refusal, warned about before the
+attempt. The two genuine certainties still refuse, because neither depends on
+who is asking: UAC switched off, and a packaged PowerShell with no MSI build
+beside it.
 
-  Still out of date after this run:
-    astral-sh.uv 0.11.19 -> 0.12.7  (the install failed; a file was in use,
-                                     so close the program and run again)
+## A failed elevation says more
 
-  Not upgradable on this machine, and expected to stay that way:
-    Cisco.CiscoWebexMeetings 45.6.4 -> 45.6.4.8  (winget listed it and did not
-                                     attempt it)
+Get-ElevationPolicyNote now names a running privilege broker. Those grant or
+deny elevation per application and leave nothing in the registry, so a refusal
+on such a machine previously produced no explanation at all.
 
-The step is marked Warning only for packages winget actually attempted. One it
-declined is not a fault of the run.
+## Verified
 
-## pip
-
-A new step upgrades pip itself, through python -m pip -- on Windows pip cannot
-replace its own running executable, so the direct form fails on a locked file.
-pip is also in the inventory now.
-
-Installed packages are left alone, and an active virtual environment is never
-touched. Those packages belong to whatever project made it.
-
-## Fixed
-
-* The gallery tooling step logged "TerminatingError(Find-PackageProvider)" for a
-  lookup it handled correctly. Start-Transcript records a terminating error
-  whether or not it is caught, so an expected empty answer no longer throws.
-
-## Documented rather than fixed
-
-An error appears twice in a run transcript. It is one error: the step log holds
-one copy and the summary counts one. PowerShell transcribes an error when it is
-raised and again when it is displayed, and removing the second copy would make
-errors invisible on the console. The README explains it and says which record to
-trust.
+The self-elevation handoff is now tested end to end for the first time, by a new
+harness in tests/Elevation that runs on a real machine with UAC on and asks for
+one click. Development machines and CI runners are already administrators, and
+Windows Sandbox ships with UAC off, so nothing before this could reach the code
+that once shipped unable to parse.
 '
 
         }


### PR DESCRIPTION
A patch release, and worth doing promptly: **1.2.0 refuses to elevate on any
machine using a privilege-management broker**, which makes it unusable there
rather than merely degraded. BeyondTrust, CyberArk EPM and Admin By Request are
all common in enterprises.

```
UpdateEverything 1.2.1
Already on PSGallery at version 1.2.0.
All checks passed.

Staged UpdateEverything 1.2.1 — Files: 60
```

## What is in it

| | |
|---|---|
| #57 | Elevation is attempted rather than refused for an account outside the Administrators group |
| #58 | A failed elevation names a running privilege broker |
| #56 | The self-elevation test harness that found both |

## Why 1.2.1 rather than 1.3.0

#57 changes what the module does, but it restores intended behaviour rather than
adding any — from a user's side it is a fix. #58 improves a message. #56 is
test-only and ships nothing to the gallery.

## Testing

711 tests, 0 failed. `Publish.ps1 -WhatIf` green.

The self-elevation handoff is verified end to end for the first time, which is
what makes this release checkable at all:

```
[PASS] both the parent and the elevated child left a transcript
       2 new transcript(s)
Elevation test passed. NotCovered : 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)