### PR TITLE
Hold the tests to the rules the code follows

### DIFF
--- a/tests/Elevation/Invoke-ElevationTest.ps1
+++ b/tests/Elevation/Invoke-ElevationTest.ps1
@@ -112,8 +112,9 @@ try {
     if ($amAdmin) {
         # A scheduled task at RunLevel Limited is how an elevated session starts
         # a genuinely unelevated child of the same user. Without it this test
-        # would run as an administrator and measure nothing, which is exactly how
-        # the relaunch shipped broken in the first place.
+        # would run as an administrator and measure nothing, because
+        # Update-Everything reaches the relaunch only when the session is not
+        # already elevated.
         $usedTask = $true
         Write-Host '  this session is elevated, so dropping privileges through a scheduled task...' -ForegroundColor DarkGray
 

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -64,10 +64,10 @@ BeforeDiscovery {
     $LintTargets += (Join-Path $RepoRoot 'test.ps1')
     $LintTargets += (Join-Path $RepoRoot 'Install.ps1')
 
-    # The fresh-machine harness. Pester never runs these -- it discovers
-    # *.Tests.ps1 only -- but they are the house style's problem like anything
-    # else, and nothing else in the suite would look at them.
-    $LintTargets += @(Get-ChildItem -Path (Join-Path $RepoRoot 'tests\FreshMachine') -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue |
+    # Everything under tests\: the test files, and the fresh-machine and
+    # elevation harnesses. Pester runs *.Tests.ps1 and nothing runs the
+    # harnesses, so for the harnesses the analyzer is the only reader they have.
+    $LintTargets += @(Get-ChildItem -Path (Join-Path $RepoRoot 'tests') -Filter *.ps1 -Recurse -ErrorAction SilentlyContinue |
             ForEach-Object { $_.FullName })
 }
 
@@ -357,10 +357,9 @@ Describe 'Shared run state' -Tag 'Static','Module' {
 
 Describe 'Logging starts before the run can decline to start' -Tag 'Static','Module' {
 
-    # Logging used to be set up after elevation succeeded, so every path that
-    # ended the run early produced no log at all. A PowerShell 7 run that could
-    # not elevate left nothing behind to read, which is exactly the case someone
-    # would go looking for a log to explain.
+    # Logging is set up before elevation is attempted, so a path that ends the
+    # run early still leaves a log behind. A PowerShell 7 run that cannot
+    # elevate is exactly the case someone goes looking for a log to explain.
 
     BeforeAll {
         $script:Source = Get-Content $script:MainPath -Raw
@@ -859,19 +858,28 @@ Describe 'PSScriptAnalyzer' -Tag 'Lint' -Skip:(-not $HasAnalyzer) {
     It 'reports no errors or warnings in <_>' -ForEach $LintTargets {
         $path = $_
 
-        # Pester puts -ForEach data in BeforeDiscovery variables the analyzer
-        # cannot see being consumed, so every test file trips
-        # PSUseDeclaredVarsMoreThanAssignments.
+        # Two rules a test file breaks by doing its job. Pester puts -ForEach
+        # data in BeforeDiscovery variables the analyzer cannot see being
+        # consumed, so every test file trips
+        # PSUseDeclaredVarsMoreThanAssignments. Shadowing a cmdlet inside a
+        # scoped scriptblock is how a test intercepts a call that Mock cannot
+        # reach, which is what PSAvoidOverwritingBuiltInCmdlets is for.
         $extra = @{}
         if ($path -like '*\tests\*') {
-            $extra['ExcludeRule'] = @('PSUseDeclaredVarsMoreThanAssignments')
+            $extra['ExcludeRule'] = @(
+                'PSUseDeclaredVarsMoreThanAssignments'
+                'PSAvoidOverwritingBuiltInCmdlets'
+            )
         }
 
         $findings = Invoke-ScriptAnalyzer -Path $path `
             -Settings (Join-Path (Split-Path $PSScriptRoot -Parent) 'PSScriptAnalyzerSettings.psd1') @extra
 
         $detail = ($findings | ForEach-Object { '{0}:{1} {2}' -f $_.RuleName, $_.Line, $_.Message }) -join "`n"
-        $findings | Should-BeNull -Because "the baseline is clean, so these are new:`n$detail"
+        # Counted rather than compared to null: a failed Should-BeNull prints the
+        # whole DiagnosticRecord, burying the rule and line under the extents and
+        # script positions hanging off it.
+        @($findings).Count | Should-Be 0 -Because "the baseline is clean, so these are new:`n$detail"
     }
 }
 

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1062,13 +1062,12 @@ Describe 'Test-ElevationCapability' -Tag 'Unit','Security' {
 
     Context 'An account that is not in the local Administrators group' {
 
-        # This used to refuse, and it was wrong on any machine running a
-        # privilege-management broker -- BeyondTrust, CyberArk EPM, Admin By
-        # Request -- where the account is deliberately not in the group and
-        # elevates anyway. Measured on one: not a member, Avecto Defendpoint
-        # running, elevated sessions working all day, and the module refusing to
-        # try. Refusing wrongly makes it unusable; attempting wrongly costs one
-        # prompt that is already reported well.
+        # Not being in the group is a Caution rather than a refusal. Machines
+        # running a privilege-management broker -- BeyondTrust, CyberArk EPM,
+        # Admin By Request -- keep the account out of the group and elevate it
+        # anyway, often per application, so membership does not settle whether
+        # elevation is available. A prompt that then fails is already reported
+        # well.
 
         BeforeEach {
             Mock Test-IsAdministrator { $false }
@@ -1918,8 +1917,8 @@ Describe 'Updating the module itself' -Tag 'Static' {
     }
 
     It 'says an update lands on the next run, on both paths' {
-        $matches = [regex]::Matches($script:SelfSource, 'loads on the next run')
-        $matches.Count | Should-BeGreaterThanOrEqual 2
+        $onNextRun = [regex]::Matches($script:SelfSource, 'loads on the next run')
+        $onNextRun.Count | Should-BeGreaterThanOrEqual 2
     }
 }
 
@@ -2323,11 +2322,11 @@ Describe 'An expected answer does not throw' -Tag 'Static' {
     #   PS>TerminatingError(Find-PackageProvider): "...No match was found for
     #   the specified search criteria and package name 'NuGet'."
     #
-    # The step went on to report the right thing. Test-PendingReboot already
-    # carried this lesson about Get-ItemProperty, and the gallery work repeated
-    # it. These two lookups have an expected empty answer on supported hosts:
-    # Find-PackageProvider cannot answer at all on PowerShell 7, and Find-Module
-    # is asked about modules that may not be published.
+    # The step goes on to report the right thing. Both lookups have an expected
+    # empty answer on supported hosts: Find-PackageProvider cannot answer at all
+    # on PowerShell 7, and Find-Module is asked about modules that may not be
+    # published. Test-PendingReboot uses SilentlyContinue with Get-ItemProperty
+    # for the same reason.
 
     BeforeAll {
         $script:LookupSources = @{
@@ -2620,14 +2619,12 @@ Describe 'pip is in the inventory' -Tag 'Unit' {
 Describe 'Get-ElevationPolicyNote names a privilege broker' -Tag 'Unit' {
 
     # A broker can deny an elevation, or allow one application and refuse
-    # another, without leaving anything in the registry. Before this, a refusal
-    # on such a machine produced no note at all -- which reads as "no policy is
-    # interfering" when one just did.
+    # another, without leaving anything in the registry, so a machine can refuse
+    # while every policy value reads as permissive.
     #
-    # Recognising vendors by service name would be the wrong trade for a
-    # decision: the next vendor would be missed and a capable machine turned
-    # away. It is the right trade for an explanation, where a missing entry costs
-    # a sentence and decides nothing.
+    # Vendors are recognised by service name, so a vendor absent from the list is
+    # not mentioned. Nothing is decided either way: the note only explains a
+    # refusal that has already happened.
 
     BeforeEach {
         # Nothing restrictive in the registry, so only the broker can produce a


### PR DESCRIPTION
The analyzer read `src`, `test.ps1`, `Install.ps1` and the fresh-machine harness. It did not read the seven `*.Tests.ps1` files, and it did not read `tests\Elevation`. That left 5,562 lines of test code and two harness scripts with no reader at all -- nothing executes the harnesses either.

The `tests\FreshMachine` entry already explained why harness scripts belong here: they are the house style''s problem like anything else, and nothing else in the suite looks at them. `tests\Elevation` was created after that was written and never added.

**72 files linted, up from 63. 720 tests, 0 failures.**

## What it found

**`$matches` assigned in `Update-Everything.Functions.Tests.ps1:1921.`** That is the automatic variable `-match` populates, so any match later in the same scope silently overwrites it. Same collision class as the `$home` one fixed earlier. Renamed to `$onNextRun`.

**`function Start-Process` in `Module.Tests.ps1:927.`** Defined inside a module-scoped scriptblock to intercept the launch, which is how a test reaches a call `Mock` cannot. `PSAvoidOverwritingBuiltInCmdlets` cannot tell that apart from the mistake it exists to catch, so it joins `PSUseDeclaredVarsMoreThanAssignments` as excluded for test files. Both exclusions now say what a test does that trips them.

## Readable failures

A failing lint test compared findings to `$null`, so Pester printed the whole `DiagnosticRecord` -- rule and line buried under the extents, script positions and suggested corrections hanging off it. Roughly 900 characters to say `ls` is an alias.

It now counts:

```
Expected [int] 0, because the baseline is clean, so these are new:
PSAvoidUsingCmdletAliases:102 'ls' is an alias of 'Get-ChildItem'..., but got [int] 1.
```

## Comments

The rule from #61 applies to tests too, and four comments broke it -- a refusal the module does not make, a measurement from one laptop, and two paragraphs arguing for decisions rather than describing code. The Pester v5-versus-v6 notes were left alone: a tool''s contract is a fact.

## Verified

Injected an aliased `ls` into `tests\Elevation\Invoke-ElevatedHandoff.ps1`, one of the files that had no coverage before this. Exactly one test failed, naming the right file, rule and line. New coverage is real, not a green tick over an unread file.
