### PR TITLE
Validate the published artifact, not just the tree that produced it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -559,3 +559,7 @@ git tag -a v1.4.0 -m "1.4.0" && git push origin v1.4.0
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so
 one text serves the manifest, the gallery page and the release.
+
+Once the gallery lists the new version, run the
+[gallery validation](tests/Gallery/README.md). It downloads the published
+artifact and runs it, which nothing before the publish can do.

--- a/tests/Gallery/Invoke-GalleryValidation.ps1
+++ b/tests/Gallery/Invoke-GalleryValidation.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 5.1
+
+<#
+    .SYNOPSIS
+    Downloads a published UpdateEverything from the PowerShell Gallery and runs
+    it, so the artifact people install is the artifact that was checked.
+
+    .DESCRIPTION
+    Everything else in this repository tests the working tree or the GitHub
+    install; nothing exercises the .nupkg the gallery serves. This does:
+    Save-Module, import by path, prove the loaded module is the downloaded copy,
+    and run the read-only Inventory pass.
+
+    The identity check is the point of the harness. In a fresh session a bare
+    Update-Everything auto-loads whichever copy PSModulePath finds, so a
+    validation that skips the check can run a stale installed version end to
+    end and report it green.
+
+    Read-only by default. -IncludeSelfUpdate adds a live -UpdateSelf pass,
+    which updates the host's installed UpdateEverything when one is present
+    and behind -- that is the behaviour under test, so it is opt-in.
+
+    .PARAMETER Version
+    The gallery version to validate. Default: the newest published.
+
+    .PARAMETER IncludeSelfUpdate
+    Also run Update-Everything -UpdateSelf and assert it runs the self step
+    alone. May update the host's installed copy.
+
+    .EXAMPLE
+    .\tests\Gallery\Invoke-GalleryValidation.ps1
+
+    .EXAMPLE
+    .\tests\Gallery\Invoke-GalleryValidation.ps1 -Version 1.4.0 -IncludeSelfUpdate
+#>
+[CmdletBinding()]
+param(
+    [string] $Version,
+    [switch] $IncludeSelfUpdate
+)
+
+$ErrorActionPreference = 'Stop'
+
+$script:Checks = [System.Collections.Generic.List[object]]::new()
+
+function Add-Check {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [bool]   $Passed,
+        [string] $Detail = ''
+    )
+    $status = if ($Passed) { 'PASS' } else { 'FAIL' }
+    $colour = if ($Passed) { 'Green' } else { 'Red' }
+    Write-Host ("  [{0}] {1}" -f $status, $Name) -ForegroundColor $colour
+    if ($Detail) { Write-Host ("         {0}" -f $Detail) -ForegroundColor DarkGray }
+    $script:Checks.Add([pscustomobject]@{ Name = $Name; Passed = $Passed; Detail = $Detail })
+}
+
+if (-not $Version) {
+    $Version = (Find-Module -Name UpdateEverything -Repository PSGallery).Version.ToString()
+}
+Write-Host "Validating UpdateEverything $Version from the PowerShell Gallery." -ForegroundColor Cyan
+
+$stage = Join-Path ([System.IO.Path]::GetTempPath()) ('UE-GalleryValidation-{0:yyyyMMdd-HHmmss}' -f (Get-Date))
+$null = New-Item -ItemType Directory -Path $stage -Force
+
+try {
+    Save-Module -Name UpdateEverything -RequiredVersion $Version -Path $stage -Repository PSGallery
+
+    $manifestPath = Join-Path $stage "UpdateEverything\$Version\UpdateEverything.psd1"
+    Add-Check 'the gallery served the requested version' (Test-Path -LiteralPath $manifestPath) $manifestPath
+
+    $manifest = Test-ModuleManifest -Path $manifestPath
+    Add-Check 'the manifest validates' ($null -ne $manifest) "version $($manifest.Version)"
+    Add-Check 'the manifest carries the six exports' ($manifest.ExportedFunctions.Count -eq 6) `
+        "$($manifest.ExportedFunctions.Count) exported"
+
+    Get-Module -Name UpdateEverything | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module $manifestPath -Force
+
+    # A bare command in a fresh session auto-loads whichever copy PSModulePath
+    # resolves, so every later assertion is meaningless unless the loaded module
+    # is provably the downloaded one.
+    $loaded = Get-Module -Name UpdateEverything
+    Add-Check 'the loaded module is the downloaded copy' ($loaded.ModuleBase -like "$stage*") $loaded.ModuleBase
+    Add-Check 'the loaded version is the requested version' ($loaded.Version.ToString() -eq $Version) `
+        "loaded $($loaded.Version)"
+
+    # Inventory reads the machine and changes nothing. Merging stream 6 puts the
+    # banner lines and the result object in one pipeline; the type separates them.
+    $mixed = @(Update-Everything -Tag Inventory -LogRetentionDays 0 6>&1)
+    $banner = @($mixed | Where-Object { $_ -is [System.Management.Automation.InformationRecord] } |
+        ForEach-Object { "$_" })
+    $run = $mixed | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] } |
+        Select-Object -Last 1
+
+    Add-Check 'the run reports the version it is' ([bool]($banner -match [regex]::Escape("UpdateEverything $Version"))) ''
+    Add-Check 'the run ran' ($run.Ran -eq $true) "Ran=$($run.Ran)"
+    Add-Check 'the Inventory step succeeded' (
+        @($run.Steps | Where-Object { $_.Step -eq 'Inventory' -and $_.Status -eq 'OK' }).Count -eq 1) ''
+    Add-Check 'every other step reported Skipped' (
+        @($run.Steps | Where-Object { $_.Step -ne 'Inventory' -and $_.Status -ne 'Skipped' }).Count -eq 0) ''
+    Add-Check 'FailedCount came back as zero' ($run.FailedCount -is [int] -and $run.FailedCount -eq 0) `
+        "FailedCount=$($run.FailedCount)"
+
+    if ($IncludeSelfUpdate) {
+        $self = Update-Everything -UpdateSelf -LogRetentionDays 0 6>$null
+        $ok = @($self.Steps | Where-Object { $_.Status -eq 'OK' })
+
+        Add-Check 'with -UpdateSelf, the self step is the only one that runs' (
+            $ok.Count -eq 1 -and $ok[0].Step -eq 'UpdateEverything (self)') `
+            (($ok.Step) -join ', ')
+        Add-Check 'the -UpdateSelf run failed nothing' ($self.FailedCount -eq 0) "FailedCount=$($self.FailedCount)"
+    }
+} finally {
+    Get-Module -Name UpdateEverything | Remove-Module -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stage -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$failed = @($script:Checks | Where-Object { -not $_.Passed })
+Write-Host ''
+if ($failed.Count) {
+    Write-Host "Gallery validation FAILED: $($failed.Count) of $($script:Checks.Count) checks." -ForegroundColor Red
+} else {
+    Write-Host "Gallery validation passed: $($script:Checks.Count) checks." -ForegroundColor Green
+}
+
+[pscustomobject]@{
+    Passed  = ($failed.Count -eq 0)
+    Version = $Version
+    Checks  = $script:Checks
+}

--- a/tests/Gallery/README.md
+++ b/tests/Gallery/README.md
@@ -1,0 +1,48 @@
+# Gallery validation
+
+Downloads a published version from the PowerShell Gallery and runs it, so the
+artifact people install is the artifact that was checked.
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\Gallery\Invoke-GalleryValidation.ps1
+```
+
+Run it after every publish, once the gallery lists the new version. It is not
+part of `test.ps1`: it needs the network, and it validates a published
+artifact rather than the working tree.
+
+## Why it exists
+
+Nothing else touches the `.nupkg` the gallery serves. The suite tests the
+working tree, CI tests the repository, and the fresh-machine harness installs
+from GitHub `main` — a packaging defect in the published artifact would pass
+all three.
+
+## The identity check is the point
+
+In a fresh session, a bare `Update-Everything` auto-loads whichever copy
+`PSModulePath` resolves — not the one just downloaded. The first ad-hoc
+validation of 1.4.0 hit exactly this: the machine carried a stale installed
+1.2.1, the run reported `UpdateEverything 1.2.1` with the old step set, and
+every check came back green against the wrong code. The harness therefore
+proves `(Get-Module UpdateEverything).ModuleBase` is inside the downloaded
+folder before asserting anything else.
+
+## What it checks
+
+- The gallery serves the requested version and the manifest validates with
+  the six exports
+- The loaded module is the downloaded copy, at the requested version
+- `-Tag Inventory` (read-only) runs: the banner names the version, the
+  Inventory step is `OK`, every other step is `Skipped`, and `FailedCount`
+  is zero
+
+## What it changes
+
+Nothing, by default: the download goes to a temporary folder that is removed
+afterwards, and Inventory only reads.
+
+`-IncludeSelfUpdate` adds a live `Update-Everything -UpdateSelf` pass and
+asserts the self step is the only one that runs. That pass updates the host's
+installed UpdateEverything when one is present and behind — which is the
+behaviour under test, so it is opt-in.


### PR DESCRIPTION
Closes the last untested surface in the release path: the `.nupkg` the gallery actually serves.

| Surface | Tested by |
|---|---|
| working tree | `test.ps1` |
| repository | CI |
| GitHub install | `tests/FreshMachine` |
| elevation handoff | `tests/Elevation` |
| **published gallery artifact** | **`tests/Gallery` (this PR)** |

### The identity check is the point

In a fresh session, a bare `Update-Everything` auto-loads whichever copy `PSModulePath` resolves -- not the one just downloaded. The first ad-hoc validation of 1.4.0 hit exactly this: the machine carried a stale installed 1.2.1, the run reported `UpdateEverything 1.2.1` with the old 25-step set, and every check was green against the wrong code. The harness proves `ModuleBase` sits inside the downloaded folder before asserting anything else.

### Verified live against the published 1.4.0

12 of 12 checks, including the opt-in `-IncludeSelfUpdate` pass: the self step ran alone (1 OK, 32 skipped), moved this machine''s stale 1.2.1 to 1.4.0 through the real gallery path, and re-ran idempotent ("1.4.0 is the newest published release", 0.7s). Also observed live along the way: the PATH-order fix from #79 -- 1.2.1 told this machine the WSL that runs is the WindowsApps copy (alphabetical); 1.4.0 correctly names System32, matching `Get-Command` ground truth.

### Wiring

CONTRIBUTING''s publishing steps end with running this once the gallery lists the new version. The harness is under `tests/`, so the lint pass covers it automatically -- and did, on the first run.

734 tests, 0 failures.
