### PR TITLE
Prepare 1.4.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -554,7 +554,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.3.0 -m "1.3.0" && git push origin v1.3.0
+git tag -a v1.4.0 -m "1.4.0" && git push origin v1.4.0
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -280,13 +280,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.3.0
+UpdateEverything 1.4.0
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.3.0 is running, which is the newest published version.
+UpdateEverything 1.4.0 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.3.1'
+    ModuleVersion     = '1.4.0'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -32,46 +32,46 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.3.1
+            ReleaseNotes = '# 1.4.0
 
-Three fixes to what a run reports, and a documentation pass that held every
-claim against the code. GitHub-only: the gallery carries minor versions, and
-this lands there with 1.4.0.
+One behaviour change to know about before upgrading, eight new update steps,
+and the fixes that shipped on GitHub as 1.3.1.
 
-## The duplicate-copy warning names the right copy
+## -UpdateSelf now updates only this module
 
-When a tool is installed in more than one place, the inventory warns that the
-first is the one that runs. The list behind that warning was alphabetised, not
-PATH-ordered, so the named copy could be the wrong one -- node in C:\tools
-loses alphabetically to C:\Program Files even when PATH runs it first. The
-list now keeps PATH-resolution order.
+The switch is a shortcut for "Install-Module UpdateEverything -Force" (or the
+Main installer with -UpdateSelfSource Main): it updates the module and runs
+nothing else. -Tag and -ExcludeTag are ignored for that run, and no elevation
+is requested, because a CurrentUser install needs none.
 
-## The Python step skips the classic launcher instead of failing
+In 1.3.0 the switch meant "also update the module during a full run". A
+scheduled task passing -UpdateSelf gets only the self-update after this
+upgrade -- give it a second task, or drop the switch, if it should keep doing
+both.
 
-"py install --update" only works on the Python Install Manager''s py alias.
-The classic python.org launcher treats install as a script path and errors,
-which marked the step Failed on every machine that has py but not pymanager.
-The step now tells the two apart and reports the classic launcher as Skipped,
-with the reason.
+## Eight new steps
 
-## A package that appears mid-run is not called permanently blocked
+Deno, Bun and pnpm join npm under the Node tag, each behind the same
+ownership check as uv, so a copy a package manager installed is left to that
+manager. cargo binaries runs "cargo install-update --all" where the
+cargo-update crate is present, and Go binaries runs "gup update" -- both skip
+naming the missing prerequisite rather than installing it. The Azure and
+Google Cloud CLIs arrive under a new Cloud tag, so "-ExcludeTag Cloud" drops
+the pair on a metered or offline machine. conda updates conda itself in the
+base environment; environment packages are left alone for the same reason
+pip''s are.
 
-The winget summary put every package it had not attempted under "Not
-upgradable on this machine, and expected to stay that way" -- including one
-listed for the first time by the closing table, about which nothing is known.
-Those now print under their own line, and the next run picks them up.
+The tag set gains Go and Cloud, and the inventory covers 24 tools.
 
-## Documentation held against the code
+## The 1.3.1 fixes, new to the gallery
 
-A max-effort review compared every rewritten comment, help topic and README
-claim to the code it describes. Among the corrections: the README documented
-a -Cadence value that does not exist (the monthly cadence is PatchTuesday);
-the winget command in the manager table omitted the --accept-* flags that
-accept licence agreements on your behalf; the help promised an exit code the
-module conversion removed; and the verbatim tool messages people grep for --
-winget''s "does not apply to your system or requirements", PowerShellGet''s
-"was not installed by using Install-Module" -- are back in the source,
-findable again.
+When a tool is installed twice, the warning now names the copy PATH actually
+resolves rather than the alphabetically first one. The Python step reports
+the classic py launcher as Skipped instead of Failed on machines without the
+Install Manager. A winget package listed for the first time during a run is
+reported as newly listed, not as permanently blocked. And a documentation
+pass held every README and help claim against the code, restoring the
+verbatim tool messages people grep for.
 '
 
         }


### PR DESCRIPTION
Raises `ModuleVersion` to 1.4.0 and rewrites the release notes for the gallery page.

## Shape of the notes

Written against 1.3.0 -- the version a gallery user upgrades from -- and led by the one thing that changes behaviour under them, per #84:

1. **`-UpdateSelf` now updates only this module.** The notes say plainly that a scheduled task passing the switch gets only the self-update after upgrading, and what to do about it.
2. **Eight new steps**: Deno, Bun, pnpm (Node tag, uv-style ownership checks), cargo binaries and Go binaries (skip naming their missing prerequisite), Azure CLI and Google Cloud CLI (new `Cloud` tag, droppable as a pair), conda (base environment, itself only). Tag set gains `Go` and `Cloud`; inventory covers 24 tools.
3. **The 1.3.1 fixes**, new to gallery users: the duplicate-copy warning names the copy PATH resolves, the Python step skips the classic launcher instead of failing, newly listed winget packages are not called permanently blocked.

## Also in this PR

README sample output moves 1.3.0 → 1.4.0 (true once published), and CONTRIBUTING''s tag example moves to `v1.4.0`, as each release has done.

## Checks

- `Publish.ps1 -WhatIf`: **All checks passed**, gallery confirmed at 1.3.0, 60 files staged, 6 exports.
- 733 tests, 0 failures.
- Fresh-machine sandbox test running now; result lands on this PR before merge.

Closes #84.
