### PR TITLE
Fix five defects the review found in the trimming pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ choose the packages; the manager's own inventory does.
 | Chocolatey | `choco` | `choco upgrade all -y` | Everything installed as a Chocolatey package. Exit codes 1641 and 3010 pass, since those are the MSI "reboot required" codes rather than failures. |
 | Scoop | `scoop` | `scoop update`, `scoop update *`, `scoop cleanup *`, each run on its own | Scoop, its buckets, installed apps, then old versions. The phases run separately so a broken bucket cannot hide the rest. |
 | npm | `npm` | `npm install -g npm@latest`, then `npm update -g` only with `-UpdateGlobalNpm` | npm itself, every run. Global packages only on request, because upgrading them can move a pinned toolchain. |
-| pip | `python`, else `py` | `python -m pip install --upgrade pip` | pip itself, for the interpreter that resolves on `PATH`. Installed packages are left alone -- see [Python](#python). |
+| pip | `py`, else `python` | `<interpreter> -m pip install --upgrade pip --disable-pip-version-check` | pip itself, for the first of those found. Where `py` is present that is the launcher's default interpreter, which is not always the `python` on `PATH`. Installed packages are left alone -- see [Python](#python). |
 | pipx | `pipx` | `pipx upgrade-all` | Every Python application pipx installed. |
 | uv | `uv`, plus an ownership check | `uv self update` | uv itself, and only when nothing else owns it. |
 | Python Install Manager | `pymanager`, else `py` | `pymanager install --update` | Installed Python runtimes. |

--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -5,7 +5,7 @@ function Get-GalleryModuleStatus {
         the PowerShell Gallery.
 
         .DESCRIPTION
-        Returns Installed, Available, Updatable and NeedsUpdate.
+        Returns Name, Installed, Available, Updatable and NeedsUpdate.
 
         Installed is $null when the module is absent, which is an install and
         needs consent, rather than an update, which does not.

--- a/src/Private/Get-WingetLeftover.ps1
+++ b/src/Private/Get-WingetLeftover.ps1
@@ -12,10 +12,12 @@ function Get-WingetLeftover {
                       often fixable -- a package whose executable is running
                       cannot be replaced until it is closed.
 
-          Skipped     winget listed it and never tried, usually because a newer
-                      version does not apply to this system. That is permanent
-                      until the vendor ships something that does, and reporting
-                      it as a failure every run teaches people to skim past it.
+          Skipped     winget listed it and never tried. Usually "a newer package
+                      version is available in a configured source, but it does
+                      not apply to your system or requirements", which is
+                      permanent until the vendor ships something that applies.
+                      Reporting it as a failure every run teaches people to skim
+                      past it.
 
         Attempted is decided by winget's own "Found <name> [<id>]" line. The rest
         of the output is localised prose.

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -269,7 +269,8 @@
     $isFirstRun = -not @(Get-ChildItem -LiteralPath $logDir -Filter 'Update-Everything-*.log' `
         -File -ErrorAction SilentlyContinue).Count
 
-    # Step logs rotate per run and are pruned by age, with stale Terminal backups.
+    # Step logs rotate per run rather than being appended to, so old ones are
+    # pruned by age, as are stale Windows Terminal settings backups.
     if ($LogRetentionDays -gt 0) {
         $cutoff = (Get-Date).AddDays(-$LogRetentionDays)
         Get-ChildItem -LiteralPath $logDir -File -ErrorAction SilentlyContinue |
@@ -350,8 +351,8 @@
     # decision is on record, before the install checks so skipping costs nothing.
     if ($PromptBeforeRun) {
         if (-not (Test-CanPrompt)) {
-        # A hidden window or redirected input cannot answer, and starting anyway beats
-        # blocking until the task time limit kills the run.
+            # A hidden window or redirected input cannot answer, and starting
+            # anyway beats blocking until the task time limit kills the run.
             Write-Warning 'PromptBeforeRun was requested, but this run cannot prompt (no interactive console, or input is redirected). Starting immediately.'
         } else {
             switch (Request-RunDecision -TimeoutSeconds $PromptTimeoutSeconds -DelayMinutes $DelayMinutes) {


### PR DESCRIPTION
Five confirmed findings from a max-effort review of #76, the pass that trimmed comments and corrected the docs.

## The one that matters

**The pip row I added to fix a documentation gap stated the code backwards.** The step builds `@('py', 'python' | ForEach-Object { Get-Command $_ ... })` and takes `$found[0]`, so `py` wins where both exist and pip is upgraded for the launcher''s default interpreter. The row said "`python`, else `py`" and described the target as "the interpreter that resolves on `PATH`". Both wrong, and the row two lines below it (`pymanager`, else `py`) already used the right convention.

The same cell also dropped `--disable-pip-version-check`, which the step passes and which every other row in that table quotes.

## The other three

| Finding | Fix |
|---|---|
| A rewritten comment landed at 8 spaces inside a 12-space block | Back to 12. A sweep of every comment in `src` against the indent of the line below finds no others |
| `Get-WingetLeftover` no longer quoted winget''s own wording for a declined package | Quotation restored. That sentence is what winget prints, what a user searches for, and what produced the Cisco WebEx investigation here -- after the paraphrase it appeared nowhere in the repo |
| "pruned by age, with stale Terminal backups" | Reworded. The compressed form lost the parenthetical that made the backups a second thing being pruned |

## Verification

Each fix was checked by re-running the check that found it, not by inspection: the indent sweep is down to its two known false positives, and winget''s wording greps again.

**No code changed.** `Update-Everything.ps1` holds the same 773 executable lines and `Get-WingetLeftover.ps1` the same 42, comparing HEAD against the working tree with comments, help blocks and blanks stripped. 720 tests, 0 failures.

## Left open

Four findings not applied, all judgement calls rather than errors: the TLS note now reads as an aside rather than a deliberate omission (`Update-Everything.ps1:251`); the transcript close/reopen lost the clause saying it does not rely on run stamps differing (`:311`); `CONTRIBUTING.md:402` carries an analyzer figure changed on a single noisy sample, better fixed by dropping the second-count than by picking another number; and `Get-GalleryModuleStatus`''s help lists four returned properties where the object has five (`Name` is the fifth) -- a one-word fix whenever that line is next touched.
