### PR TITLE
Updatable means the receipt covers the newest installed copy

### DIFF
--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -19,7 +19,9 @@ function Get-GalleryModuleStatus {
         Updatable reports whether Update-Module can move this copy forward. It
         refuses anything it did not install, answering "Module 'X' was not
         installed by using Install-Module, so it cannot be updated" -- which
-        covers every module that shipped with the host. Windows PowerShell
+        covers every module that shipped with the host, and any copy whose
+        receipt names an older version than the newest one installed, since
+        Update-Module moves only the receipted lineage. Windows PowerShell
         ships PowerShellGet 1.0.0.1
         under Program Files rather than $PSHOME, so the path is not the test;
         whether PowerShellGet recorded the install is. Moving a shipped copy
@@ -48,10 +50,17 @@ function Get-GalleryModuleStatus {
 
     # Ask PowerShellGet what it installed, rather than inferring it from the
     # path. Get-InstalledModule reports only what came through Install-Module,
-    # which is exactly the set Update-Module will act on.
+    # which is exactly the set Update-Module will act on -- and the receipt has
+    # to cover the newest installed copy, the one Installed names. A machine can
+    # carry a receipted older version beside a GitHub-installed newer one, and
+    # Update-Module moves only the receipted lineage.
     $updatable = $false
     if ($present.Count -and (Get-Command Get-InstalledModule -ErrorAction SilentlyContinue)) {
-        $updatable = [bool] (Get-InstalledModule -Name $Name -ErrorAction SilentlyContinue)
+        $receipt = Get-InstalledModule -Name $Name -ErrorAction SilentlyContinue
+        if ($receipt) {
+            $raw = "$($receipt.Version)" -replace '-.*$', ''
+            $updatable = [bool] ($raw -and ([version] $raw -eq $installed))
+        }
     }
 
     # SilentlyContinue and a check, not Stop and a catch. A module the gallery

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1381,11 +1381,21 @@ Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
     # decides between an update and a side-by-side install. Get-InstalledModule
     # is mocked rather than read, because whether this machine's Pester arrived
     # through Install-Module is not something a test should depend on.
-    It 'reports Updatable when PowerShellGet recorded the install' {
+    It 'reports Updatable when the receipt covers the newest installed copy' {
         Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
-        Mock Get-InstalledModule { [pscustomobject]@{ Name = 'Pester' } }
+        Mock Get-InstalledModule { [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion } }
 
         (Get-GalleryModuleStatus -Name Pester).Updatable | Should-BeTrue
+    }
+
+    # A receipt can name an older version than the newest copy on disk: a
+    # gallery install followed by a GitHub install leaves exactly that. The
+    # newest copy is then not the one Update-Module moves.
+    It 'does not call the newest copy updatable on an older receipt' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledModule { [pscustomobject]@{ Name = 'Pester'; Version = [version] '0.0.1' } }
+
+        (Get-GalleryModuleStatus -Name Pester).Updatable | Should-BeFalse
     }
 
     It 'reports a copy the host shipped as not updatable' {


### PR DESCRIPTION
Found live by the new gallery-validation harness, on the machine that ran it.

### The defect

`Get-GalleryModuleStatus` computed `Updatable` from the existence of **any** PowerShellGet receipt for the name -- version-blind:

```powershell
$updatable = [bool] (Get-InstalledModule -Name $Name -ErrorAction SilentlyContinue)
```

A gallery install followed by the GitHub one-liner leaves a receipted older version beside an unreceipted newer one. `Installed` names the newest copy, `Updatable` answers for a different one, and the self step then says "1.2.1 -> 1.4.0" while `Update-Module` acts on the 1.1.0 lineage the message never mentions. This machine was in exactly that state (receipt for 1.1.0, GitHub 1.2.1 on disk), and the run looked right only because newest-wins resolution made the outcome right.

### The fix

`Updatable` is true only when the receipt''s version equals the newest installed version (prerelease suffix trimmed the same way the gallery answer is). On mixed machines the self step now takes the honest branch -- "was not installed from the gallery" with `Install-Module -Force` / `-UpdateSelfSource Main` guidance, both of which do what they say there.

### Tests

The existing `Updatable` test mocked a receipt **without a version** -- the exact blind spot -- and now vouches for the version it covers. A new test pins the mixed-lineage case: an older receipt does not make the newest copy updatable.

735 tests, 0 failures.
