### PR TITLE
Write down that only minor versions reach the gallery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,6 +473,37 @@ Maintainers only, and not casually: the PowerShell Gallery has no delete, only
 unlist, which hides a version from search while leaving it installable by anyone
 who names it.
 
+### Only x.y.0 reaches the gallery
+
+Minor versions are published. Patch versions are not, and live on `main` for
+whoever wants them:
+
+| Version | Where |
+|---|---|
+| 1.2.0, 1.3.0, 1.4.0 | PowerShell Gallery, and GitHub |
+| 1.2.1, 1.2.2 | GitHub only |
+
+Every gallery version is permanent -- unlist hides it from search and leaves it
+installable -- so each one is a commitment, and fewer of them means fewer to
+stand behind.
+
+Two things follow, and both are already handled rather than needing thought at
+release time:
+
+A patch fix reaches people through the GitHub install, so the README's
+**Install from GitHub** section is not a footnote. It is the supported route to
+anything not yet in a minor release, and it says so.
+
+`Update-Everything -UpdateSelf` defaults to `-UpdateSelfSource Gallery`, which is
+right for most people and wrong for anyone tracking a fix. `Main` is the setting
+for that, and the help says which is which.
+
+A run reports both, so nobody has to work it out:
+
+```
+UpdateEverything 1.2.1 is running, ahead of the published 1.2.0.
+```
+
 `Publish.ps1` front-loads every check before it sends anything, and `-WhatIf`
 runs those checks and stops:
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ Requires PowerShell 5.1 or later on Windows 10 or a matching Server release.
 
 ### Install from GitHub
 
-The gallery carries releases. `main` carries what is being worked on, which is
-where to get a fix that has landed but not shipped. Nothing but the URL is
+**The gallery carries minor versions only** -- 1.2.0, 1.3.0, 1.4.0. A patch
+release such as 1.2.1 is published here and nowhere else, so this is the
+supported way to get a fix that has landed but is not in a minor release yet.
+
+`main` also carries whatever is being worked on. Nothing but the URL is
 needed:
 
 ```powershell
@@ -46,8 +49,9 @@ it does nothing; on every one after, it is what makes the line safe to paste
 again. Nothing is lost if it is interrupted: the installer stages the new copy
 and validates it before it replaces the old one.
 
-`Update-Everything -UpdateSelf` does the same thing from inside a run, and also
-tracks `main` rather than the gallery.
+`Update-Everything -UpdateSelf -UpdateSelfSource Main` does the same thing from
+inside a run. The default source is `Gallery`, which is right for most people
+and wrong for anyone tracking a patch.
 
 ### Why that command is shaped the way it is
 


### PR DESCRIPTION
Documentation only. The policy is: **minor versions are published, patch versions
are not.**

| Version | Where |
|---|---|
| 1.2.0, 1.3.0, 1.4.0 | PowerShell Gallery, and GitHub |
| 1.2.1, 1.2.2 | GitHub only |

Every gallery version is permanent — unlist hides it from search and leaves it
installable — so each one is a commitment, and fewer of them means fewer to stand
behind.

## Two documents assumed otherwise

**The README undersold the GitHub install.** It described it as the way to get "a
fix that has landed but not shipped", which reads as *early access*. Under this
policy it is the **only** route to a patch release, so it says that.

**The `-UpdateSelf` note was stale.** It said the switch tracks `main` rather than
the gallery — true until `-UpdateSelfSource` arrived in 1.2.0 and defaulted to
`Gallery`. It now names the parameter and says which default suits whom: `Gallery`
for most people, `Main` for anyone tracking a patch.

That one was wrong regardless of the policy, and the policy is what surfaced it.

## Nothing in the code changes

The version reporting added in 1.2.0 already says the useful thing on a machine
running a patch:

```
UpdateEverything 1.2.1 is running, ahead of the published 1.2.0.
```

It was built to avoid calling a GitHub install "out of date", and it turns out to
be exactly what this policy needs.

## Testing

711 tests, 0 failed. Docs only, so no `src` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)