### PR TITLE
Stop paying twice for the same scheduled task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,8 +370,8 @@ Cases that vary only by data use `BeforeDiscovery` with `-ForEach`, so each is
 reported as its own test rather than as one test that loops.
 
 Tag every `Describe`. The suite uses `Static`, `Module`, `Docs`, `Unit`,
-`Consent`, `Prompt`, `Notification` and `Lint`, and they are what make
-`test.ps1 -Tag` and `-ExcludeTag` useful.
+`Consent`, `Prompt`, `Notification`, `Lint` and `Integration`, and they are what
+make `test.ps1 -Tag` and `-ExcludeTag` useful.
 
 One logical assertion per `It`. `Should.ErrorAction` is left at its default of
 `Stop`, so the first failure ends the test — which is what you want, because the
@@ -391,6 +391,29 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File .\test.ps1
 
 Linting is a tagged test inside the suite rather than a separate CI step, so
 there is one source of truth about whether the code passes.
+
+### Where the time goes
+
+The full suite takes about 88 seconds, and two costs account for half of it.
+Neither is a defect and neither is worth optimising:
+
+| Cost | What it is |
+|---|---|
+| ~17s | The **first** `Invoke-ScriptAnalyzer` call in a process. Loading the rule assemblies is the entire expense: every call after it is milliseconds, and analysing all 57 files takes 0.44s once the first has paid. Batching the calls does not help, because the number of calls is not what costs. |
+| ~25s | Four `Integration` tests, registering three real scheduled tasks. Registering one costs 3.7s and removing it 2.9s against the real Task Scheduler, and there is nothing between the test and that price. |
+
+The rest of the suite -- 644 tests -- runs in 58 seconds. While iterating, skip
+both:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\test.ps1 -ExcludeTag Lint,Integration
+```
+
+Run the whole thing before opening a PR. CI runs it either way.
+
+A test that registers a real task should register it once and assert several
+times, in a `Context` with the registration in `BeforeAll`. Two tests that each
+register the same cadence pay the full 6.6s twice for the same task.
 
 ### Ways a test here has passed while the code was broken
 

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -667,7 +667,7 @@ Describe 'Every cadence can actually register a task' -Tag 'Integration' {
         Unregister-ScheduledTask -TaskName $script:TestTaskName -Confirm:$false -ErrorAction SilentlyContinue
     }
 
-    It 'registers a <_> task' -ForEach @('Daily', 'Weekly', 'PatchTuesday') -Skip:(-not $script:CanRegister) {
+    It 'registers a <_> task' -ForEach @('Daily', 'Weekly') -Skip:(-not $script:CanRegister) {
         $cadence = $_
 
         # Not wrapped in an assertion about throwing: if it throws, the test
@@ -680,19 +680,37 @@ Describe 'Every cadence can actually register a task' -Tag 'Integration' {
             Should-NotBeNull
     }
 
-    # Week 3, Wednesday, all twelve months. Registering is not enough on its own:
-    # the weekly trigger it starts from would also register cleanly, and would
-    # then run every week instead of every month.
-    It 'gives PatchTuesday a monthly day-of-week trigger, not the weekly one it started as' -Skip:(-not $script:CanRegister) {
-        Register-UpdateEverythingTask -TaskName $script:TestTaskName -Cadence PatchTuesday `
-            -Notify $false -Confirm:$false -ErrorAction Stop 6>$null | Out-Null
+    # PatchTuesday is registered once here and asserted twice, rather than once
+    # per test. Registering costs 3.7s and removing costs 2.9s against the real
+    # Task Scheduler, and the second registration would produce the same task as
+    # the first.
+    #
+    # The parent AfterEach still runs between these two, so the export is taken
+    # in BeforeAll while the task exists.
+    Context 'PatchTuesday' -Skip:(-not $script:CanRegister) {
 
-        $xml = [xml](Export-ScheduledTask -TaskName $script:TestTaskName)
-        $schedule = $xml.Task.Triggers.CalendarTrigger.ScheduleByMonthDayOfWeek
+        BeforeAll {
+            Register-UpdateEverythingTask -TaskName $script:TestTaskName -Cadence PatchTuesday `
+                -Notify $false -Confirm:$false -ErrorAction Stop 6>$null | Out-Null
 
-        $schedule | Should-NotBeNull
-        $schedule.Weeks.Week | Should-Be '3'
-        @($schedule.DaysOfWeek.ChildNodes).Name | Should-Be 'Wednesday'
-        @($schedule.Months.ChildNodes) | Should-BeCollection -Count 12
+            $script:PatchTuesdayXml = [xml](Export-ScheduledTask -TaskName $script:TestTaskName)
+        }
+
+        It 'registers a task' {
+            Get-ScheduledTask -TaskName $script:TestTaskName -ErrorAction SilentlyContinue |
+                Should-NotBeNull
+        }
+
+        # Week 3, Wednesday, all twelve months. Registering is not enough on its
+        # own: the weekly trigger it starts from would also register cleanly, and
+        # would then run every week instead of every month.
+        It 'gives it a monthly day-of-week trigger, not the weekly one it started as' {
+            $schedule = $script:PatchTuesdayXml.Task.Triggers.CalendarTrigger.ScheduleByMonthDayOfWeek
+
+            $schedule | Should-NotBeNull
+            $schedule.Weeks.Week | Should-Be '3'
+            @($schedule.DaysOfWeek.ChildNodes).Name | Should-Be 'Wednesday'
+            @($schedule.Months.ChildNodes) | Should-BeCollection -Count 12
+        }
     }
 }

--- a/tests/RunPrompt.Tests.ps1
+++ b/tests/RunPrompt.Tests.ps1
@@ -82,14 +82,17 @@ Describe 'Read-TimedChoice' -Tag 'Unit','Prompt' {
         $warnings | Should-BeNull -Because "the countdown should draw cleanly: $($warnings -join '; ')"
     }
 
+    # The timeout is short because the assertion is that one is honoured at all,
+    # not that it lasts any particular length. The upper bound stays well clear
+    # of it so a loaded CI agent cannot fail this for being slow.
     It 'gives up and takes the default rather than waiting forever' {
         $elapsed = Measure-Command {
             $script:answer = Read-TimedChoice -Caption 'x' -Choice @('a', 'b') `
-                -TimeoutSeconds 5 -DefaultIndex 1 6>$null
+                -TimeoutSeconds 2 -DefaultIndex 1 6>$null
         }
 
         $script:answer | Should-Be 1
-        $elapsed.TotalSeconds | Should-BeLessThan 15
+        $elapsed.TotalSeconds | Should-BeLessThan 12
     }
 }
 


### PR DESCRIPTION
First holistic pass over the test suite. It has grown one test per issue and had never been looked at as a whole.

## What the profile said

711 tests, 95s. Three `Describe`s -- 69 tests -- held 61% of it.

| Describe | Tests | Seconds |
|---|---|---|
| Every cadence can actually register a task | 4 | 31.7 |
| PSScriptAnalyzer | 63 | 18.4 |
| Read-TimedChoice | 2 | 8.2 |
| everything else | 642 | ~37 |

## Fixed

**`Read-TimedChoice` slept for real.** `-TimeoutSeconds 5` in a test whose assertion is that a timeout is honoured at all, not that it lasts any particular length. Now 2s, upper bound still well clear so a loaded CI agent cannot fail it for being slow. **-3.1s**

**PatchTuesday was registered twice.** Once per test, against the real Task Scheduler. Registering costs 3.7s and removing costs 2.9s, so the second registration bought a task identical to the first for 6.6s. Now registered once in a `Context` with the export taken in `BeforeAll`, asserted twice. **-6.5s**

**95s to 88s. 711 tests, 0 failures.**

## The dead end, recorded so nobody repeats it

I first refactored the 63 per-file analyzer calls into one batched call, on a measurement showing 16.9s for the loop against 1.6s for the batch.

**That measurement was wrong** -- I ran the loop first in the same process, so the batch inherited a warm analyzer. Measured properly in a fresh process, batch first:

```
COLD batch first : 17.66s
WARM per-file    :  0.44s  (57 files)
```

The entire cost is PSScriptAnalyzer''s one-time cold start. The number of calls is irrelevant. Batching saved about a second of wall clock while adding a hashtable index, a set of root definitions and a coverage guard, so I reverted it.

Worth noting the batched version was verified non-vacuous before I threw it away -- injecting an aliased `ls` into a source file failed exactly one test with the right rule, line and message. The refactor was correct. It just was not worth anything.

## Documented

`CONTRIBUTING.md` gains a "Where the time goes" section with both costs that are *not* worth attacking, so the next person does not chase the analyzer either. Plus:

- `-ExcludeTag Lint,Integration` runs 644 of the 711 tests in **58s** instead of 88s. Nothing said so.
- `Integration` was missing from the tag list, though the tag is used and documented further down.
- The rule that a test registering a real task should register once and assert several times.
