### PR TITLE
Prepare 1.3.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -555,7 +555,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.2.1 -m "1.2.1" && git push origin v1.2.1
+git tag -a v1.3.0 -m "1.3.0" && git push origin v1.3.0
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -279,13 +279,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.2.0
+UpdateEverything 1.3.0
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.2.0 is running, which is the newest published version.
+UpdateEverything 1.3.0 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.2.1'
+    ModuleVersion     = '1.3.0'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -32,7 +32,7 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.2.1
+            ReleaseNotes = '# 1.3.0
 
 One fix, and it matters on managed machines: UpdateEverything refused to elevate
 on any machine using a privilege-management broker.
@@ -45,8 +45,8 @@ privilege-management broker is in use -- BeyondTrust, CyberArk EPM, Admin By
 Request -- because the account is deliberately not in the group and elevates
 anyway, often per application.
 
-On such a machine the module was unusable: it refused before raising a prompt,
-and told the user something untrue about their computer.
+On such a machine 1.2.0 is unusable: it refuses before raising a prompt, and
+tells the user something untrue about their computer.
 
 Group membership is now a caution rather than a refusal, warned about before the
 attempt. The two genuine certainties still refuse, because neither depends on
@@ -55,15 +55,15 @@ beside it.
 
 ## A failed elevation says more
 
-Get-ElevationPolicyNote now names a running privilege broker. Those grant or
-deny elevation per application and leave nothing in the registry, so a refusal
-on such a machine previously produced no explanation at all.
+Get-ElevationPolicyNote names a running privilege broker. Those grant or deny
+elevation per application and leave nothing in the registry, so in 1.2.0 a
+refusal on such a machine came with no explanation at all.
 
 ## Verified
 
-The self-elevation handoff is now tested end to end for the first time, by a new
-harness in tests/Elevation that runs on a real machine with UAC on and asks for
-one click. Development machines and CI runners are already administrators, and
+The self-elevation handoff is tested end to end for the first time, by a harness
+in tests/Elevation that runs on a real machine with UAC on and asks for one
+click. Development machines and CI runners are already administrators, and
 Windows Sandbox ships with UAC off, so nothing before this could reach the code
 that once shipped unable to parse.
 '


### PR DESCRIPTION
Raises `ModuleVersion` to 1.3.0 and rewrites the release notes for the gallery page.

## What is in it

Everything user-facing is the elevation work that has been on `main` since 1.2.1:

- **Group membership is a caution, not a refusal.** `Test-ElevationCapability` treated "not in the local Administrators group" as proof Windows would refuse. That is false on any machine running a privilege-management broker -- BeyondTrust, CyberArk EPM, Admin By Request -- where the account is deliberately outside the group and elevates anyway. On such a machine the published 1.2.0 is unusable: it refuses before raising a prompt.
- **A failed elevation names the broker.** Brokers leave nothing in the registry, so a refusal on such a machine came with no explanation at all in 1.2.0.

Everything since 1.2.1 -- #62, #64, #66 -- is tests, comments and documentation. No behaviour changed.

## Notes are written against 1.2.0

Not against 1.2.1, because 1.2.1 never reached the gallery. Anyone installing this is coming from 1.2.0, so the notes describe what 1.2.0 does wrong rather than referring to a version they have never seen.

## Stale examples

Two places named a version while claiming it was current, which the bump made wrong rather than merely dated:

- `README.md` sample output said `UpdateEverything 1.2.0 is running, which is the newest published version.`
- `CONTRIBUTING.md` showed `git tag -a v1.2.1` in the publishing steps -- a patch version, which by the policy two sections above it is never published or tagged.

## Checks

`Publish.ps1 -WhatIf` reports **All checks passed**, confirms the gallery is at 1.2.0, and stages 60 files with the 6 expected exports. 720 tests, 0 failures.

Still outstanding before publishing, both from the CONTRIBUTING pre-flight: the fresh-machine smoke test, and the self-elevation test -- which this release specifically calls for, since it touches elevation, and which needs a UAC click.
