### PR TITLE
Prepare 1.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Install test dependencies
         shell: pwsh
         run: |
+          # Set-PSRepository throws rather than registering when a runner image
+          # arrives without the PSGallery registration, so restore the default
+          # registration before touching it.
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module Pester -MinimumVersion 6.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
           Install-Module PSScriptAnalyzer -Scope CurrentUser -Force

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.5.0'
+    ModuleVersion     = '1.5.1'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -32,32 +32,53 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.5.0
+            ReleaseNotes = '# 1.5.1
 
-One fix, for machines that installed from the gallery once and from GitHub
-later.
+Fixes from a review of the whole 1.4.0-1.5.0 feature stack. GitHub-only: the
+gallery carries minor versions, and these land there with 1.6.0.
 
-## Updatable means the receipt covers the newest installed copy
+## Self-update
 
-Get-GalleryModuleStatus answered Updatable from the existence of any
-PowerShellGet receipt for the module name. A gallery install followed by the
-GitHub one-liner leaves a receipted older version beside an unreceipted newer
-one, and the helper then called the newest copy updatable while Update-Module
-moves only the receipted lineage -- so the self-update step could describe an
-update it was not performing.
+-UpdateSelf skipped elevation on the premise that a self-update never needs
+it. For an all-users install that premise failed the update on Windows
+PowerShell and let newer PowerShellGet side-install a per-user copy instead.
+The step still raises no UAC prompt; an all-users copy is now reported as
+needing an elevated session.
 
-Updatable is now true only when the receipt names the same version as the
-newest installed copy. On a mixed machine the self step takes the guidance
-branch instead, naming Install-Module -Force and -UpdateSelfSource Main,
-both of which do what they say there.
+-Tag Self selected nothing, because the self step was gated on the switch
+alone. The tag now selects the step too, so a scheduled task built with
+-Tag Self performs the self-update it names.
 
-## Verified before publishing
+A machine holding a receipted older version beside a newer copy without a
+receipt is no longer told the newer copy shipped with this host. The self and
+gallery-tooling steps name the mixed lineage and the command that resolves
+it, and a receipt carrying a prerelease or build suffix no longer throws
+during the check.
 
-Found and fixed through a new release harness that downloads the published
-package from the gallery and runs it as installed, on a machine in exactly
-the mixed state above. The self-elevation handoff was re-verified end to end
-on a real machine with UAC on -- eight checks, none skipped -- before this
-version shipped.
+A copy running from outside every module path is pointed at Install-Module,
+which -UpdateSelf could not have reached.
+
+## Steps and reporting
+
+Duplicate-tool detection compares directories case-insensitively again, so a
+PATH that lists the same directory twice in different casing counts as one
+install rather than drawing a warning.
+
+The Python launcher probe runs from the system directory inside a try/catch.
+A file named help in the working directory can no longer be executed by the
+probe, and a launcher that fails to start no longer inherits the previous
+command exit code.
+
+conda moved under the Python banner and gained the same ownership check as
+uv and pipx: a copy that another package manager installed is left to that
+manager.
+
+A step whose tool is absent reports the absent tool rather than a need for
+Administrator when both are true, and skipped steps record the path of the
+log they wrote.
+
+The task wizard reads its tag list from the cmdlet it drives, so the Go and
+Cloud tags introduced in 1.4.0 are offered instead of missing.
 '
 
         }

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -634,11 +634,19 @@ Describe 'Update-Everything' -Tag 'Static' {
 
 Describe 'Repository documentation' -Tag 'Docs' {
 
+    # The count comes from the function rather than a live probe: with command
+    # lookup shadowed to resolve nothing, every tool reports absent, no version
+    # command executes, and one record per catalogue entry still comes out.
     It 'shows an inventory sample sized to the real catalogue' {
         $readme = Get-Content (Join-Path $script:RepoRoot 'README.md') -Raw
         $readme -match 'of (\d+) tools present' | Should-BeTrue
-        [int]$Matches[1] |
-            Should-Be @(& (Get-Module UpdateEverything) { Get-UpdateToolInventory }).Count
+        [int]$documented = $Matches[1]
+
+        $catalogue = & (Get-Module UpdateEverything) {
+            function Get-Command { }
+            Get-UpdateToolInventory
+        }
+        $documented | Should-Be @($catalogue).Count
     }
 
     It 'README documents -<Name>' -ForEach $ExpectedParameters {


### PR DESCRIPTION
The fifteen #91 fixes are on main and gallery users cannot see them until 1.6.0, so main carries them as the GitHub-only 1.5.1, the way 1.2.1 through 1.4.1 carried theirs. Release notes rewritten for what changed since 1.5.0.

Two pieces of hardening ride along:

- CI restores the PSGallery registration before configuring it, so the runner transient that failed a #91 check run ("No repository with the name 'PSGallery' was found") cannot recur.
- The docs test that sizes the README inventory sample against the real catalogue now shadows command lookup instead of probing every installed tool, cutting it from 6.5s to 8ms and restoring the test file's stated premise that nothing in it runs the module's work.

736 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
