### PR TITLE
Cover the toolchain updaters the run was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ thing that crosses a process boundary.
 more of:
 
 `Windows` `Microsoft` `PowerShell` `PackageManager` `Python` `Node` `DotNet`
-`Rust` `Git` `Self` `Inventory`
+`Rust` `Go` `Git` `Self` `Inventory`
 
 ```powershell
 Update-Everything -Tag Python
@@ -298,13 +298,13 @@ called out of date.
 quickest way to see why a run skipped what it skipped:
 
 ```
-10 of 15 tools present.
+12 of 21 tools present.
 
   winget           Unknown     v1.29.290
   PowerShell 7     Unknown     PowerShell 7.6.5
   uv               Standalone  uv 0.12.7
 
-Not installed: .NET SDK, Chocolatey, pipx, rustup, Scoop
+Not installed: .NET SDK, Bun, Chocolatey, Deno, gup, pipx, pnpm, rustup, Scoop
 Their steps report Skipped, which is the expected result rather than a fault.
 
 WARNING: PowerShell 7 is installed in 2 places; the first is the one that runs:
@@ -399,6 +399,9 @@ choose the packages; the manager's own inventory does.
 | Chocolatey | `choco` | `choco upgrade all -y` | Everything installed as a Chocolatey package. Exit codes 1641 and 3010 pass, since those are the MSI "reboot required" codes rather than failures. |
 | Scoop | `scoop` | `scoop update`, `scoop update *`, `scoop cleanup *`, each run on its own | Scoop, its buckets, installed apps, then old versions. The phases run separately so a broken bucket cannot hide the rest. |
 | npm | `npm` | `npm install -g npm@latest`, then `npm update -g` only with `-UpdateGlobalNpm` | npm itself, every run. Global packages only on request, because upgrading them can move a pinned toolchain. |
+| Deno | `deno`, plus an ownership check | `deno upgrade` | Deno itself, when nothing else owns it. |
+| Bun | `bun`, plus an ownership check | `bun upgrade` | Bun itself, when nothing else owns it. |
+| pnpm | `pnpm`, plus an ownership check | `pnpm self-update` | The standalone pnpm only. A Corepack-managed pnpm is pinned per project and left to Corepack. |
 | pip | `py`, else `python` | `<interpreter> -m pip install --upgrade pip --disable-pip-version-check` | pip itself, for the first of those found. Where `py` is present that is the launcher's default interpreter, which is not always the `python` on `PATH`. Installed packages are left alone -- see [Python](#python). |
 | pipx | `pipx` | `pipx upgrade-all` | Every Python application pipx installed. |
 | uv | `uv`, plus an ownership check | `uv self update` | uv itself, and only when nothing else owns it. |
@@ -406,6 +409,8 @@ choose the packages; the manager's own inventory does.
 | .NET SDK | `dotnet`, plus an SDK version of 6 or higher | `dotnet tool update --all --global`, falling back to updating each tool by name | Global .NET tools. `dotnet` exists for runtime-only installs too, so the step confirms the SDK before using it. |
 | .NET workloads | `dotnet` | `dotnet workload update` | MAUI, Android, iOS and WASM workloads. |
 | rustup | `rustup` | `rustup update` | Every installed Rust toolchain. |
+| cargo binaries | `cargo`, plus the `cargo-update` crate | `cargo install-update --all` | Every binary `cargo install` put on the machine. Skips naming `cargo install cargo-update` when the subcommand is absent. |
+| Go binaries | `go`, plus `gup` | `gup update` | Every binary `go install` put in `GOBIN`. Skips naming `go install github.com/nao1215/gup@latest` when gup is absent. |
 | GitHub CLI | `gh`, plus a non-empty `gh extension list` | `gh extension upgrade --all` | Installed `gh` extensions. That second check matters, because the upgrade command exits non-zero when nothing is installed. |
 
 ### How it decides who owns a tool

--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -48,6 +48,9 @@ function Get-UpdateToolInventory {
             @{ Name = 'PowerShell 7';    Command = 'pwsh';    VersionArgument = '--version' }
             @{ Name = 'Node.js';         Command = 'node';    VersionArgument = '--version' }
             @{ Name = 'npm';             Command = 'npm';     VersionArgument = '--version' }
+            @{ Name = 'Deno';            Command = 'deno';    VersionArgument = '--version' }
+            @{ Name = 'Bun';             Command = 'bun';     VersionArgument = '--version' }
+            @{ Name = 'pnpm';            Command = 'pnpm';    VersionArgument = '--version' }
             @{ Name = 'Python launcher'; Command = 'py';      VersionArgument = '--version' }
             @{ Name = 'Python manager';  Command = 'pymanager'; VersionArgument = '--version' }
             @{ Name = 'uv';              Command = 'uv';      VersionArgument = '--version' }
@@ -55,6 +58,9 @@ function Get-UpdateToolInventory {
             @{ Name = 'pipx';            Command = 'pipx';    VersionArgument = '--version' }
             @{ Name = '.NET SDK';        Command = 'dotnet';  VersionArgument = '--version' }
             @{ Name = 'rustup';          Command = 'rustup';  VersionArgument = '--version' }
+            @{ Name = 'cargo-update';    Command = 'cargo-install-update'; VersionArgument = '--version' }
+            @{ Name = 'Go';              Command = 'go';      VersionArgument = 'version' }
+            @{ Name = 'gup';             Command = 'gup';     VersionArgument = 'version' }
             @{ Name = 'GitHub CLI';      Command = 'gh';      VersionArgument = '--version' }
             @{ Name = 'WSL';             Command = 'wsl';     VersionArgument = $null }
         )

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -135,10 +135,10 @@
         # Passed straight through to the run this task performs, so one machine
         # can carry a daily task that skips a toolchain and a monthly one that
         # updates only that toolchain.
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Git', 'Self', 'Inventory')]
         [string[]] $Tag = @(),
 
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Git', 'Self', 'Inventory')]
         [string[]] $ExcludeTag = @(),
 
         [ValidateSet('Normal', 'Minimized', 'Hidden')]

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -12,9 +12,10 @@
 
         Steps cover winget and the Microsoft Store, Windows Update through
         PSWindowsUpdate, Microsoft 365 Apps, Defender signatures, PowerShell
-        modules and help, Chocolatey, Scoop, Python, uv, pip, pipx, npm, rustup,
-        dotnet, GitHub CLI extensions, the WSL kernel, PowerShell 7 itself and
-        the Windows Terminal default profile. The README lists what each runs.
+        modules and help, Chocolatey, Scoop, Python, uv, pip, pipx, npm, Deno,
+        Bun, pnpm, rustup, cargo binaries, Go binaries, dotnet, GitHub CLI
+        extensions, the WSL kernel, PowerShell 7 itself and the Windows Terminal
+        default profile. The README lists what each runs.
 
         Presence of an executable is not proof a feature is installed, and package
         managers routinely return non-zero for "nothing to do", so steps that
@@ -156,7 +157,7 @@
         every step.
 
         A step carries one or more of: Windows, Microsoft, PowerShell,
-        PackageManager, Python, Node, DotNet, Rust, Git, Self, Inventory.
+        PackageManager, Python, Node, DotNet, Rust, Go, Git, Self, Inventory.
 
             Update-Everything -Tag Python
             Update-Everything -Tag Inventory    report what is installed, update nothing
@@ -239,9 +240,9 @@
         [switch] $Notify,
         [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Git', 'Self', 'Inventory')]
         [string[]] $Tag = @(),
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Git', 'Self', 'Inventory')]
         [string[]] $ExcludeTag = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30,
@@ -1135,6 +1136,70 @@
         }
     }
 
+    # The three below follow the uv rule: self-update only what nothing else
+    # manages, and treat the tool's own refusal as correct rather than failed.
+    Invoke-Step -Name 'Deno' -RequiresCommand 'deno' -Tag 'Node' -Action {
+        $owner = Get-ToolInstallSource -Name 'deno'
+        if ($owner -notin 'Standalone', 'Unknown') {
+            Stop-StepAsSkipped -Reason "Deno is managed by $owner, which updates it in its own step"
+        }
+
+        $output = deno upgrade 2>&1
+        $output
+
+        if ($LASTEXITCODE -ne 0) {
+            if (($output | Out-String) -match 'package manager') {
+                Write-Output 'Deno declined to upgrade because something else manages it.'
+                $global:LASTEXITCODE = 0
+            } else {
+                Write-Error "deno upgrade failed with exit code $LASTEXITCODE. Deno's own message is in this step's log."
+                $global:LASTEXITCODE = 0
+            }
+        }
+    }
+
+    Invoke-Step -Name 'Bun' -RequiresCommand 'bun' -Tag 'Node' -Action {
+        $owner = Get-ToolInstallSource -Name 'bun'
+        if ($owner -notin 'Standalone', 'Unknown') {
+            Stop-StepAsSkipped -Reason "Bun is managed by $owner, which updates it in its own step"
+        }
+
+        $output = bun upgrade 2>&1
+        $output
+
+        if ($LASTEXITCODE -ne 0) {
+            if (($output | Out-String) -match 'package manager') {
+                Write-Output 'Bun declined to upgrade because something else manages it.'
+                $global:LASTEXITCODE = 0
+            } else {
+                Write-Error "bun upgrade failed with exit code $LASTEXITCODE. Bun's own message is in this step's log."
+                $global:LASTEXITCODE = 0
+            }
+        }
+    }
+
+    Invoke-Step -Name 'pnpm' -RequiresCommand 'pnpm' -Tag 'Node' -Action {
+        $owner = Get-ToolInstallSource -Name 'pnpm'
+        if ($owner -notin 'Standalone', 'Unknown') {
+            Stop-StepAsSkipped -Reason "pnpm is managed by $owner, which updates it in its own step"
+        }
+
+        # self-update applies to the standalone install only; a Corepack-managed
+        # pnpm is pinned per project and updated through Corepack.
+        $output = pnpm self-update 2>&1
+        $output
+
+        if ($LASTEXITCODE -ne 0) {
+            if (($output | Out-String) -match 'corepack|standalone') {
+                Write-Output 'pnpm declined to self-update because Corepack or a package manager manages it.'
+                $global:LASTEXITCODE = 0
+            } else {
+                Write-Error "pnpm self-update failed with exit code $LASTEXITCODE. pnpm's own message is in this step's log."
+                $global:LASTEXITCODE = 0
+            }
+        }
+    }
+
     # ---------------------------------------------------------------------------
     # 6. .NET global tools
     # ---------------------------------------------------------------------------
@@ -1205,6 +1270,39 @@
     # ---------------------------------------------------------------------------
     Invoke-Step -Name 'rustup' -RequiresCommand 'rustup' -Tag 'Rust' -Action {
         rustup update
+    }
+
+    # rustup moves the toolchains; nothing moves the binaries cargo install put
+    # on the machine. The cargo-update crate adds the subcommand that does.
+    Invoke-Step -Name 'cargo binaries' -RequiresCommand 'cargo' -Tag 'Rust' -Action {
+        $null = cargo install-update --version 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            $global:LASTEXITCODE = 0
+            Stop-StepAsSkipped -Reason 'the cargo-update crate is not installed; "cargo install cargo-update" adds the subcommand this step runs'
+        }
+
+        # cargo writes progress to stderr as a matter of course; judge by exit code.
+        $output = cargo install-update --all 2>&1
+        $output
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "cargo install-update --all failed with exit code $LASTEXITCODE. cargo's own message is in this step's log."
+            $global:LASTEXITCODE = 0
+        }
+    }
+
+    # go install has no update-everything form; gup is the tool that adds one,
+    # updating every binary under GOBIN.
+    Invoke-Step -Name 'Go binaries' -RequiresCommand 'go' -Tag 'Go' -Action {
+        if (-not (Get-Command gup -CommandType Application -ErrorAction SilentlyContinue)) {
+            Stop-StepAsSkipped -Reason 'gup is not installed; "go install github.com/nao1215/gup@latest" adds it'
+        }
+
+        $output = gup update 2>&1
+        $output
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "gup update failed with exit code $LASTEXITCODE. gup's own message is in this step's log."
+            $global:LASTEXITCODE = 0
+        }
     }
 
     Invoke-Step -Name 'GitHub CLI extensions' -RequiresCommand 'gh' -Tag 'Git' -Action {

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -1131,9 +1131,9 @@ Describe 'No step updates through a tool it has not verified' -Tag 'Static','Mod
 
     # Self-update is only right when nothing else owns the tool. Running it
     # against a scoop or winget install fights that manager.
-    It 'asks who owns uv before telling it to update itself' {
+    It 'asks who owns <_> before telling it to update itself' -ForEach @('uv', 'Deno', 'Bun', 'pnpm') {
         $source = Get-Content (Join-Path $script:ModuleRoot 'Public\Update-Everything.ps1') -Raw
-        $step = [regex]::Match($source, "(?s)Invoke-Step -Name 'uv'.*?\r?\n    \}").Value
+        $step = [regex]::Match($source, "(?s)Invoke-Step -Name '$_'.*?\r?\n    \}").Value
 
         $step | Should-MatchString 'Get-ToolInstallSource'
         $step | Should-MatchString 'Stop-StepAsSkipped'

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1663,9 +1663,19 @@ Describe 'Every step declares a tag' -Tag 'Static' {
             if ($name) { $script:StepTags[$name] = $tags }
         }
 
-        # The set both public entry points validate against.
-        $script:DeclaredTags = @('Windows', 'Microsoft', 'PowerShell', 'PackageManager',
-                                 'Python', 'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')
+        # Read from the parameter itself rather than kept as a copy, which had
+        # already drifted once by the time a new tag landed.
+        $script:DeclaredTags = @((Get-Command Update-Everything).Parameters['Tag'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } |
+            ForEach-Object { $_.ValidValues })
+    }
+
+    It 'validates the same tag set on both entry points' {
+        $register = @((Get-Command Register-UpdateEverythingTask).Parameters['Tag'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } |
+            ForEach-Object { $_.ValidValues })
+
+        $register | Should-BeCollection $script:DeclaredTags
     }
 
     It 'found the steps to check' {


### PR DESCRIPTION
Five steps for the updaters #68, #69 and #73 found missing, one PR because they share a shape: found by the binary on `PATH`, ownership-checked the way `uv` already is, the tool''s own refusal treated as declined rather than failed, and prerequisites named in a skip reason rather than installed.

| Step | Tag | Runs | Skips when |
|---|---|---|---|
| Deno | `Node` | `deno upgrade` | a manager owns the copy |
| Bun | `Node` | `bun upgrade` | a manager owns the copy |
| pnpm | `Node` | `pnpm self-update` | a manager or Corepack owns it |
| cargo binaries | `Rust` | `cargo install-update --all` | the `cargo-update` crate is absent (skip names `cargo install cargo-update`) |
| Go binaries | `Go` (new) | `gup update` | gup is absent (skip names `go install github.com/nao1215/gup@latest`) |

Per #73''s recommendation, Yarn is left out: `yarn set version` writes a project''s `.yarnrc.yml`, which is not machine maintenance.

### The drift the new tag caught

The tag test kept its own hardcoded copy of the ValidateSet -- commented "The set both public entry points validate against" -- and adding `Go` proved it wrong by failing. The copy is gone: the test now reads the set from the parameter''s own ValidateSet, and a new test asserts Update-Everything and Register-UpdateEverythingTask validate the same set, which nothing checked before.

### Also

- Inventory catalogue 15 → 21 (Deno, Bun, pnpm, cargo-update, Go, gup); the README sample moves with it, enforced by the catalogue-count test from #79.
- The ownership static test is now a ForEach over uv, Deno, Bun and pnpm.

726 tests, 0 failures.
