### PR TITLE
Fix the fifteen defects the max review found

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
       "PowerShell(git log *)",
       "PowerShell(git diff *)",
       "PowerShell(git show *)",
-      "PowerShell(git branch *)",
+      "PowerShell(git branch)",
       "PowerShell(gh pr checks *)",
       "PowerShell(gh pr list *)",
       "PowerShell(gh pr view *)",

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ thing that crosses a process boundary.
 | `-Tag` | *(all)* | Run only the steps carrying one of these tags. Everything else is reported as skipped. |
 | `-ExcludeTag` | *(none)* | Run everything except the steps carrying one of these tags. Exclusion wins when both are given. |
 | `-LogRetentionDays` | `30` | Prune logs and settings.json backups older than this. `0` keeps everything. |
-| `-UpdateSelf` | off | Update this module and run nothing else — a shortcut for `Install-Module UpdateEverything -Force`. Skips elevation, and `-Tag`/`-ExcludeTag` are ignored. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. |
+| `-UpdateSelf` | off | Update this module through `Update-Module` and run nothing else. `-Tag`/`-ExcludeTag` are ignored; no UAC prompt is raised, and an all-users copy is reported as needing an elevated session. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. |
 | `-UpdateSelfSource` | `Gallery` | Where `-UpdateSelf` gets it from. `Gallery` is the newest published release; `Main` is the development head, fetched from GitHub. |
 
 ## Selecting steps
@@ -346,7 +346,7 @@ rest, a package manager's own inventory decides.
 
 `winget upgrade --all` returns one exit code for the whole pass, so a partial
 failure says only that *something* did not upgrade. The step names them, and
-separates the two cases:
+separates three cases:
 
 ```
 Still out of date after this run:
@@ -357,11 +357,15 @@ Not upgradable on this machine, and expected to stay that way:
   Cisco.CiscoWebexMeetings 45.6.4 -> 45.6.4.8  (winget listed it and did not
                                    attempt it, usually because the newer
                                    package does not apply to this system)
+
+Newly listed during this run; the next run picks these up:
+  Some.Package 1.0 -> 1.1
 ```
 
 The distinction matters. The first is worth doing something about; the second
 will not change until the vendor ships a package that applies, and reporting it
 as a failure on every run is how people learn to skim past the ones that are.
+The third only appeared in the closing table, so the next run is when it moves.
 
 **The step is marked `Warning` only when something may really have failed** — a
 package winget attempted, or a non-zero exit it could not attribute to one. A
@@ -396,7 +400,7 @@ choose the packages; the manager's own inventory does.
 
 | Manager | Found by | What runs | Covers |
 |---|---|---|---|
-| winget | `winget` on `PATH` | `winget source update`, then `winget upgrade --all --include-unknown --silent --accept-source-agreements --accept-package-agreements --disable-interactivity` | Desktop applications from the winget community repository and the Microsoft Store. The broadest step by far, covering browsers, editors, runtimes and drivers shipped as apps. The `--accept-*` flags accept source and vendor licence agreements on your behalf. |
+| winget | `winget` on `PATH` | `winget source update --disable-interactivity`, then `winget upgrade --all --include-unknown --silent --accept-source-agreements --accept-package-agreements --disable-interactivity` | Desktop applications from the winget community repository and the Microsoft Store. The broadest step by far, covering browsers, editors, runtimes and drivers shipped as apps. The `--accept-*` flags accept source and vendor licence agreements on your behalf. |
 | Chocolatey | `choco` | `choco upgrade all -y` | Everything installed as a Chocolatey package. Exit codes 1641 and 3010 pass, since those are the MSI "reboot required" codes rather than failures. |
 | Scoop | `scoop` | `scoop update`, `scoop update *`, `scoop cleanup *`, each run on its own | Scoop, its buckets, installed apps, then old versions. The phases run separately so a broken bucket cannot hide the rest. |
 | npm | `npm` | `npm install -g npm@latest`, then `npm update -g` only with `-UpdateGlobalNpm` | npm itself, every run. Global packages only on request, because upgrading them can move a pinned toolchain. |
@@ -442,7 +446,7 @@ rather than going quiet.
 
 ### Python
 
-Four steps, and they cover different things:
+Five steps, and they cover different things:
 
 | Step | Updates |
 |---|---|
@@ -485,7 +489,8 @@ tries to elevate anyway. Treating "unknown" as "no" would lock out real
 administrators, which is the worse mistake.
 
 With `-SkipElevation`, the run proceeds and the admin-only steps (Windows
-Update, Defender signatures, the PowerShell 7 install) are reported as skipped
+Update, Defender signatures, the PowerShell 7 install, the Azure CLI) are
+reported as skipped
 rather than failing on permissions.
 
 ## Logs

--- a/src/Private/Format-SelfVersionStatus.ps1
+++ b/src/Private/Format-SelfVersionStatus.ps1
@@ -46,10 +46,12 @@ function Format-SelfVersionStatus {
     $available = [version] $Status.Available
 
     if ($Running -lt $available) {
-        $how = if ($Status.Installed -and -not $Status.Updatable) {
+        $how = if (-not $Status.Installed) {
+            'This copy is running from outside a module path, so use "Install-Module UpdateEverything -Force" to install the gallery copy.'
+        } elseif (-not $Status.Updatable) {
             'This copy did not come from the gallery, so use "Install-Module UpdateEverything -Force", or -UpdateSelf -UpdateSelfSource Main to track the branch it came from.'
         } else {
-            'Run with -UpdateSelf to install it.'
+            'Run with -UpdateSelf to update it.'
         }
         return "UpdateEverything $Running is running; $available is published. $how"
     }

--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -5,7 +5,8 @@ function Get-GalleryModuleStatus {
         the PowerShell Gallery.
 
         .DESCRIPTION
-        Returns Name, Installed, Available, Updatable and NeedsUpdate.
+        Returns Name, Installed, Available, Receipted, Updatable and
+        NeedsUpdate.
 
         Installed is $null when the module is absent. Absent means any install
         is a new install and needs consent; present but old means an update,
@@ -54,12 +55,22 @@ function Get-GalleryModuleStatus {
     # to cover the newest installed copy, the one Installed names. A machine can
     # carry a receipted older version beside a GitHub-installed newer one, and
     # Update-Module moves only the receipted lineage.
+    # Receipted is whether a PowerShellGet receipt exists at all; Updatable is
+    # the stricter test that the receipt covers the newest installed copy, the
+    # one Installed names. A machine can carry a receipted older version beside
+    # an unreceipted newer one, and Update-Module moves only the receipted
+    # lineage -- so a caller distinguishes "no gallery lineage" (not Receipted)
+    # from "gallery lineage, but behind the copy running" (Receipted, not
+    # Updatable).
+    $receipted = $false
     $updatable = $false
     if ($present.Count -and (Get-Command Get-InstalledModule -ErrorAction SilentlyContinue)) {
         $receipt = Get-InstalledModule -Name $Name -ErrorAction SilentlyContinue
         if ($receipt) {
+            $receipted = $true
             $raw = "$($receipt.Version)" -replace '-.*$', ''
-            $updatable = [bool] ($raw -and ([version] $raw -eq $installed))
+            $parsed = $null
+            $updatable = [bool] ($raw -and [version]::TryParse($raw, [ref] $parsed) -and $parsed -eq $installed)
         }
     }
 
@@ -88,7 +99,8 @@ function Get-GalleryModuleStatus {
         # versions and a [version] on others, and a prerelease carries a suffix
         # that [version] cannot parse. Trim the suffix and let the cast decide.
         $raw = "$($found.Version)" -replace '-.*$', ''
-        if ($raw) { $available = [version] $raw }
+        $parsedAvailable = $null
+        if ($raw -and [version]::TryParse($raw, [ref] $parsedAvailable)) { $available = $parsedAvailable }
     } else {
         Write-Verbose "The gallery had no answer for ${Name}; it may be absent or unreachable."
     }
@@ -97,6 +109,7 @@ function Get-GalleryModuleStatus {
         Name        = $Name
         Installed   = $installed
         Available   = $available
+        Receipted   = $receipted
         Updatable   = $updatable
         NeedsUpdate = [bool] ($installed -and $available -and $available -gt $installed)
     }

--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -72,11 +72,14 @@ function Get-UpdateToolInventory {
     foreach ($tool in $Catalogue) {
         $resolved = @(Get-Command $tool.Command -CommandType Application -ErrorAction SilentlyContinue)
         # First-occurrence order is PATH-resolution order, so the first entry is
-        # the copy that actually runs.
+        # the copy that actually runs. Dedupe case-insensitively: a Windows PATH
+        # routinely carries the same directory in different casing across its
+        # machine and user segments, and Select-Object -Unique is case-sensitive.
+        $seen = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase)
         $places = @($resolved |
             ForEach-Object { Split-Path $_.Source -Parent } |
-            Where-Object { $_ } |
-            Select-Object -Unique)
+            Where-Object { $_ -and $seen.Add($_) })
 
         if (-not $resolved.Count) {
             [pscustomobject]@{

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -38,21 +38,23 @@
     if (-not $safeName) { $safeName = 'step' }
     $stepLog = Join-Path $script:logDir "$safeName-$script:runStamp.log"
 
-    # Pre-check administrator rights
-    if ($RequiresAdmin -and -not $script:isAdmin) {
-        $msg = "SKIP  $Name (requires Administrator; this run is not elevated)"
-        Write-Host $msg -ForegroundColor DarkGray
-        Write-StepLog -Path $stepLog -Message $msg
-        $script:Results.Add([pscustomobject]@{ Step = $Name; Status = 'Skipped'; Seconds = 0; Log = '' })
-        return
-    }
-
-    # Pre-check command availability
+    # Command availability is checked before administrator rights: an absent
+    # tool is absent whether or not the run is elevated, and reporting it as
+    # "requires Administrator" would send someone to elevate for a tool that is
+    # simply not installed.
     if ($RequiresCommand -and -not (Get-Command $RequiresCommand -ErrorAction SilentlyContinue)) {
         $msg = "SKIP  $Name (command '$RequiresCommand' not found)"
         Write-Host $msg -ForegroundColor DarkGray
         Write-StepLog -Path $stepLog -Message $msg
-        $script:Results.Add([pscustomobject]@{ Step = $Name; Status = 'Skipped'; Seconds = 0; Log = '' })
+        $script:Results.Add([pscustomobject]@{ Step = $Name; Status = 'Skipped'; Seconds = 0; Log = $stepLog })
+        return
+    }
+
+    if ($RequiresAdmin -and -not $script:isAdmin) {
+        $msg = "SKIP  $Name (requires Administrator; this run is not elevated)"
+        Write-Host $msg -ForegroundColor DarkGray
+        Write-StepLog -Path $stepLog -Message $msg
+        $script:Results.Add([pscustomobject]@{ Step = $Name; Status = 'Skipped'; Seconds = 0; Log = $stepLog })
         return
     }
 
@@ -150,7 +152,7 @@
             $reason = $message -replace '^STEP-SKIPPED:\s*', ''
             Write-Host "SKIP  $Name ($reason)" -ForegroundColor DarkGray
             Write-StepLog -Path $stepLog -Message "SKIPPED | $reason"
-            $script:Results.Add([pscustomobject]@{ Step = $Name; Status = 'Skipped'; Seconds = $secs; Log = '' })
+            $script:Results.Add([pscustomobject]@{ Step = $Name; Status = 'Skipped'; Seconds = $secs; Log = $stepLog })
             return
         }
 

--- a/src/Private/New-TaskFromPrompt.ps1
+++ b/src/Private/New-TaskFromPrompt.ps1
@@ -30,8 +30,11 @@ function New-TaskFromPrompt {
         [switch] $Replace
     )
 
-    $tags = @('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python',
-              'Node', 'DotNet', 'Rust', 'Git', 'Self', 'Inventory')
+    # Read the tag names from the cmdlet that will validate them, so this list
+    # cannot drift from the ValidateSet the way a hand-kept copy would.
+    $tags = @((Get-Command Register-UpdateEverythingTask).Parameters['Tag'].Attributes |
+        Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } |
+        ForEach-Object { $_.ValidValues })
 
     if (-not $DefaultName) {
         # Update-Everything, then Update-Everything-2 and up. Named after what

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -10,12 +10,13 @@
         the rest. Every step writes its own log, and the run ends with a summary
         table and a result object.
 
-        Steps cover winget and the Microsoft Store, Windows Update through
-        PSWindowsUpdate, Microsoft 365 Apps, Defender signatures, PowerShell
-        modules and help, Chocolatey, Scoop, Python, uv, pip, pipx, npm, Deno,
+        Steps cover an inventory pass, winget and the Microsoft Store, Windows
+        Update through PSWindowsUpdate, Microsoft 365 Apps, Defender signatures,
+        the PowerShell Gallery (trust and its client tooling), PowerShell modules
+        and help, Chocolatey, Scoop, Python, uv, pip, pipx, conda, npm, Deno,
         Bun, pnpm, rustup, cargo binaries, Go binaries, dotnet, GitHub CLI
-        extensions, the Azure and Google Cloud CLIs, conda, the WSL kernel,
-        PowerShell 7 itself and the Windows Terminal default profile. The README
+        extensions, the Azure and Google Cloud CLIs, the WSL kernel, PowerShell 7
+        itself, this module, and the Windows Terminal default profile. The README
         lists what each runs.
 
         Presence of an executable is not proof a feature is installed, and package
@@ -139,11 +140,11 @@
         warning has scrolled well out of sight.
 
     .PARAMETER UpdateSelf
-        Update this module, and run nothing else: a shortcut for Install-Module
-        UpdateEverything -Force, or for the Main installer with
-        -UpdateSelfSource Main. Default: $false. -Tag and -ExcludeTag are
-        ignored for the run, and elevation is never requested, because a
-        CurrentUser install needs none.
+        Update this module through Update-Module (or the Main installer with
+        -UpdateSelfSource Main), and run nothing else. Default: $false. -Tag and
+        -ExcludeTag are ignored for the run, and no UAC prompt is raised: a
+        per-user copy updates in place, and an all-users copy reports that it
+        needs an elevated session rather than failing silently.
 
         The new version takes effect on the *next* run. This module is already
         loaded by the time the step runs: the files on disk are replaced, and
@@ -297,10 +298,10 @@
         Write-Warning "Transcript unavailable ($($_.Exception.Message)); per-step logs are unaffected."
     }
 
-    # -UpdateSelf is a shortcut: update this module and run nothing else. The
-    # self step needs no elevation -- the gallery path is Install-Module -Scope
-    # CurrentUser and the Main installer writes to the user's modules -- so the
-    # run skips the UAC prompt and narrows the tag filter to Self.
+    # -UpdateSelf is a shortcut: update this module and run nothing else, so the
+    # tag filter narrows to Self. No UAC prompt is raised -- a per-user copy
+    # updates without one, and the self step reports when an all-users copy
+    # would need an elevated session rather than raising a prompt mid-run.
     if ($UpdateSelf) {
         if ($Tag.Count -or $ExcludeTag.Count) {
             Write-Warning '-UpdateSelf updates only this module; -Tag and -ExcludeTag are ignored for this run.'
@@ -490,25 +491,40 @@
     # ---------------------------------------------------------------------------
     # 1b. The module itself
     # ---------------------------------------------------------------------------
-    if ($UpdateSelf) {
+    if ($UpdateSelf -or ($script:TagFilter -contains 'Self')) {
         Invoke-Step -Name 'UpdateEverything (self)' -Tag 'Self' -Action {
             if ($UpdateSelfSource -eq 'Gallery') {
                 $status = Get-GalleryModuleStatus -Name 'UpdateEverything'
 
-                if (-not $status.Available) {
+                if (-not $status.Installed) {
+                    Write-Output "UpdateEverything is running from a copy that is not under a module path, so Update-Module has nothing to move. Install-Module UpdateEverything -Force installs the gallery copy."
+                } elseif (-not $status.Available) {
                     Write-Output "UpdateEverything $($status.Installed) is installed; the gallery could not be asked about it."
+                } elseif ($status.Receipted -and -not $status.Updatable) {
+                    # A gallery-installed copy is present but older than the copy
+                    # running now, which the gallery did not install. Update-Module
+                    # would move the older lineage, not this one.
+                    Write-Output "UpdateEverything $($status.Installed) is running from a copy the gallery did not install; the gallery-installed copy beside it is older. Use -UpdateSelfSource Main, or Install-Module UpdateEverything -Force to move to the gallery copy."
                 } elseif (-not $status.Updatable) {
-                    # A copy the GitHub installer put there was not installed by
-                    # PowerShellGet, so Update-Module refuses it. -UpdateSelfSource
-                    # Main is the matching path.
+                    # No PowerShellGet receipt at all -- the GitHub installer put it
+                    # there, so Update-Module refuses it. -UpdateSelfSource Main is
+                    # the matching path.
                     Write-Output "UpdateEverything $($status.Installed) was not installed from the gallery, so Update-Module cannot move it. The published version is $($status.Available)."
                     Write-Output 'Use -UpdateSelfSource Main to track the branch it came from, or Install-Module UpdateEverything -Force to switch to the gallery copy.'
                 } elseif (-not $status.NeedsUpdate) {
                     Write-Output "UpdateEverything $($status.Installed) is the newest published release."
                 } else {
                     Write-Output "UpdateEverything $($status.Installed) -> $($status.Available)..."
-                    Update-Module -Name 'UpdateEverything' -Force -Confirm:$false -ErrorAction Stop
-                    Write-Output 'Updated. The new version loads on the next run; this one continues on the code already in memory.'
+                    try {
+                        Update-Module -Name 'UpdateEverything' -Force -Confirm:$false -ErrorAction Stop
+                        Write-Output 'Updated. The new version loads on the next run; this one continues on the code already in memory.'
+                    } catch {
+                        if ("$_" -match 'Administrator rights|elevated') {
+                            Write-Output 'UpdateEverything is installed for all users, so updating it needs Administrator rights. Run "Update-Module UpdateEverything -Force" from an elevated PowerShell.'
+                        } else {
+                            throw
+                        }
+                    }
                 }
                 return
             }
@@ -540,7 +556,7 @@
             }
         }
     } else {
-        Add-SkippedStep -Name 'UpdateEverything (self)' -Reason 'not requested (-UpdateSelf)'
+        Add-SkippedStep -Name 'UpdateEverything (self)' -Reason 'not requested (pass -UpdateSelf or -Tag Self)'
     }
 
     # ---------------------------------------------------------------------------
@@ -911,11 +927,14 @@
             # Nothing left but an install: either absent, or a shipped copy that
             # can only be replaced side by side.
             if ($status.Installed -and $status.Installed -ge $status.Available) {
-                Write-Output "$name $($status.Installed) shipped with this host and is not behind the gallery; leaving it alone."
+                $why = if ($status.Receipted) { 'is not behind the gallery' } else { 'shipped with this host and is not behind the gallery' }
+                Write-Output "$name $($status.Installed) $why; leaving it alone."
                 continue
             }
 
-            $what = if ($status.Installed) {
+            $what = if ($status.Receipted) {
+                "$name $($status.Installed) has a gallery receipt for an older version, so Update-Module would move that older copy rather than the one running. Installing $($status.Available) fresh is the way forward"
+            } elseif ($status.Installed) {
                 "$name $($status.Installed) is the copy this PowerShell shipped with, which cannot be updated in place. Installing $($status.Available) alongside it is the only way forward"
             } else {
                 "$name is not installed. It is the current PowerShell Gallery client, and installing it changes which client every later module update uses. This would install $($status.Available)"
@@ -1021,13 +1040,28 @@
         } elseif (Get-Command py -ErrorAction SilentlyContinue) {
             # Two tools answer to py: the Install Manager's alias, which has an
             # install subcommand, and the classic launcher, which treats a bare
-            # word as a script path and errors. "py help install" tells them
-            # apart without changing anything: the alias exits 0, the launcher
-            # cannot open a script named help and does not.
-            $null = & py help install 2>&1
-            if ($LASTEXITCODE -ne 0) {
+            # word as a script path. "py help install" tells them apart -- the
+            # alias exits 0; the launcher cannot open a script named help.
+            #
+            # Run the probe from SystemRoot so the launcher cannot instead run a
+            # 'help' or 'install' file that happens to sit in the working
+            # directory, and catch a py that resolves but cannot start (a stale
+            # execution alias) rather than trusting a left-over exit code.
+            $isManager = $false
+            Push-Location $env:SystemRoot
+            try {
                 $global:LASTEXITCODE = 0
-                Stop-StepAsSkipped -Reason 'py here is the classic launcher, which cannot update runtimes; the Python Install Manager replaces it'
+                $null = & py help install 2>&1
+                $isManager = ($LASTEXITCODE -eq 0)
+            } catch {
+                $isManager = $false
+            } finally {
+                Pop-Location
+                $global:LASTEXITCODE = 0
+            }
+
+            if (-not $isManager) {
+                Stop-StepAsSkipped -Reason 'py here is the classic launcher or could not start; the Python Install Manager is what updates runtimes'
             }
             py install --update
         } else {
@@ -1115,22 +1149,34 @@
         pipx upgrade-all
     }
 
-    # ---------------------------------------------------------------------------
-    # 5. Node / npm
-    # ---------------------------------------------------------------------------
     # conda updates conda itself in the base environment and nothing else.
     # Environments hold project package sets, and "conda update --all" is the
     # operation the pip step's rule declines: upgrading one package can silently
     # downgrade another's dependency.
     Invoke-Step -Name 'conda' -RequiresCommand 'conda' -Tag 'Python' -Action {
+        # Self-update only what nothing else manages: a scoop- or winget-installed
+        # conda is moved by that manager's own step.
+        $owner = Get-ToolInstallSource -Name 'conda'
+        if ($owner -notin 'Standalone', 'Unknown') {
+            Stop-StepAsSkipped -Reason "conda is managed by $owner, which updates it in its own step"
+        }
+
         $output = conda update --name base conda --yes 2>&1
         $output
         if ($LASTEXITCODE -ne 0) {
-            Write-Error "conda update failed with exit code $LASTEXITCODE. conda's own message is in this step's log."
-            $global:LASTEXITCODE = 0
+            if (($output | Out-String) -match 'NotWritable|permission') {
+                Write-Output 'conda declined to update its base environment; it is installed for all users and needs an elevated session.'
+                $global:LASTEXITCODE = 0
+            } else {
+                Write-Error "conda update failed with exit code $LASTEXITCODE. conda's own message is in this step's log."
+                $global:LASTEXITCODE = 0
+            }
         }
     }
 
+    # ---------------------------------------------------------------------------
+    # 5. Node / npm
+    # ---------------------------------------------------------------------------
     Invoke-Step -Name 'npm' -RequiresCommand 'npm' -Tag 'Node' -Action {
         # npm writes progress and deprecation notices to stderr as a matter of
         # course, so judge it by exit code. Output is captured as well as passed

--- a/tests/Gallery/Invoke-GalleryValidation.ps1
+++ b/tests/Gallery/Invoke-GalleryValidation.ps1
@@ -53,7 +53,7 @@ function Add-Check {
     $colour = if ($Passed) { 'Green' } else { 'Red' }
     Write-Host ("  [{0}] {1}" -f $status, $Name) -ForegroundColor $colour
     if ($Detail) { Write-Host ("         {0}" -f $Detail) -ForegroundColor DarkGray }
-    $script:Checks.Add([pscustomobject]@{ Name = $Name; Passed = $Passed; Detail = $Detail })
+    $script:Checks.Add([pscustomobject]@{ Name = $Name; Status = $status; Passed = $Passed; Detail = $Detail })
 }
 
 if (-not $Version) {
@@ -65,12 +65,14 @@ $stage = Join-Path ([System.IO.Path]::GetTempPath()) ('UE-GalleryValidation-{0:y
 $null = New-Item -ItemType Directory -Path $stage -Force
 
 try {
-    Save-Module -Name UpdateEverything -RequiredVersion $Version -Path $stage -Repository PSGallery
+    # -Force so an untrusted PSGallery (the shipped default) does not stop the
+    # download on a Y/N prompt. It suppresses only the prompt, not repo state.
+    Save-Module -Name UpdateEverything -RequiredVersion $Version -Path $stage -Repository PSGallery -Force
 
     $manifestPath = Join-Path $stage "UpdateEverything\$Version\UpdateEverything.psd1"
     Add-Check 'the gallery served the requested version' (Test-Path -LiteralPath $manifestPath) $manifestPath
 
-    $manifest = Test-ModuleManifest -Path $manifestPath
+    $manifest = Test-ModuleManifest -Path $manifestPath -ErrorAction SilentlyContinue
     Add-Check 'the manifest validates' ($null -ne $manifest) "version $($manifest.Version)"
     Add-Check 'the manifest carries the six exports' ($manifest.ExportedFunctions.Count -eq 6) `
         "$($manifest.ExportedFunctions.Count) exported"
@@ -88,7 +90,7 @@ try {
 
     # Inventory reads the machine and changes nothing. Merging stream 6 puts the
     # banner lines and the result object in one pipeline; the type separates them.
-    $mixed = @(Update-Everything -Tag Inventory -LogRetentionDays 0 6>&1)
+    $mixed = @(Update-Everything -Tag Inventory -SkipElevation -LogRetentionDays 0 6>&1)
     $banner = @($mixed | Where-Object { $_ -is [System.Management.Automation.InformationRecord] } |
         ForEach-Object { "$_" })
     $run = $mixed | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] } |
@@ -104,14 +106,21 @@ try {
         "FailedCount=$($run.FailedCount)"
 
     if ($IncludeSelfUpdate) {
-        $self = Update-Everything -UpdateSelf -LogRetentionDays 0 6>$null
+        # -Tag Self -SkipElevation pins the narrow, no-elevation behavior even
+        # on a downloaded version older than 1.4.0, where -UpdateSelf alone still
+        # meant "self-update and then the whole maintenance run".
+        $self = Update-Everything -UpdateSelf -Tag Self -SkipElevation -LogRetentionDays 0 6>$null
         $ok = @($self.Steps | Where-Object { $_.Status -eq 'OK' })
 
         Add-Check 'with -UpdateSelf, the self step is the only one that runs' (
             $ok.Count -eq 1 -and $ok[0].Step -eq 'UpdateEverything (self)') `
             (($ok.Step) -join ', ')
-        Add-Check 'the -UpdateSelf run failed nothing' ($self.FailedCount -eq 0) "FailedCount=$($self.FailedCount)"
+        Add-Check 'the -UpdateSelf run failed nothing' ($self.FailedCount -is [int] -and $self.FailedCount -eq 0) "FailedCount=$($self.FailedCount)"
     }
+} catch {
+    # Record the failure as a check so the summary and result object still print
+    # -- the harness exists to report a verdict, not to abort on the first throw.
+    Add-Check 'validation completed without an unexpected error' $false "$_"
 } finally {
     Get-Module -Name UpdateEverything | Remove-Module -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $stage -Recurse -Force -ErrorAction SilentlyContinue

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1680,12 +1680,17 @@ Describe 'Every step declares a tag' -Tag 'Static' {
             ForEach-Object { $_.ValidValues })
     }
 
-    It 'validates the same tag set on both entry points' {
-        $register = @((Get-Command Register-UpdateEverythingTask).Parameters['Tag'].Attributes |
+    It 'validates the same tag set on <_> of both entry points' -ForEach @('Tag', 'ExcludeTag') {
+        $parameter = $_
+        $register = @((Get-Command Register-UpdateEverythingTask).Parameters[$parameter].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } |
+            ForEach-Object { $_.ValidValues })
+        $update = @((Get-Command Update-Everything).Parameters[$parameter].Attributes |
             Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } |
             ForEach-Object { $_.ValidValues })
 
         $register | Should-BeCollection $script:DeclaredTags
+        $update   | Should-BeCollection $script:DeclaredTags
     }
 
     It 'found the steps to check' {
@@ -1937,7 +1942,7 @@ Describe '-UpdateSelf runs only the self step' -Tag 'Static' {
         $script:Guard | Should-MatchString "\`$ExcludeTag = @\(\)"
     }
 
-    It 'skips elevation, which a CurrentUser install never needs' {
+    It 'skips the elevation prompt for the self-update' {
         $script:Guard | Should-MatchString "\`$SkipElevation = \`$true"
     }
 


### PR DESCRIPTION
Fixes all 15 findings from the max review of the eleven-PR feature stack (`e513aed...HEAD`). Every one was verified with quoted or measured evidence during the review, and every fix was verified live before commit. 736 tests, 0 failures; the gallery harness passes 10/10 against the published 1.5.0.

## The four that could bite a real user

- **`-UpdateSelf` broke all-users installs** (`Update-Everything.ps1`). The guard forced `-SkipElevation` on a false "CurrentUser needs none" premise; an all-users copy then failed on Windows PowerShell (AdminPrivilegesRequiredForUpdate promoted by `-ErrorAction Stop`) or silently side-installed on PowerShellGet 2.x. Now the self step catches that error and reports the elevation need; the no-UAC intent of #78 is kept.
- **`-Tag Self` did nothing** \u2014 the Self step was gated on the switch, not the tag, so `Register-UpdateEverythingTask -Tag Self` made a task that skipped all 33 steps and exited 0 forever. It now runs when Self is selected by switch or tag (verified live).
- **Mixed-lineage machines were told "shipped with this host"** \u2014 #88's tightened `Updatable` collapsed "no receipt" and "receipt behind newest". A new `Receipted` property splits them; both the self step and Gallery tooling now word each case honestly.
- **The gallery harness had four ways to misfire**: a UAC prompt on its "read-only" pass, a hang on Save-Module's untrusted-repo prompt, a full *mutating* maintenance run under `-IncludeSelfUpdate -Version <pre-1.4.0>`, and an abort before its own summary. All fixed; harness re-run 10/10.

## The rest

Case-insensitive PATH dedupe restored (the PATH-order fix had made it case-sensitive); the `py help install` probe hardened against executing a cwd file and against a stale exit code; conda given the ownership guard its siblings have and moved under the Python banner; `Invoke-Step` checks command-availability before admin and records the skip-log path; the wizard derives its tag list from the ValidateSet (it rejected `Cloud`/`Go`); receipt version casts guarded with `TryParse`; the `git branch *` allowlist entry narrowed to exact (the `*` rode `-D`/`-f`); and the docs corrected to match (Update-Module not Install-Module -Force, three winget buckets, Azure CLI in the admin list, five Python steps, gallery/inventory steps named in the help).

## Refuted, so left alone

The `PowerShell(cd *)` "total bypass" candidate was **refuted by reading the shipped Claude Code bundle**: compound commands are AST-split and each part must be independently allowed, with extra circuit-breakers (cd+git even prompts unconditionally). Only the `git branch` flag-riding was real.

## Noted, not changed (design calls for you)

- **Azure CLI `-RequiresAdmin`** skips per-user `az` installs; kept, since the common machine-wide MSI needs admin.
- **1.5.0 already shipped** with several of these (the `-UpdateSelf` docs overclaim, mixed-lineage wording, the harness gaps). This branch is the GitHub-track fix; it folds into the next minor. Nothing here is a gallery regression severe enough to unlist 1.5.0 in my view, but that call is yours.
