### PR TITLE
Fix everything the Fable review confirmed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -394,16 +394,15 @@ there is one source of truth about whether the code passes.
 
 ### Where the time goes
 
-The full suite takes about 90 seconds, and two costs account for half of it.
-Neither is a defect and neither is worth optimising:
+Two costs dominate the suite, and neither is a defect nor worth optimising:
 
 | Cost | What it is |
 |---|---|
-| ~19s | The **first** `Invoke-ScriptAnalyzer` call in a process. Loading the rule assemblies is the entire expense: every call after it is milliseconds, and the remaining files together take under a second. Batching the calls does not help, because the number of calls is not what costs. |
-| ~25s | Four `Integration` tests, registering three real scheduled tasks. Registering one costs 3.7s and removing it 2.9s against the real Task Scheduler, and there is nothing between the test and that price. |
+| The first `Invoke-ScriptAnalyzer` call in a process | Loading the rule assemblies is the entire expense, tens of seconds; every call after it is milliseconds. Batching the calls does not help, because the number of calls is not what costs. Every analyzer pass carries the `Lint` tag, including the gallery-readiness test. |
+| The `Integration` tests | They register and remove real scheduled tasks, seconds per task against the real Task Scheduler, and there is nothing between the test and that price. |
 
-The rest of the suite -- 644 of the 720 tests -- runs in 59 seconds. While
-iterating, skip both:
+While iterating, skip both; the rest of the suite finishes in well under a
+minute:
 
 ```powershell
 pwsh -NoProfile -ExecutionPolicy Bypass -File .\test.ps1 -ExcludeTag Lint,Integration

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ on the one that keeps everything else current:
 
 ```powershell
 Register-UpdateEverythingTask -ExcludeTag Python -Cadence Daily
-Register-UpdateEverythingTask -Tag Python -Cadence Monthly
+Register-UpdateEverythingTask -Tag Python -Cadence PatchTuesday
 ```
 
 ## What it updates
@@ -362,8 +362,9 @@ The distinction matters. The first is worth doing something about; the second
 will not change until the vendor ships a package that applies, and reporting it
 as a failure on every run is how people learn to skim past the ones that are.
 
-**The step is only marked `Warning` for packages winget actually attempted.** One
-it declined is not a fault of the run and does not colour it.
+**The step is marked `Warning` only when something may really have failed** — a
+package winget attempted, or a non-zero exit it could not attribute to one. A
+package it declined is not a fault of the run and does not colour it.
 
 ### Products updated by name
 
@@ -373,7 +374,7 @@ it declined is not a fault of the run and does not colour it.
 | Microsoft 365 Apps, meaning Word, Excel, Outlook, PowerPoint, Teams and OneNote | `OfficeC2RClient.exe /update user`, the same action as the Update Now button without the prompts. Click-to-run does the work in the background, so the step reports "requested" rather than "applied". |
 | Microsoft Store apps | The `msstore` source, covered by `winget upgrade --all`. |
 | Microsoft Defender antivirus signatures | `Update-MpSignature`. It skips when a third-party antivirus has taken over, which it detects by asking `Get-MpComputerStatus` whether the antimalware service is on. Otherwise a managed machine would report a failed step every run. |
-| PowerShell 7 | winget, forced to the MSI package with `--installer-type wix`. It installs only with your consent and upgrades in place when it is already there. |
+| PowerShell 7 | winget. A fresh install is forced to the MSI with `--installer-type wix`, and only with your consent; an existing copy upgrades in place as whatever package it already is, so an MSIX copy stays MSIX and the step prints how to switch. |
 | PowerShell modules from the Gallery | `Update-PSResource -Name *` where PSResourceGet exists, otherwise `Update-Module`. |
 | PowerShell help | `Update-Help`, pinned to `en-US` under any other UI culture, where most modules publish no help at all. |
 | PowerShell Gallery tooling | `PowerShellGet`, `PSResourceGet` and the NuGet package provider, which every other gallery step runs on. A copy the host shipped cannot be updated in place, so moving it forward is a side-by-side install and asks first. |
@@ -394,14 +395,14 @@ choose the packages; the manager's own inventory does.
 
 | Manager | Found by | What runs | Covers |
 |---|---|---|---|
-| winget | `winget` on `PATH` | `winget source update`, then `winget upgrade --all --include-unknown --silent` | Desktop applications from the winget community repository and the Microsoft Store. The broadest step by far, covering browsers, editors, runtimes and drivers shipped as apps. |
+| winget | `winget` on `PATH` | `winget source update`, then `winget upgrade --all --include-unknown --silent --accept-source-agreements --accept-package-agreements --disable-interactivity` | Desktop applications from the winget community repository and the Microsoft Store. The broadest step by far, covering browsers, editors, runtimes and drivers shipped as apps. The `--accept-*` flags accept source and vendor licence agreements on your behalf. |
 | Chocolatey | `choco` | `choco upgrade all -y` | Everything installed as a Chocolatey package. Exit codes 1641 and 3010 pass, since those are the MSI "reboot required" codes rather than failures. |
 | Scoop | `scoop` | `scoop update`, `scoop update *`, `scoop cleanup *`, each run on its own | Scoop, its buckets, installed apps, then old versions. The phases run separately so a broken bucket cannot hide the rest. |
 | npm | `npm` | `npm install -g npm@latest`, then `npm update -g` only with `-UpdateGlobalNpm` | npm itself, every run. Global packages only on request, because upgrading them can move a pinned toolchain. |
 | pip | `py`, else `python` | `<interpreter> -m pip install --upgrade pip --disable-pip-version-check` | pip itself, for the first of those found. Where `py` is present that is the launcher's default interpreter, which is not always the `python` on `PATH`. Installed packages are left alone -- see [Python](#python). |
 | pipx | `pipx` | `pipx upgrade-all` | Every Python application pipx installed. |
 | uv | `uv`, plus an ownership check | `uv self update` | uv itself, and only when nothing else owns it. |
-| Python Install Manager | `pymanager`, else `py` | `pymanager install --update` | Installed Python runtimes. |
+| Python Install Manager | `pymanager`, else a `py` that answers `py help install` | `pymanager install --update`, or `py install --update` through the Install Manager's `py` alias | Installed Python runtimes. The classic `py` launcher cannot update runtimes, so a machine that has only it reports Skipped. |
 | .NET SDK | `dotnet`, plus an SDK version of 6 or higher | `dotnet tool update --all --global`, falling back to updating each tool by name | Global .NET tools. `dotnet` exists for runtime-only installs too, so the step confirms the SDK before using it. |
 | .NET workloads | `dotnet` | `dotnet workload update` | MAUI, Android, iOS and WASM workloads. |
 | rustup | `rustup` | `rustup update` | Every installed Rust toolchain. |
@@ -437,7 +438,7 @@ Four steps, and they cover different things:
 | Step | Updates |
 |---|---|
 | `Python (Install Manager)` | the Python runtimes |
-| `pip` | pip itself, for the interpreter on PATH |
+| `pip` | pip itself, for the first of `py`, `python` found |
 | `uv` | uv itself, and only when no package manager owns it |
 | `pipx packages` | isolated CLI applications |
 
@@ -451,9 +452,10 @@ both have their own steps.
 step reports skipped and says so: those packages belong to whatever project made
 the environment, not to the machine.
 
-Only the interpreter that resolves on PATH is updated. Others the launcher knows
-about are named in the output and left alone — upgrading pip in every Python on a
-machine is a larger claim than a maintenance run should make on its own.
+Only one interpreter's pip is updated: the launcher's default when `py` is
+present, else the `python` on `PATH`. Others the launcher knows about are named
+in the output and left alone — upgrading pip in every Python on a machine is a
+larger claim than a maintenance run should make on its own.
 
 pip is upgraded through `python -m pip`, never the bare `pip.exe`: on Windows pip
 cannot replace its own running executable, so the direct form fails on a locked
@@ -481,7 +483,9 @@ The module writes logs to the first writable location among `%USERPROFILE%`,
 `%LOCALAPPDATA%`, `%TEMP%` and the module directory, under `UpdateLogs\`:
 
 - `Update-Everything-<timestamp>.log`, the transcript of the whole run
-- `<step>-<timestamp>.log`, every stream from that one step
+- `<step>-<timestamp>.log`, every stream from that one step. Progress repaints
+  — bars, spinner ticks, bare percentages — are dropped, so a redrawing download
+  does not arrive as a column of noise
 
 Many CLIs write ordinary progress to stderr, so a step earns `Warning` only when
 PowerShell itself raises an error record.

--- a/src/Private/Format-SelfVersionStatus.ps1
+++ b/src/Private/Format-SelfVersionStatus.ps1
@@ -11,13 +11,15 @@ function Format-SelfVersionStatus {
 
         Three answers that must not be confused:
 
-          behind          the gallery is ahead, and -UpdateSelf will fetch it
+          behind          the gallery is ahead; -UpdateSelf fetches a gallery
+                          copy, and for one it cannot move it names the switch
+                          that will
           ahead / equal   nothing to do
           cannot tell     the gallery was not reachable
 
-        A copy PowerShellGet did not install is frequently ahead of the gallery
-        rather than behind, so it is named separately and never called out of
-        date.
+        A copy PowerShellGet did not install is named separately, with the
+        switch that matches where it came from. When it is ahead of the gallery
+        -- the usual state for one -- it is not called out of date.
 
         .PARAMETER Running
         The version of the module actually executing.

--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -7,20 +7,26 @@ function Get-GalleryModuleStatus {
         .DESCRIPTION
         Returns Name, Installed, Available, Updatable and NeedsUpdate.
 
-        Installed is $null when the module is absent, which is an install and
-        needs consent, rather than an update, which does not.
+        Installed is $null when the module is absent. Absent means any install
+        is a new install and needs consent; present but old means an update,
+        which does not.
 
-        Available is $null when the gallery could not be reached, and NeedsUpdate
-        is then $false, so a network failure presents as "cannot tell" rather
-        than as a reason to reinstall. An update is never reported for a module
-        that is not installed.
+        Available is $null when the gallery could not be reached or does not
+        carry the name, and NeedsUpdate is then $false, so neither presents as
+        a reason to reinstall. An update is never reported for a module that is
+        not installed.
 
         Updatable reports whether Update-Module can move this copy forward. It
-        refuses anything it did not install, which covers every module that
-        shipped with the host. Windows PowerShell ships PowerShellGet 1.0.0.1
+        refuses anything it did not install, answering "Module 'X' was not
+        installed by using Install-Module, so it cannot be updated" -- which
+        covers every module that shipped with the host. Windows PowerShell
+        ships PowerShellGet 1.0.0.1
         under Program Files rather than $PSHOME, so the path is not the test;
         whether PowerShellGet recorded the install is. Moving a shipped copy
         forward is a side-by-side install, and so an install decision.
+
+        .PARAMETER Name
+        The module to look up, on this machine and on the gallery.
 
         .EXAMPLE
         Get-GalleryModuleStatus -Name PowerShellGet

--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -62,10 +62,12 @@ function Get-UpdateToolInventory {
 
     foreach ($tool in $Catalogue) {
         $resolved = @(Get-Command $tool.Command -CommandType Application -ErrorAction SilentlyContinue)
+        # First-occurrence order is PATH-resolution order, so the first entry is
+        # the copy that actually runs.
         $places = @($resolved |
             ForEach-Object { Split-Path $_.Source -Parent } |
             Where-Object { $_ } |
-            Sort-Object -Unique)
+            Select-Object -Unique)
 
         if (-not $resolved.Count) {
             [pscustomobject]@{

--- a/src/Private/Get-WingetLeftover.ps1
+++ b/src/Private/Get-WingetLeftover.ps1
@@ -12,12 +12,16 @@ function Get-WingetLeftover {
                       often fixable -- a package whose executable is running
                       cannot be replaced until it is closed.
 
-          Skipped     winget listed it and never tried. Usually "a newer package
-                      version is available in a configured source, but it does
-                      not apply to your system or requirements", which is
-                      permanent until the vendor ships something that applies.
-                      Reporting it as a failure every run teaches people to skim
-                      past it.
+          Skipped     winget listed it and never tried. winget's usual wording:
+                      "a newer package version is available in a configured
+                      source, but it does not apply to your system or
+                      requirements". That is permanent until the vendor ships
+                      something that applies, and reporting it as a failure
+                      every run teaches people to skim past the ones that are
+                      real failures.
+
+          A package only the closing table lists was listed for the first time
+          during the run and is neither of these; Listed tells it apart.
 
         Attempted is decided by winget's own "Found <name> [<id>]" line. The rest
         of the output is localised prose.
@@ -87,6 +91,7 @@ function Get-WingetLeftover {
             Version   = $package.Version
             Available = $package.Available
             Attempted = $attempted
+            Listed    = $wasListed
             Reason    = $reason
         }
     }

--- a/src/Private/Test-ProgressRepaint.ps1
+++ b/src/Private/Test-ProgressRepaint.ps1
@@ -17,6 +17,9 @@
         The patterns are narrow -- a bar, a bare percentage, a spinner tick --
         because this runs over every line of every step, and dropping real
         output to tidy a log would be the worse bug.
+
+        .PARAMETER Line
+        One line of captured step output.
     #>
     [CmdletBinding()]
     [OutputType([bool])]

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -17,8 +17,9 @@
         the Windows Terminal default profile. The README lists what each runs.
 
         Presence of an executable is not proof a feature is installed, and package
-        managers routinely return non-zero for "nothing to do", so every step
-        probes before it runs and enumerates its own acceptable exit codes. Steps
+        managers routinely return non-zero for "nothing to do", so steps that
+        drive an external tool probe for it first, and each step decides which
+        of its tool's exit codes are routine. Steps
         capture every stream (*>&1); only errors raised by PowerShell itself are
         counted, and those mark a step Warning rather than OK.
 
@@ -83,7 +84,9 @@
           All              approve everything below
           PowerShell7      install PowerShell 7 via winget (machine-wide MSI)
           PSWindowsUpdate  install the PSWindowsUpdate module (AllUsers scope)
-          NuGetProvider    install the NuGet package provider (CurrentUser)
+          NuGetProvider    install or refresh the NuGet package provider
+                           (the first bootstrap is CurrentUser; a refresh is
+                           AllUsers when elevated, otherwise CurrentUser)
           BurntToast       install the BurntToast module for -Notify (CurrentUser)
           PowerShellGet    replace the PowerShellGet 1.0.0.1 Windows ships with
                            2.x, which can accept module licenses and can see
@@ -206,8 +209,9 @@
 
     .NOTES
         Elevation is checked before it is requested. A standard user gets a clear
-        explanation and exit 64 rather than a UAC prompt that cannot succeed. Run
-        with -SkipElevation to perform the steps that do not need admin.
+        explanation and a result with Ran = $false rather than a UAC prompt that
+        cannot succeed. Run with -SkipElevation to perform the steps that do not
+        need admin.
 
         Execution policy: the elevated relaunch passes -ExecutionPolicy Bypass.
         Importing the module obeys whatever policy is in force, so on a machine
@@ -406,8 +410,7 @@
     $WingetNothingToDo = @(-1978335189, -1978335212)
 
     # The version that produced this log, so a transcript can be read against the
-    # code that made it. The running module, not the highest installed: a session
-    # imported by path, or loaded before an update, is running something else.
+    # code that made it. The running module, not the highest installed.
     $script:RunningVersion = $MyInvocation.MyCommand.Module.Version
 
     Write-Host "Maintenance run started $(Get-Date)  |  Admin: $isAdmin  |  Main Log: $mainLog" -ForegroundColor Green
@@ -426,8 +429,9 @@
         Write-Output "$($present.Count) of $($inventory.Count) tools present."
         Write-Output ''
 
-        # Aligned by hand: inside a step action the output has to reach the pipeline
-        # for Invoke-Step to capture, and Format-Table records only render to a host.
+        # Aligned by hand to control the widths: the step pipeline renders
+        # Format-Table records through Out-String -Stream, but with widths of its
+        # own choosing.
         $nameWidth = 0
         $ownerWidth = 0
         foreach ($tool in $present) {
@@ -444,16 +448,18 @@
             Write-Output 'Their steps report Skipped, which is the expected result rather than a fault.'
         }
 
-        # Compared against the gallery here rather than in the banner because it costs
-        # a network call, and -ExcludeTag Inventory turns it off.
+        # Compared against the gallery here rather than in the banner: it costs a
+        # network call a machine with no network should not pay before the run
+        # starts, and -ExcludeTag Inventory turns it off.
         if ($script:RunningVersion) {
             Write-Output ''
             Write-Output (Format-SelfVersionStatus -Running $script:RunningVersion `
                 -Status (Get-GalleryModuleStatus -Name 'UpdateEverything'))
         }
 
-        # More than one executable of a name on PATH means the first runs and the rest
-        # are updated by nobody, or by a manager that does not own the copy in use.
+        # More than one executable of a name on PATH means the first on PATH runs
+        # and the rest are updated by nobody, or by a manager that does not own
+        # the copy in use. Places preserves that resolution order.
         $duplicated = @($present | Where-Object { $_.Copies -gt 1 })
         if ($duplicated.Count) {
             Write-Output ''
@@ -570,7 +576,8 @@
             $leftover = @(Get-WingetLeftover -Before $before -After $after -Output $text)
 
             $attempted = @($leftover | Where-Object { $_.Attempted })
-            $skipped = @($leftover | Where-Object { -not $_.Attempted })
+            $skipped   = @($leftover | Where-Object { -not $_.Attempted -and $_.Listed })
+            $appeared  = @($leftover | Where-Object { -not $_.Attempted -and -not $_.Listed })
 
             if ($attempted.Count) {
                 Write-Output ''
@@ -581,12 +588,23 @@
             }
 
             # Information, not a problem: these do not change until the vendor ships
-            # something applicable, and reading them as failures teaches skimming.
+            # something applicable, and a person who reads them as failures learns
+            # to skim past the ones that are.
             if ($skipped.Count) {
                 Write-Output ''
                 Write-Output 'Not upgradable on this machine, and expected to stay that way:'
                 foreach ($package in $skipped) {
                     Write-Output ("  {0} {1} -> {2}  ({3})" -f $package.Id, $package.Version, $package.Available, $package.Reason)
+                }
+            }
+
+            # Listed for the first time by the closing table: nothing was tried
+            # and nothing is known to block it, so the next run picks it up.
+            if ($appeared.Count) {
+                Write-Output ''
+                Write-Output 'Newly listed during this run; the next run picks these up:'
+                foreach ($package in $appeared) {
+                    Write-Output ("  {0} {1} -> {2}" -f $package.Id, $package.Version, $package.Available)
                 }
             }
 
@@ -607,9 +625,10 @@
     }
 
     # ---------------------------------------------------------------------------
-    # A manager runs before the tools it may own. Chocolatey and Scoop install
-    # language toolchains, so updating uv or npm first would update a tool before
-    # the thing responsible for it.
+    # A manager runs before the tools it may own. The uv step asks
+    # Get-ToolInstallSource and skips a managed copy, so for it this order is
+    # presentation rather than protection -- but the sequence should read the
+    # way the dependency runs.
     # ---------------------------------------------------------------------------
     # 2b. Chocolatey and Scoop, before the toolchains they may own
     # ---------------------------------------------------------------------------
@@ -664,8 +683,9 @@
                 }
 
                 Write-Output 'PowerShell 7 not detected; installing the MSI package via winget...'
-                # --installer-type wix forces the MSI (winget 7.6+ defaults to MSIX) so it
-                # installs to C:\Program Files\PowerShell\7 where Terminal expects it.
+                # --installer-type wix forces the MSI (the Microsoft.PowerShell winget
+                # package defaults to MSIX from PowerShell 7.6) so it installs to
+                # C:\Program Files\PowerShell\7 where Terminal expects it.
                 winget install --id $id --exact --source winget --installer-type wix `
                     --accept-source-agreements --accept-package-agreements --disable-interactivity
                 if ($LASTEXITCODE -ne 0) { throw "winget install returned $LASTEXITCODE" }
@@ -726,8 +746,9 @@
     # ---------------------------------------------------------------------------
     # 3. PowerShell repository trust, modules + help
     # ---------------------------------------------------------------------------
-    # PSGallery ships Untrusted, so every module install stops on a confirmation
-    # prompt that -ErrorAction SilentlyContinue does not suppress. Trust is stored
+    # PSGallery ships Untrusted, so every module install or update stops on the
+    # "You are installing the modules from an untrusted repository" prompt, which
+    # -ErrorAction SilentlyContinue does not suppress. Trust is stored
     # per-user under LOCALAPPDATA, and UAC keeps the same profile, so setting it
     # once here covers both the elevated and non-elevated run.
     Invoke-Step -Name 'Trust PSGallery' -Tag 'PowerShell' -Action {
@@ -772,10 +793,10 @@
         # which handles the 1.0.0.1 Windows ships as one case of a general rule.
     }
 
-    # The tooling every other gallery step runs on. Bootstrapped above when missing,
-    # but nothing brought it forward once present, so a machine could carry a
-    # years-old provider for as long as it lived. Runs before PowerShell modules,
-    # which depends on it.
+    # The tooling every other gallery step runs on. Bootstrapping covers absence;
+    # this step is what brings a present copy forward, without which a machine
+    # could carry a years-old NuGet provider or a PowerShellGet 2.1 for as long
+    # as it lived. Runs before PowerShell modules, which depends on it.
     Invoke-Step -Name 'Gallery tooling' -Tag 'PowerShell' -Action {
         # Not admin-gated, and -Scope AllUsers fails without elevation, so the
         # scope follows what the run actually has.
@@ -784,8 +805,9 @@
         # --- NuGet package provider ------------------------------------------
         #
         # There is no Update-PackageProvider; Install-PackageProvider is the only way
-        # forward, so the refresh is an install command fetching a binary assembly and
-        # asks under the same NuGetProvider component. Declining is not fatal.
+        # forward, so the refresh is an install command fetching a binary assembly. It
+        # asks under the same NuGetProvider component as the bootstrap, so one consent
+        # covers both. Declining is not fatal: the provider present keeps working.
         $nuget = @(Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue |
             Sort-Object Version -Descending)
         if (-not $nuget.Count) {
@@ -827,9 +849,10 @@
         # --- PowerShellGet and PSResourceGet ---------------------------------
         #
         #   absent                  an install, and asks
-        #   present but not ours    a shipped copy; Update-Module refuses it, so
-        #                           moving it forward is a side-by-side install,
-        #                           and asks
+        #   present but not ours    a shipped copy. Update-Module answers "Module
+        #                           'X' was not installed by using Install-Module,
+        #                           so it cannot be updated"; moving it forward is
+        #                           a side-by-side install, and asks
         #   present and ours        an update, and does not ask
         #
         # Windows PowerShell ships PowerShellGet 1.0.0.1 under Program Files and
@@ -861,7 +884,8 @@
                 }
 
                 # The same trap as -UpdateSelf: the module is loaded, so the files on
-                # disk are replaced and the cmdlets running now stay on memory.
+                # disk are replaced and the cmdlets running now stay on the code in
+                # memory.
                 Write-Output "$name updated. It loads in the next session; this run continues on the version already in memory."
                 continue
             }
@@ -893,8 +917,9 @@
         Add-SkippedStep -Name 'PowerShell modules'
     } else {
     Invoke-Step -Name 'PowerShell modules' -Tag 'PowerShell' -Action {
-        # Both update commands are silent on success, so the step reported only OK
-        # and a duration. Taken either side of the pass, this says what moved.
+        # Both update commands are silent on success; without this capture the step
+        # would report only OK and a duration. Taken either side of the pass, this
+        # says what moved.
         $before = Get-ModuleVersionMap
 
         if (Get-Command Update-PSResource -ErrorAction SilentlyContinue) {
@@ -973,9 +998,23 @@
     Invoke-Step -Name 'Python (Install Manager)' -Tag 'Python' -Action {
         # Skipped rather than OK: a step that did nothing because the tool is absent
         # is not a step that updated something.
-        if     (Get-Command pymanager -ErrorAction SilentlyContinue) { pymanager install --update }
-        elseif (Get-Command py        -ErrorAction SilentlyContinue) { py install --update }
-        else   { Stop-StepAsSkipped -Reason 'the Python Install Manager is not installed' }
+        if (Get-Command pymanager -ErrorAction SilentlyContinue) {
+            pymanager install --update
+        } elseif (Get-Command py -ErrorAction SilentlyContinue) {
+            # Two tools answer to py: the Install Manager's alias, which has an
+            # install subcommand, and the classic launcher, which treats a bare
+            # word as a script path and errors. "py help install" tells them
+            # apart without changing anything: the alias exits 0, the launcher
+            # cannot open a script named help and does not.
+            $null = & py help install 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                $global:LASTEXITCODE = 0
+                Stop-StepAsSkipped -Reason 'py here is the classic launcher, which cannot update runtimes; the Python Install Manager replaces it'
+            }
+            py install --update
+        } else {
+            Stop-StepAsSkipped -Reason 'the Python Install Manager is not installed'
+        }
     }
 
     Invoke-Step -Name 'uv' -RequiresCommand 'uv' -Tag 'Python' -Action {
@@ -991,7 +1030,8 @@
 
         if ($LASTEXITCODE -ne 0) {
             # uv refuses to self-update when a package manager owns it and says so in
-            # its output, which is correct rather than failed. Any other non-zero is.
+            # its output, which is correct rather than failed. Any other non-zero
+            # exit is reported as a real failure.
             if (($output | Out-String) -match 'package manager|self-update.*(disabled|unavailable)') {
                 Write-Output 'uv declined to self-update because something else manages it.'
                 $global:LASTEXITCODE = 0
@@ -1004,7 +1044,8 @@
 
     Invoke-Step -Name 'pip' -Tag 'Python' -Action {
         # Never inside an active virtual environment: its packages belong to whatever
-        # project made it, and it is the easiest interpreter to reach from here.
+        # project made it, and it is both the easiest interpreter to reach from here
+        # and the worst one to change.
         if ($env:VIRTUAL_ENV) {
             Stop-StepAsSkipped -Reason "a virtual environment is active ($env:VIRTUAL_ENV), and its packages belong to that project rather than to this machine"
         }
@@ -1048,9 +1089,8 @@
             $others | ForEach-Object { Write-Output "  $($_.Trim())" }
         }
 
-        # Installed packages are left alone. pip has no upgrade-all, and upgrading
-        # each outdated package can silently downgrade another's dependency -- the
-        # problem pipx and uv exist to avoid, and both have their own steps.
+        # Installed packages are left alone; the README's Python section carries
+        # the why.
     }
 
     Invoke-Step -Name 'pipx packages' -RequiresCommand 'pipx' -Tag 'Python' -Action {
@@ -1070,8 +1110,9 @@
             $npmText = $npmOutput | Out-String
 
             # EBADENGINE means the newest npm does not support the installed Node,
-            # which is a fact about this machine. Reported in full, because the bare
-            # exit code does not say which it is.
+            # which is a fact about this machine rather than a fault in the update.
+            # Reported in full, because the bare exit code does not say which of
+            # the two it is.
             if ($npmText -match 'EBADENGINE') {
                 $nodeVersion = try { node --version 2>$null } catch { 'unknown' }
                 Write-Error ("npm could not update itself: the latest npm does not support the installed Node.js ($nodeVersion). " +
@@ -1269,8 +1310,8 @@
             Import-Module PSWindowsUpdate -ErrorAction Stop
 
             # Windows Update alone offers the OS and drivers; registering Microsoft
-            # Update widens the scan to Office. Managed devices often block this by
-            # policy, so degrade rather than fail.
+            # Update widens the scan to Office and other Microsoft products. Managed
+            # devices often block this by policy, so degrade rather than fail.
             $useMicrosoftUpdate = $false
             $muServiceId = '7971f918-a847-4430-9279-4a52d1efe18d'
             try {

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -634,6 +634,13 @@ Describe 'Update-Everything' -Tag 'Static' {
 
 Describe 'Repository documentation' -Tag 'Docs' {
 
+    It 'shows an inventory sample sized to the real catalogue' {
+        $readme = Get-Content (Join-Path $script:RepoRoot 'README.md') -Raw
+        $readme -match 'of (\d+) tools present' | Should-BeTrue
+        [int]$Matches[1] |
+            Should-Be @(& (Get-Module UpdateEverything) { Get-UpdateToolInventory }).Count
+    }
+
     It 'README documents -<Name>' -ForEach $ExpectedParameters {
         $script:Readme | Should-MatchString ([regex]::Escape("-$Name"))
     }
@@ -1158,7 +1165,7 @@ Describe 'Get-ToolInstallSource' -Tag 'Unit' {
     }
 }
 
-Describe 'Ready for the PowerShell Gallery' -Tag 'Static','Module' {
+Describe 'Ready for the PowerShell Gallery' -Tag 'Static','Module','Lint' {
 
     # The gallery runs PSScriptAnalyzer with its own default rules and shows the
     # result on the package page. This repository's settings suppress several

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -681,9 +681,9 @@ Describe 'Every cadence can actually register a task' -Tag 'Integration' {
     }
 
     # PatchTuesday is registered once here and asserted twice, rather than once
-    # per test. Registering costs 3.7s and removing costs 2.9s against the real
-    # Task Scheduler, and the second registration would produce the same task as
-    # the first.
+    # per test. Registering and removing real tasks costs seconds each against
+    # the Task Scheduler, and the second registration would produce the same
+    # task as the first.
     #
     # The parent AfterEach still runs between these two, so the export is taken
     # in BeforeAll while the task exists.

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2487,6 +2487,14 @@ remove: Access is denied.: "C:\...\WinGet\Packages\astral-sh.uv_...\uv.exe"
         $uv.Version   | Should-Be '0.11.19'
         $uv.Available | Should-Be '0.12.7'
     }
+
+    It 'tells a newly listed package apart from a skipped one' {
+        $extra = [pscustomobject]@{ Name = 'New App'; Id = 'New.New'; Version = '1.0'; Available = '1.1' }
+        $rows = @(Get-WingetLeftover -Before $script:Before -After (@($script:Before) + $extra) -Output $script:Output)
+
+        @($rows | Where-Object { $_.Id -eq 'New.New' }).Listed | Should-BeFalse
+        @($rows | Where-Object { $_.Id -eq 'Cisco.CiscoWebexMeetings' }).Listed | Should-BeTrue
+    }
 }
 
 Describe 'Errors reach the person watching the run' -Tag 'Unit' {


### PR DESCRIPTION
Fixes all 15 reported findings from the Fable 5 max review of the trimming pass, plus the 13 confirmed items that fell below the report cap. 47 edits across 11 files; 722 tests (720 + 2 new), 0 failures.

## Behavior fixes (the 1.3.1 payload)

1. **The duplicate-copy warning could name the wrong copy.** `Get-UpdateToolInventory` built `Places` with `Sort-Object -Unique`, which alphabetises away PATH-resolution order. Now `Select-Object -Unique`, verified with a two-directory counterexample: the PATH-first copy leads regardless of spelling.
2. **The Python step failed on classic-launcher machines.** `py install --update` hands "install" to the classic launcher as a script path and errors, marking the step Failed on every pre-PIM machine. The step now probes with `py help install` -- the Install Manager alias exits 0 (verified live), the classic launcher does not -- and skips with a reason instead.
3. **Newly listed packages were called permanently blocked.** A package that appears only in the closing winget table landed under "Not upgradable on this machine, and expected to stay that way". `Get-WingetLeftover` now carries `Listed`, and those rows print under "Newly listed during this run; the next run picks these up". New test covers the distinction.

## Docs and help

The invalid `-Cadence Monthly` sample (the ValidateSet says `PatchTuesday`), the omitted winget `--accept-*` consent flags, the pip Python-section contradiction, the dead `exit 64`, the false "every step probes and enumerates exit codes", the `-UpdateSelf`-fetches-it overpromise, "(CurrentUser)" on an AllUsers refresh, "forced to MSI" (install branch only), the "only marked Warning for attempted" absolute, "(winget 7.6+)", and the "every stream" log claim now disclosing the progress-repaint filter.

## Greppability restored, wrap-safe

`"You are installing the modules from an untrusted repository"`, `"installed by using Install-Module"` (both homes), `"does not apply to your system"`, `"newer package version"` -- all grep to hits again, each literal kept intact within one line.

## Mechanism over prose

The gallery-readiness analyzer pass is now tagged `Lint`, which makes CONTRIBUTING''s "skip both" advice true and takes the ~19s analyzer cold start out of the iterate loop for real. The self-contradicting timing figures (90s, 59s, "half") became durable statements of cost, and a new Docs test ties the README''s "10 of 15 tools" sample to the live catalogue count -- the number that had already drifted once.

## Also

Six meaning-inverting compressions restored (venv "worst one to change", uv''s dangling predicate, the cry-wolf skim rationale at two sites, EBADENGINE''s lost alternative, the NuGetProvider comparand, "stay on the code in memory"), two helpers'' missing `.PARAMETER` blocks added, the Gallery-tooling header un-contradicted, "Office and other Microsoft products" restored, and the one-day 3.7s/2.9s figures in a test comment stated as costs.

One fix was itself corrected mid-PR: pointing the version-banner comment at `Format-SelfVersionStatus` tripped the position test that keeps the gallery lookup out of the startup path -- the dedup is by removal instead.
