### PR TITLE
Prepare 1.5.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -554,7 +554,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.4.0 -m "1.4.0" && git push origin v1.4.0
+git tag -a v1.5.0 -m "1.5.0" && git push origin v1.5.0
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -280,13 +280,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.4.0
+UpdateEverything 1.5.0
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.4.0 is running, which is the newest published version.
+UpdateEverything 1.5.0 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.4.1'
+    ModuleVersion     = '1.5.0'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -32,10 +32,10 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.4.1
+            ReleaseNotes = '# 1.5.0
 
-One fix. GitHub-only: the gallery carries minor versions, and this lands
-there with 1.5.0.
+One fix, for machines that installed from the gallery once and from GitHub
+later.
 
 ## Updatable means the receipt covers the newest installed copy
 
@@ -51,8 +51,13 @@ newest installed copy. On a mixed machine the self step takes the guidance
 branch instead, naming Install-Module -Force and -UpdateSelfSource Main,
 both of which do what they say there.
 
-Found by the new gallery-validation harness (tests/Gallery) on its first
-run, on a machine in exactly that mixed state.
+## Verified before publishing
+
+Found and fixed through a new release harness that downloads the published
+package from the gallery and runs it as installed, on a machine in exactly
+the mixed state above. The self-elevation handoff was re-verified end to end
+on a real machine with UAC on -- eight checks, none skipped -- before this
+version shipped.
 '
 
         }


### PR DESCRIPTION
Manifest to 1.5.0, notes written against 1.4.0: the Updatable receipt fix (#88), found by the gallery-validation harness on its first run. Pre-flight complete: \Publish.ps1 -WhatIf\ all checks passed (gallery at 1.4.0, 60 files, 6 exports); attended self-elevation test 8/8 PASS with zero N/A on this machine against this exact code; 735 tests, 0 failures. README samples and the CONTRIBUTING tag example move to 1.5.0 as every release has done.