### PR TITLE
Make -UpdateSelf a shortcut for updating the module alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ it does nothing; on every one after, it is what makes the line safe to paste
 again. Nothing is lost if it is interrupted: the installer stages the new copy
 and validates it before it replaces the old one.
 
-`Update-Everything -UpdateSelf -UpdateSelfSource Main` does the same thing from
-inside a run. The default source is `Gallery`, which is right for most people
-and wrong for anyone tracking a patch.
+`Update-Everything -UpdateSelf -UpdateSelfSource Main` does the same thing as
+a command: with `-UpdateSelf` the run updates this module and does nothing
+else. The default source is `Gallery`, which is right for most people and
+wrong for anyone tracking a patch.
 
 ### Why that command is shaped the way it is
 
@@ -258,7 +259,7 @@ thing that crosses a process boundary.
 | `-Tag` | *(all)* | Run only the steps carrying one of these tags. Everything else is reported as skipped. |
 | `-ExcludeTag` | *(none)* | Run everything except the steps carrying one of these tags. Exclusion wins when both are given. |
 | `-LogRetentionDays` | `30` | Prune logs and settings.json backups older than this. `0` keeps everything. |
-| `-UpdateSelf` | off | Update this module before anything else. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. |
+| `-UpdateSelf` | off | Update this module and run nothing else — a shortcut for `Install-Module UpdateEverything -Force`. Skips elevation, and `-Tag`/`-ExcludeTag` are ignored. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. |
 | `-UpdateSelfSource` | `Gallery` | Where `-UpdateSelf` gets it from. `Gallery` is the newest published release; `Main` is the development head, fetched from GitHub. |
 
 ## Selecting steps

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -139,13 +139,15 @@
         warning has scrolled well out of sight.
 
     .PARAMETER UpdateSelf
-        Update this module before doing anything else. Default: $false.
-        -UpdateSelfSource decides where from, and defaults to the gallery.
+        Update this module, and run nothing else: a shortcut for Install-Module
+        UpdateEverything -Force, or for the Main installer with
+        -UpdateSelfSource Main. Default: $false. -Tag and -ExcludeTag are
+        ignored for the run, and elevation is never requested, because a
+        CurrentUser install needs none.
 
-        It takes effect on the *next* run either way. Unlike winget, which is a
-        fresh process every step, this module is already loaded by the time the
-        step runs: the files on disk are replaced, and the functions executing
-        now stay on the code already in memory.
+        The new version takes effect on the *next* run. This module is already
+        loaded by the time the step runs: the files on disk are replaced, and
+        the functions executing now stay on the code already in memory.
 
         Off by default. From Main it fetches and runs an installer from a
         branch, which is a supply-chain decision rather than a routine update,
@@ -293,6 +295,19 @@
         $transcriptRunning = $true
     } catch {
         Write-Warning "Transcript unavailable ($($_.Exception.Message)); per-step logs are unaffected."
+    }
+
+    # -UpdateSelf is a shortcut: update this module and run nothing else. The
+    # self step needs no elevation -- the gallery path is Install-Module -Scope
+    # CurrentUser and the Main installer writes to the user's modules -- so the
+    # run skips the UAC prompt and narrows the tag filter to Self.
+    if ($UpdateSelf) {
+        if ($Tag.Count -or $ExcludeTag.Count) {
+            Write-Warning '-UpdateSelf updates only this module; -Tag and -ExcludeTag are ignored for this run.'
+        }
+        $Tag = @('Self')
+        $ExcludeTag = @()
+        $SkipElevation = $true
     }
 
     $script:isAdmin = Test-IsAdministrator

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1903,6 +1903,47 @@ Describe 'The PowerShell modules step' -Tag 'Static' {
     }
 }
 
+Describe '-UpdateSelf runs only the self step' -Tag 'Static' {
+
+    BeforeAll {
+        $source = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+
+        # The guard block, told apart from the step's own if ($UpdateSelf) by
+        # the inner tag check.
+        $script:Guard = [regex]::Match($source,
+            "(?s)if \(\`$UpdateSelf\) \{\s*\n\s*if \(\`$Tag.*?\n    \}").Value
+    }
+
+    It 'found the guard' {
+        $script:Guard | Should-NotBeEmptyString
+    }
+
+    It 'narrows the run to the Self tag' {
+        $script:Guard | Should-MatchString "\`$Tag = @\('Self'\)"
+    }
+
+    It 'clears any exclusion, so -ExcludeTag Self cannot empty the run' {
+        $script:Guard | Should-MatchString "\`$ExcludeTag = @\(\)"
+    }
+
+    It 'skips elevation, which a CurrentUser install never needs' {
+        $script:Guard | Should-MatchString "\`$SkipElevation = \`$true"
+    }
+
+    It 'says so when tags were also passed' {
+        $script:Guard | Should-MatchString 'ignored'
+    }
+
+    It 'runs before the elevation decision it suppresses' {
+        $guardAt = $source.IndexOf('-UpdateSelf is a shortcut')
+        $elevationAt = $source.IndexOf('$script:isAdmin = Test-IsAdministrator')
+
+        $guardAt | Should-BeGreaterThan 0
+        $guardAt | Should-BeLessThan $elevationAt
+    }
+}
+
 Describe 'Updating the module itself' -Tag 'Static' {
 
     BeforeAll {


### PR DESCRIPTION
Builds #78: `-UpdateSelf` updates the UpdateEverything module and does nothing else -- effectively `Install-Module UpdateEverything -Force` (or the Main installer with `-UpdateSelfSource Main`).

### How

A guard ahead of the elevation decision narrows the tag filter to `Self`, clears any exclusion, warns when `-Tag`/`-ExcludeTag` were also passed, and sets `-SkipElevation` -- a CurrentUser install needs no UAC prompt, which the issue called out.

Six new static tests pin the guard: that it exists, narrows, clears, skips elevation, warns, and sits before the elevation decision it suppresses.

### Breaking change, flagged for 1.4.0 notes

The switch previously meant "also update the module during a full run". A scheduled task passing `-UpdateSelf` today gets a full pass plus self-update; after this it gets only the self-update. The 1.4.0 release notes must call this out -- noted here so the release PR picks it up.

`Format-SelfVersionStatus`''s "behind" guidance already names `-UpdateSelf`, which now does exactly what that message implies.

733 tests, 0 failures.
