### PR TITLE
Allow the read-only PowerShell commands Claude Code uses

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "PowerShell(cd *)",
+      "PowerShell(Select-String *)",
+      "PowerShell(Get-Content *)",
+      "PowerShell(Get-ChildItem *)",
+      "PowerShell(Get-Command *)",
+      "PowerShell(Get-Module *)",
+      "PowerShell(Get-Help *)",
+      "PowerShell(Get-Process *)",
+      "PowerShell(Get-ItemProperty *)",
+      "PowerShell(Test-ModuleManifest *)",
+      "PowerShell(Import-PowerShellDataFile *)",
+      "PowerShell(Find-Module *)",
+      "PowerShell(git status *)",
+      "PowerShell(git log *)",
+      "PowerShell(git diff *)",
+      "PowerShell(git show *)",
+      "PowerShell(git branch *)",
+      "PowerShell(gh pr checks *)",
+      "PowerShell(gh pr list *)",
+      "PowerShell(gh pr view *)",
+      "PowerShell(gh issue list *)",
+      "PowerShell(gh issue view *)",
+      "PowerShell(gh release list *)",
+      "PowerShell(gh release view *)",
+      "PowerShell(winget search *)"
+    ]
+  }
+}


### PR DESCRIPTION
Adds `.claude/settings.json` with the read-only permission allowlist, mirroring the one measured from actual usage (scan of session transcripts, ranked by frequency -- `Select-String` alone was 304 calls).

Every entry is read-only: `Select-String`, `Get-Content`/`Get-ChildItem`/`Get-Command`/`Get-Module`/`Get-Help`/`Get-Process`/`Get-ItemProperty`, `Test-ModuleManifest`, `Import-PowerShellDataFile`, `Find-Module`, the `git` and `gh` inspection subcommands, and `winget search`. `cd` is included because nearly every PowerShell command is `cd <repo>; <command>` and compound commands prompt unless each part is allowed.

Deliberately absent: anything that writes (`git push`, `gh pr merge`, `Set-Content`, `winget install`), anything that executes arbitrary code (`python`, `pwsh`, `Import-Module`, `Measure-Command`), and `./test.ps1`, whose `Integration` tag registers real scheduled tasks.

This is the shared settings file, so contributors using Claude Code inherit it; per-machine approvals stay in `settings.local.json`, which is not tracked.
