### PR TITLE
Say what the code does, not how it got that way

### DIFF
--- a/src/Private/Get-ElevationPolicyNote.ps1
+++ b/src/Private/Get-ElevationPolicyNote.ps1
@@ -4,19 +4,16 @@ function Get-ElevationPolicyNote {
         Explains, from policy, why an elevation attempt was refused.
 
         .DESCRIPTION
-        Reporting rather than deciding, and deliberately so. Refusing a run over
-        these values would lock out the people most likely to be affected by
-        them: Test-AdministratorGroupMember already returns $null when a
-        filtered token hides the Administrators SID, and treating an unknown
-        answer plus a restrictive policy as "cannot elevate" would turn a real
-        administrator away. Nothing here changes what is attempted. It only
-        names what is set, once the attempt has already failed.
+        Reports. It decides nothing and changes nothing about what is
+        attempted, and names what is set only once an attempt has failed.
 
         "Elevation was declined or failed" is true and useless on a managed
-        machine. Naming the value that did it turns the same failure into
+        machine. Naming the value responsible turns the same failure into
         something someone can take to whoever manages the policy.
 
-        The registry values that explain a failure:
+        The registry values under
+        HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System that
+        explain a failure:
 
           ConsentPromptBehaviorUser = 0     a standard user's request is denied
                                             outright; no prompt is ever shown
@@ -24,17 +21,14 @@ function Get-ElevationPolicyNote {
                                             signature may elevate
           EnableLUA = 0                     there is no consent prompt to answer
 
-        A privilege-management broker is also named when one is running.
-        Nothing it does appears in the registry at all: it can deny an elevation,
-        or allow one application and refuse another, without leaving a value
-        behind. Without this, a refusal on such a machine produced no note --
-        which reads as "no policy is interfering" when one just did.
+        A running privilege-management broker is also named. Nothing a broker
+        does appears in the registry: it can deny an elevation, or allow one
+        application and refuse another, without leaving a value behind, so a
+        machine can refuse while every value above reads as permissive.
 
-        Recognising brokers by service name means keeping a list of vendors, and
-        that would be the wrong trade for a decision -- the next vendor would be
-        missed and a capable machine turned away. It is the right trade for an
-        explanation: a missing entry costs a sentence, and nothing is decided
-        either way.
+        Brokers are recognised by vendor name in the service list, so a vendor
+        absent from that list is not mentioned. Nothing is decided either way --
+        a missing entry costs a sentence of explanation.
 
         Returns nothing when nothing restrictive is found, so a caller can append
         the result and say nothing extra on an ordinary machine.
@@ -73,8 +67,7 @@ function Get-ElevationPolicyNote {
     }
 
     # Vendor-identifying names rather than a bare "privilege", which matches
-    # unrelated services and would send someone to their IT department over
-    # nothing.
+    # unrelated services.
     $brokerPatterns = @(
         '*defendpoint*', '*avecto*', '*beyondtrust*', '*privilege management*',
         '*adminbyrequest*', '*admin by request*', '*cyberark*',

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -60,8 +60,8 @@
     Write-StepLog -Path $stepLog -Message "STARTING $Name"
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
 
-    # Function-local, so the caller's session is untouched -- which is the point
-    # of the rule against setting this in a module, and is not what this does.
+    # Function-local: the assignment is scoped to this function, so the caller's
+    # own preference is untouched once it returns.
     #
     # A caller that prefers Stop makes a native command's stderr terminating, and
     # most of these steps drive tools that write to stderr as a matter of course:

--- a/src/Private/Test-ElevationCapability.ps1
+++ b/src/Private/Test-ElevationCapability.ps1
@@ -7,24 +7,19 @@ function Test-ElevationCapability {
         .DESCRIPTION
         Returns IsElevated, CanElevate, Reason, and Caution.
 
-        Only two things refuse outright, and both are certain rather than
+        Only two conditions refuse outright, and both are certain rather than
         probable: UAC switched off, and a packaged PowerShell with no MSI build
         beside it. In each case Windows will not grant elevation to anybody, so
         raising a prompt would waste a person's time and then report the failure
         as though they had declined it.
 
         Not being in the local Administrators group is a Caution, not a refusal.
-        It used to be a refusal, and that was wrong on any machine running a
-        privilege-management broker -- BeyondTrust, CyberArk EPM, Admin By
-        Request and others -- where the account is deliberately not in the group
-        and elevates anyway, often per application. Measured on one such laptop:
-        not a member, Avecto Defendpoint running, elevated sessions working all
-        day, and this function refusing to try.
-
-        The harm is lopsided. Refusing wrongly makes the module unusable and says
-        something untrue about the machine. Attempting wrongly costs one prompt
-        that fails, which Invoke-SelfElevation already reports well and
-        Get-ElevationPolicyNote already explains.
+        Machines running a privilege-management broker -- BeyondTrust, CyberArk
+        EPM, Admin By Request and others -- keep the account out of that group
+        and elevate it anyway, often per application, so membership does not
+        settle whether elevation is available. A prompt that then fails costs
+        one refusal, which Invoke-SelfElevation reports and
+        Get-ElevationPolicyNote explains.
 
         .EXAMPLE
         $elevation = Test-ElevationCapability
@@ -54,10 +49,9 @@ function Test-ElevationCapability {
 
     # An MSIX PowerShell cannot be elevated at all: Windows does not run packaged
     # apps elevated, and the app execution alias that also reaches it is a
-    # zero-byte reparse point rather than a program. This one is a genuine
-    # certainty -- it does not depend on who is asking -- so it still refuses.
-    # The MSI build, if it is installed alongside, can elevate, and
-    # Invoke-SelfElevation relaunches through it.
+    # zero-byte reparse point rather than a program. The result does not depend
+    # on who is asking. The MSI build, if it is installed alongside, can
+    # elevate, and Invoke-SelfElevation relaunches through it.
     if ((Test-PackagedProcess) -and -not (Test-Path -LiteralPath (Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'))) {
         return [pscustomobject]@{
             IsElevated = $false
@@ -67,9 +61,9 @@ function Test-ElevationCapability {
         }
     }
 
-    # A definite "not in the group" is worth saying and not worth refusing over.
-    # $null means it could not be determined at all, which was never grounds for
-    # anything.
+    # $false is a definite "not in the group" and is worth saying. $null means
+    # the answer could not be determined -- a filtered token hides the SID --
+    # and neither is grounds for refusing.
     $caution = $null
     if ((Test-AdministratorGroupMember) -eq $false) {
         $caution = 'This account is not in the local Administrators group, so the prompt may be refused. Machines using a privilege-management broker elevate without that membership, so it is worth attempting. If it fails, -SkipElevation runs the steps that do not need admin.'

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -889,15 +889,17 @@
             # "TerminatingError(Find-PackageProvider)" in the middle of a step
             # that went on to report the right thing.
             #
-            # Test-PendingReboot carries the same lesson about Get-ItemProperty.
+            # Test-PendingReboot uses SilentlyContinue with Get-ItemProperty
+            # for the same reason.
             $newest = $null
             try {
                 $candidates = @(Find-PackageProvider -Name NuGet -ErrorAction SilentlyContinue |
                     Sort-Object Version -Descending)
                 if ($candidates.Count) { $newest = $candidates[0].Version }
             } catch {
-                # A backstop for a hard failure. The ordinary answer no longer
-                # throws, which is the point.
+                # A backstop. With SilentlyContinue the absent-provider case
+                # returns nothing instead of throwing, so reaching here means a
+                # hard failure.
                 Write-Verbose "Asking for the newest NuGet provider failed outright: $($_.Exception.Message)"
             }
 


### PR DESCRIPTION
`CONTRIBUTING.md` says a comment states a fact about the code, not the story of how it got there. Four files broke that, all of it in long-form help and block comments added recently. No behaviour changes; 711 tests still pass.

### What went

| File | Was | Now |
|---|---|---|
| `Test-ElevationCapability` | "It used to be a refusal, and that was wrong"; "Measured on one such laptop: not a member, Avecto Defendpoint running"; "The harm is lopsided." | states that broker-managed machines keep the account out of the group and elevate anyway, so membership does not settle the question |
| `Get-ElevationPolicyNote` | "Reporting rather than deciding, and deliberately so"; "that would be the wrong trade for a decision" | states that it reports, decides nothing, and that a vendor absent from the service-name list is not mentioned |
| `Invoke-Step` | "which is the point of the rule against setting this in a module, and is not what this does" | states that the assignment is function-scoped, so the caller''s preference is untouched |
| `Update-Everything` | "The ordinary answer no longer throws, which is the point" | states that `SilentlyContinue` returns nothing for the absent-provider case, so reaching the catch means a hard failure |

Every underlying fact is kept, including the whole `ErrorActionPreference` explanation in `Invoke-Step` -- npm, winget and wsl all write to stderr as a matter of course, and a caller preferring `Stop` makes that terminating. That is a property of PowerShell, so it stays.

The registry table in `Get-ElevationPolicyNote` now names the key it describes rather than leaving the reader to find it.

### No test enforces this, deliberately

I scanned for a rule worth automating and did not find one.

- Prose markers are too blunt. A pattern list catching today''s violations also flagged `an earlier native command`, `results from an earlier, unrelated match` and `used to build a path from $null` -- four false positives in thirteen hits, all ordinary English about runtime rather than project history.
- The crisp version of the rule is already met. First and second person in `#` comments across all 57 source files: two hits, both false -- a quoted Windows prompt string, and `en-US` matching `us`.

So the drift does not show up where a regex can see it. It shows up as essays in `.DESCRIPTION` blocks, and a test tuned tightly enough to avoid false positives would be evaded by the next paragraph worded differently. A test that green-lights the next violation is worse than review.
