### PR TITLE
Cover the cloud CLIs and conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ thing that crosses a process boundary.
 more of:
 
 `Windows` `Microsoft` `PowerShell` `PackageManager` `Python` `Node` `DotNet`
-`Rust` `Go` `Git` `Self` `Inventory`
+`Rust` `Go` `Cloud` `Git` `Self` `Inventory`
 
 ```powershell
 Update-Everything -Tag Python
@@ -298,13 +298,13 @@ called out of date.
 quickest way to see why a run skipped what it skipped:
 
 ```
-12 of 21 tools present.
+12 of 24 tools present.
 
   winget           Unknown     v1.29.290
   PowerShell 7     Unknown     PowerShell 7.6.5
   uv               Standalone  uv 0.12.7
 
-Not installed: .NET SDK, Bun, Chocolatey, Deno, gup, pipx, pnpm, rustup, Scoop
+Not installed: .NET SDK, Azure CLI, Bun, Chocolatey, conda, Deno, Google Cloud CLI, gup, pipx, pnpm, rustup, Scoop
 Their steps report Skipped, which is the expected result rather than a fault.
 
 WARNING: PowerShell 7 is installed in 2 places; the first is the one that runs:
@@ -405,12 +405,15 @@ choose the packages; the manager's own inventory does.
 | pip | `py`, else `python` | `<interpreter> -m pip install --upgrade pip --disable-pip-version-check` | pip itself, for the first of those found. Where `py` is present that is the launcher's default interpreter, which is not always the `python` on `PATH`. Installed packages are left alone -- see [Python](#python). |
 | pipx | `pipx` | `pipx upgrade-all` | Every Python application pipx installed. |
 | uv | `uv`, plus an ownership check | `uv self update` | uv itself, and only when nothing else owns it. |
+| conda | `conda` | `conda update --name base conda --yes` | conda itself, in the base environment. Environment packages are left alone for the same reason pip's are -- see [Python](#python). |
 | Python Install Manager | `pymanager`, else a `py` that answers `py help install` | `pymanager install --update`, or `py install --update` through the Install Manager's `py` alias | Installed Python runtimes. The classic `py` launcher cannot update runtimes, so a machine that has only it reports Skipped. |
 | .NET SDK | `dotnet`, plus an SDK version of 6 or higher | `dotnet tool update --all --global`, falling back to updating each tool by name | Global .NET tools. `dotnet` exists for runtime-only installs too, so the step confirms the SDK before using it. |
 | .NET workloads | `dotnet` | `dotnet workload update` | MAUI, Android, iOS and WASM workloads. |
 | rustup | `rustup` | `rustup update` | Every installed Rust toolchain. |
 | cargo binaries | `cargo`, plus the `cargo-update` crate | `cargo install-update --all` | Every binary `cargo install` put on the machine. Skips naming `cargo install cargo-update` when the subcommand is absent. |
 | Go binaries | `go`, plus `gup` | `gup update` | Every binary `go install` put in `GOBIN`. Skips naming `go install github.com/nao1215/gup@latest` when gup is absent. |
+| Azure CLI | `az` | `az upgrade --yes --only-show-errors` | The CLI and its installed extensions. Reruns the MSI, so it needs administrator rights. Tagged `Cloud`: `-ExcludeTag Cloud` drops it on a metered or offline machine. |
+| Google Cloud CLI | `gcloud`, plus an ownership check | `gcloud components update --quiet` | Every installed component of the bundled install. A Chocolatey or Scoop gcloud disables its own component manager and is left to that manager. Tagged `Cloud`. |
 | GitHub CLI | `gh`, plus a non-empty `gh extension list` | `gh extension upgrade --all` | Installed `gh` extensions. That second check matters, because the upgrade command exits non-zero when nothing is installed. |
 
 ### How it decides who owns a tool
@@ -446,8 +449,10 @@ Four steps, and they cover different things:
 | `pip` | pip itself, for the first of `py`, `python` found |
 | `uv` | uv itself, and only when no package manager owns it |
 | `pipx packages` | isolated CLI applications |
+| `conda` | conda itself, in the base environment |
 
-**Installed packages are deliberately left alone.** pip has no `upgrade-all`, and
+**Installed packages are deliberately left alone**, and conda environments with
+them. pip has no `upgrade-all`, and
 the usual recipe — list outdated, upgrade each — does not keep the dependency set
 consistent, because upgrading one package can silently downgrade another's
 dependency. That is the problem `pipx` and `uv` exist to solve by isolating, and

--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -56,12 +56,15 @@ function Get-UpdateToolInventory {
             @{ Name = 'uv';              Command = 'uv';      VersionArgument = '--version' }
             @{ Name = 'pip';             Command = 'pip';     VersionArgument = '--version' }
             @{ Name = 'pipx';            Command = 'pipx';    VersionArgument = '--version' }
+            @{ Name = 'conda';           Command = 'conda';   VersionArgument = '--version' }
             @{ Name = '.NET SDK';        Command = 'dotnet';  VersionArgument = '--version' }
             @{ Name = 'rustup';          Command = 'rustup';  VersionArgument = '--version' }
             @{ Name = 'cargo-update';    Command = 'cargo-install-update'; VersionArgument = '--version' }
             @{ Name = 'Go';              Command = 'go';      VersionArgument = 'version' }
             @{ Name = 'gup';             Command = 'gup';     VersionArgument = 'version' }
             @{ Name = 'GitHub CLI';      Command = 'gh';      VersionArgument = '--version' }
+            @{ Name = 'Azure CLI';       Command = 'az';      VersionArgument = $null }
+            @{ Name = 'Google Cloud CLI'; Command = 'gcloud'; VersionArgument = $null }
             @{ Name = 'WSL';             Command = 'wsl';     VersionArgument = $null }
         )
     }

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -135,10 +135,10 @@
         # Passed straight through to the run this task performs, so one machine
         # can carry a daily task that skips a toolchain and a monthly one that
         # updates only that toolchain.
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Self', 'Inventory')]
         [string[]] $Tag = @(),
 
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Self', 'Inventory')]
         [string[]] $ExcludeTag = @(),
 
         [ValidateSet('Normal', 'Minimized', 'Hidden')]

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -14,8 +14,9 @@
         PSWindowsUpdate, Microsoft 365 Apps, Defender signatures, PowerShell
         modules and help, Chocolatey, Scoop, Python, uv, pip, pipx, npm, Deno,
         Bun, pnpm, rustup, cargo binaries, Go binaries, dotnet, GitHub CLI
-        extensions, the WSL kernel, PowerShell 7 itself and the Windows Terminal
-        default profile. The README lists what each runs.
+        extensions, the Azure and Google Cloud CLIs, conda, the WSL kernel,
+        PowerShell 7 itself and the Windows Terminal default profile. The README
+        lists what each runs.
 
         Presence of an executable is not proof a feature is installed, and package
         managers routinely return non-zero for "nothing to do", so steps that
@@ -157,7 +158,8 @@
         every step.
 
         A step carries one or more of: Windows, Microsoft, PowerShell,
-        PackageManager, Python, Node, DotNet, Rust, Go, Git, Self, Inventory.
+        PackageManager, Python, Node, DotNet, Rust, Go, Cloud, Git, Self,
+        Inventory.
 
             Update-Everything -Tag Python
             Update-Everything -Tag Inventory    report what is installed, update nothing
@@ -240,9 +242,9 @@
         [switch] $Notify,
         [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Self', 'Inventory')]
         [string[]] $Tag = @(),
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Self', 'Inventory')]
         [string[]] $ExcludeTag = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30,
@@ -1101,6 +1103,19 @@
     # ---------------------------------------------------------------------------
     # 5. Node / npm
     # ---------------------------------------------------------------------------
+    # conda updates conda itself in the base environment and nothing else.
+    # Environments hold project package sets, and "conda update --all" is the
+    # operation the pip step's rule declines: upgrading one package can silently
+    # downgrade another's dependency.
+    Invoke-Step -Name 'conda' -RequiresCommand 'conda' -Tag 'Python' -Action {
+        $output = conda update --name base conda --yes 2>&1
+        $output
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "conda update failed with exit code $LASTEXITCODE. conda's own message is in this step's log."
+            $global:LASTEXITCODE = 0
+        }
+    }
+
     Invoke-Step -Name 'npm' -RequiresCommand 'npm' -Tag 'Node' -Action {
         # npm writes progress and deprecation notices to stderr as a matter of
         # course, so judge it by exit code. Output is captured as well as passed
@@ -1315,6 +1330,46 @@
             return
         }
         gh extension upgrade --all
+    }
+
+    # ---------------------------------------------------------------------------
+    # 7b. Cloud CLIs
+    # ---------------------------------------------------------------------------
+    # Both talk to a vendor endpoint and can pull a large payload, which is what
+    # the Cloud tag is for: -ExcludeTag Cloud drops the pair on a metered or
+    # offline machine.
+
+    # az upgrade reruns the MSI on the standard Windows install, so the step
+    # needs the elevation it would otherwise stall asking for. It also updates
+    # installed az extensions by default.
+    Invoke-Step -Name 'Azure CLI' -RequiresCommand 'az' -RequiresAdmin -Tag 'Cloud' -Action {
+        $output = az upgrade --yes --only-show-errors 2>&1
+        $output
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "az upgrade failed with exit code $LASTEXITCODE. az's own message is in this step's log."
+            $global:LASTEXITCODE = 0
+        }
+    }
+
+    Invoke-Step -Name 'Google Cloud CLI' -RequiresCommand 'gcloud' -Tag 'Cloud' -Action {
+        # A gcloud that Chocolatey or Scoop installed disables its own component
+        # manager, so self-update is only right for the bundled install.
+        $owner = Get-ToolInstallSource -Name 'gcloud'
+        if ($owner -notin 'Standalone', 'Unknown') {
+            Stop-StepAsSkipped -Reason "gcloud is managed by $owner, which updates it in its own step"
+        }
+
+        $output = gcloud components update --quiet 2>&1
+        $output
+        if ($LASTEXITCODE -ne 0) {
+            if (($output | Out-String) -match 'component manager is disabled') {
+                Write-Output 'gcloud declined to self-update because its component manager is disabled for this install.'
+                $global:LASTEXITCODE = 0
+            } else {
+                Write-Error "gcloud components update failed with exit code $LASTEXITCODE. gcloud's own message is in this step's log."
+                $global:LASTEXITCODE = 0
+            }
+        }
     }
 
     # ---------------------------------------------------------------------------

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -1131,7 +1131,7 @@ Describe 'No step updates through a tool it has not verified' -Tag 'Static','Mod
 
     # Self-update is only right when nothing else owns the tool. Running it
     # against a scoop or winget install fights that manager.
-    It 'asks who owns <_> before telling it to update itself' -ForEach @('uv', 'Deno', 'Bun', 'pnpm') {
+    It 'asks who owns <_> before telling it to update itself' -ForEach @('uv', 'Deno', 'Bun', 'pnpm', 'Google Cloud CLI') {
         $source = Get-Content (Join-Path $script:ModuleRoot 'Public\Update-Everything.ps1') -Raw
         $step = [regex]::Match($source, "(?s)Invoke-Step -Name '$_'.*?\r?\n    \}").Value
 


### PR DESCRIPTION
Builds #70 and #72 together -- three steps, one new tag.

| Step | Tag | Runs | Notes |
|---|---|---|---|
| Azure CLI | `Cloud` (new) | `az upgrade --yes --only-show-errors` | `-RequiresAdmin`: the standard install upgrades by rerunning its MSI. Updates az extensions too (az''s default). |
| Google Cloud CLI | `Cloud` | `gcloud components update --quiet` | uv-style ownership check; a choco/scoop gcloud disables its own component manager and is left alone. Its refusal message is treated as declined, not failed. |
| conda | `Python` | `conda update --name base conda --yes` | conda itself only. |

**The Cloud tag** answers #70''s open question: both CLIs reach vendor endpoints and can pull large payloads, so they are droppable as a pair on metered or offline machines.

**The conda decision** (#72 asked for the principle before code): option (b), conda-itself-only. `conda update --all` is precisely the operation the pip rule refuses -- a resolver upgrading one package can downgrade another''s dependency -- and environments belong to their projects, the same reasoning the pip step applies to `VIRTUAL_ENV`. The README now states the pip and conda rules in the same breath so they cannot drift apart.

Also: catalogue 21 → 24 (az and gcloud are presence-only -- both take seconds to answer `--version`, too slow for an inventory line); the README sample and its count test move in lockstep; `Google Cloud CLI` joins the ownership-check ForEach.

727 tests, 0 failures.
