### PR TITLE
Cover the paths the first coverage measurement found dark

### DIFF
--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -290,6 +290,16 @@ Describe 'Get-UpdateTaskArgument' -Tag 'Unit' {
         Get-UpdateTaskArgument -ModuleRoot 'C:\x' -ExtraArgument '-IncludeWindowsUpdate', '$false' |
             Should-MatchString ([regex]::Escape('-IncludeWindowsUpdate $false'))
     }
+
+    It 'quotes each tag so the child parses them as a list' {
+        Get-UpdateTaskArgument -ModuleRoot 'C:\x' -Tag 'Node', 'Cloud' |
+            Should-MatchString ([regex]::Escape("-Tag 'Node','Cloud'"))
+    }
+
+    It 'quotes exclusions the same way' {
+        Get-UpdateTaskArgument -ModuleRoot 'C:\x' -ExcludeTag 'Cloud' |
+            Should-MatchString ([regex]::Escape("-ExcludeTag 'Cloud'"))
+    }
 }
 
 Describe 'Get-CadenceDescription' -Tag 'Unit' {
@@ -348,6 +358,91 @@ Describe 'Registration safety' -Tag 'Static' {
             Where-Object { $_ -match 'Write-Host' -and $_.Contains('.\') -and $_ -match '\.ps1' }
 
         $offenders | Should-BeNull -Because "these are refused under AllSigned:`n$($offenders -join "`n")"
+    }
+}
+
+Describe 'Registration refusals' -Tag 'Unit' {
+
+    # Both guards throw before anything is created, so a refused registration
+    # leaves no task behind.
+
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Register-ScheduledTask { }
+        Mock Get-ScheduledTask { }
+    }
+
+    It 'refuses a session without elevation' {
+        Mock Test-IsAdministrator { $false }
+
+        { Register-UpdateEverythingTask } | Should-Throw -ExceptionMessage '*elevated session*'
+        Should-NotInvoke Register-ScheduledTask
+    }
+
+    It 'refuses to replace an existing task without -Force' {
+        Mock Test-IsAdministrator { $true }
+        Mock Get-ScheduledTask { [pscustomobject]@{ TaskName = 'Update-Everything' } }
+
+        { Register-UpdateEverythingTask } | Should-Throw -ExceptionMessage '*already exists*'
+        Should-NotInvoke Register-ScheduledTask
+    }
+
+    # A scheduled run cannot prompt for consent to install BurntToast, so a
+    # task registered with -Notify and no way to notify deserves a warning now,
+    # not silence at three in the morning.
+    It 'warns when the task will notify nobody' {
+        Mock Test-IsAdministrator { $true }
+        Mock Test-NotificationModuleAvailable { $false }
+        Mock Register-ScheduledTask { [pscustomobject]@{ TaskName = $TaskName } }
+
+        $everything = @(Register-UpdateEverythingTask 3>&1)
+
+        "$($everything -join ' ')" | Should-MatchString 'notify nobody'
+    }
+}
+
+Describe 'Unregister-UpdateEverythingTask' -Tag 'Unit' {
+
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Unregister-ScheduledTask { }
+    }
+
+    It 'removes the task when it exists' {
+        Mock Get-ScheduledTask { [pscustomobject]@{ TaskName = 'Update-Everything' } }
+
+        Unregister-UpdateEverythingTask -Confirm:$false
+
+        Should-Invoke Unregister-ScheduledTask -Times 1 -Exactly -ParameterFilter {
+            $TaskName -eq 'Update-Everything'
+        }
+    }
+
+    It 'does nothing, quietly, when there is no task' {
+        Mock Get-ScheduledTask { }
+
+        Unregister-UpdateEverythingTask -Confirm:$false
+
+        Should-NotInvoke Unregister-ScheduledTask
+    }
+
+    It 'carries a custom name and folder through' {
+        Mock Get-ScheduledTask { [pscustomobject]@{ TaskName = 'Nightly' } }
+
+        Unregister-UpdateEverythingTask -TaskName 'Nightly' -TaskPath '\WWT\' -Confirm:$false
+
+        Should-Invoke Unregister-ScheduledTask -Times 1 -Exactly -ParameterFilter {
+            $TaskName -eq 'Nightly' -and $TaskPath -eq '\WWT\'
+        }
+    }
+
+    # Removing a schedule is the operation -WhatIf exists for.
+    It 'honours -WhatIf' {
+        Mock Get-ScheduledTask { [pscustomobject]@{ TaskName = 'Update-Everything' } }
+
+        Unregister-UpdateEverythingTask -WhatIf
+
+        Should-NotInvoke Unregister-ScheduledTask
     }
 }
 
@@ -634,6 +729,20 @@ Describe 'Adding a second task' -Tag 'Unit' {
         New-TaskFromPrompt -DefaultName 'Update-Everything' -Replace
 
         Should-Invoke Register-UpdateEverythingTask -ParameterFilter { $Force }
+    }
+
+    # Register throws on a session without elevation. Mid-wizard that becomes a
+    # warning naming the cause, not a stack trace out of the menu.
+    It 'turns a failed registration into a warning' {
+        $script:answers = @('', '', '', '')
+        $script:next = 0
+        Mock Read-Host { $script:answers[$script:next++] }
+        Mock Register-UpdateEverythingTask { throw 'requires an elevated session' }
+
+        $warnings = @(New-TaskFromPrompt 3>&1)
+
+        "$($warnings -join ' ')" | Should-MatchString 'Could not register the task'
+        "$($warnings -join ' ')" | Should-MatchString 'elevated session'
     }
 }
 

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1790,6 +1790,20 @@ Describe 'Get-UpdateToolInventory' -Tag 'Unit' {
         $null = Get-UpdateToolInventory -Catalogue @($bad)
         $LASTEXITCODE | Should-Be 0
     }
+
+    # A command can resolve and still not start: a stale shim, a stub whose
+    # target was uninstalled. The record stays Present with no version, no
+    # throw and no leftover exit code.
+    It 'reports a tool whose version command cannot start as present, without a version' {
+        Mock Get-Command { [pscustomobject]@{ Source = 'C:\shims\ue-broken-shim.exe' } }
+
+        $r = Get-UpdateToolInventory -Catalogue @(
+            @{ Name = 'Broken'; Command = 'ue-broken-shim-2b9d'; VersionArgument = '--version' })
+
+        $r.Present | Should-BeTrue
+        $r.Version | Should-BeNull
+        $LASTEXITCODE | Should-Be 0
+    }
 }
 
 Describe 'Step order' -Tag 'Static' {
@@ -2061,6 +2075,95 @@ Describe 'Install-DeveloperTool' -Tag 'Unit' {
         $result = Install-DeveloperTool -Name 'PowerShell 7' -WarningAction SilentlyContinue 6>$null
         $result.Installed | Should-Be 0
         $result.Skipped   | Should-Be 1
+    }
+
+    It 'says when winget itself is missing' {
+        Mock Get-Command { }
+
+        $warnings = @(Install-DeveloperTool -Name 'Git' 3>&1)
+
+        "$($warnings -join ' ')" | Should-MatchString 'winget is not available'
+    }
+
+    Context 'An approved install' {
+
+        BeforeEach {
+            Mock Write-Host { }
+            Mock Get-Command { [pscustomobject]@{ Name = 'winget' } }
+            Mock Approve-Install { $true }
+            Mock Get-DeveloperToolCatalogue {
+                [pscustomobject]@{
+                    Name          = 'FakeTool'
+                    Id            = 'Fake.Tool'
+                    Present       = $false
+                    Description   = 'A catalogue entry for this test'
+                    InstallerType = $null
+                }
+            }
+        }
+
+        # winget is a native executable, so Mock cannot intercept it; a function
+        # of the same name in this scope can, because command resolution finds
+        # it before the application.
+        It 'runs winget against the exact id and counts the success' {
+            function winget { $script:WingetArgs = $args; $global:LASTEXITCODE = 0 }
+
+            $result = Install-DeveloperTool -Name 'FakeTool'
+
+            $result.Installed | Should-Be 1
+            $result.Failed    | Should-Be 0
+            "$script:WingetArgs" | Should-MatchString ([regex]::Escape('install --id Fake.Tool --exact'))
+        }
+
+        It 'declines interactivity and accepts agreements, so a menu install cannot hang' {
+            function winget { $script:WingetArgs = $args; $global:LASTEXITCODE = 0 }
+
+            $null = Install-DeveloperTool -Name 'FakeTool'
+
+            "$script:WingetArgs" | Should-MatchString '--disable-interactivity'
+            "$script:WingetArgs" | Should-MatchString '--accept-package-agreements'
+        }
+
+        It 'passes a pinned installer type through' {
+            Mock Get-DeveloperToolCatalogue {
+                [pscustomobject]@{
+                    Name          = 'FakeTool'
+                    Id            = 'Fake.Tool'
+                    Present       = $false
+                    Description   = 'A catalogue entry for this test'
+                    InstallerType = 'msi'
+                }
+            }
+            function winget { $script:WingetArgs = $args; $global:LASTEXITCODE = 0 }
+
+            $null = Install-DeveloperTool -Name 'FakeTool'
+
+            "$script:WingetArgs" | Should-MatchString '--installer-type msi'
+        }
+
+        It 'counts a failed installer as failed and leaves no exit code behind' {
+            function winget { $global:LASTEXITCODE = 5 }
+
+            $result = Install-DeveloperTool -Name 'FakeTool' -WarningAction SilentlyContinue
+
+            $result.Failed    | Should-Be 1
+            $result.Installed | Should-Be 0
+            $LASTEXITCODE     | Should-Be 0
+        }
+
+        # The gate this module lives by: declined means skipped, and winget is
+        # never reached.
+        It 'installs nothing when consent is declined' {
+            Mock Approve-Install { $false }
+            function winget { $script:WingetRan = $true }
+
+            $script:WingetRan = $false
+            $result = Install-DeveloperTool -Name 'FakeTool'
+
+            $result.Skipped   | Should-Be 1
+            $result.Installed | Should-Be 0
+            $script:WingetRan | Should-BeFalse
+        }
     }
 }
 
@@ -2343,6 +2446,62 @@ Describe 'Format-SelfVersionStatus' -Tag 'Unit' {
         $line = Format-SelfVersionStatus -Running '1.2.0' -Status (& $script:StatusOf $null '1.1.0' $false)
         $line | Should-MatchString '1\.2\.0'
     }
+
+    # Behind the gallery with no installed copy anywhere: imported by path from
+    # a clone of an old tag. Update-Module has no receipt to move there, so the
+    # advice is the install command, not -UpdateSelf.
+    It 'sends a behind copy that is installed nowhere to Install-Module' {
+        $line = Format-SelfVersionStatus -Running '1.0.0' -Status (& $script:StatusOf $null '1.2.0' $false)
+        $line | Should-MatchString 'outside a module path'
+        $line | Should-MatchString ([regex]::Escape('Install-Module UpdateEverything -Force'))
+    }
+}
+
+Describe 'New-UpdateEverythingResult' -Tag 'Unit' {
+
+    # The counts exist so a scheduled task can end with "exit FailedCount".
+    # They are derived from the step records rather than passed in, so they
+    # cannot disagree with the steps they describe.
+
+    BeforeAll {
+        $script:FiveSteps = @(
+            [pscustomobject]@{ Step = 'a'; Status = 'OK' }
+            [pscustomobject]@{ Step = 'b'; Status = 'OK' }
+            [pscustomobject]@{ Step = 'c'; Status = 'Warning' }
+            [pscustomobject]@{ Step = 'd'; Status = 'Skipped' }
+            [pscustomobject]@{ Step = 'e'; Status = 'Failed' }
+        )
+    }
+
+    It 'derives every count from the step records' {
+        $r = New-UpdateEverythingResult -Ran $true -Steps $script:FiveSteps
+        $r.OkCount      | Should-Be 2
+        $r.WarningCount | Should-Be 1
+        $r.SkippedCount | Should-Be 1
+        $r.FailedCount  | Should-Be 1
+    }
+
+    It 'counts nothing as failed when nothing ran' {
+        $r = New-UpdateEverythingResult -Ran $false -Reason 'declined at the prompt'
+        $r.FailedCount | Should-Be 0
+        $r.Reason      | Should-Be 'declined at the prompt'
+    }
+
+    # A parent that handed the work to an elevated child has no step records of
+    # its own, only the child's exit code. That number must win.
+    It 'lets a handed-in failure count stand in for missing step records' {
+        (New-UpdateEverythingResult -Ran $true -FailedCount 3).FailedCount | Should-Be 3
+    }
+
+    It 'treats a handed-in zero as an answer, not an absence' {
+        (New-UpdateEverythingResult -Ran $true -Steps $script:FiveSteps -FailedCount 0).FailedCount |
+            Should-Be 0
+    }
+
+    It 'types the result so callers can recognise it' {
+        (New-UpdateEverythingResult -Ran $true).PSTypeNames -contains 'UpdateEverything.Result' |
+            Should-BeTrue
+    }
 }
 
 Describe 'A run says which version produced it' -Tag 'Static' {
@@ -2560,6 +2719,15 @@ remove: Access is denied.: "C:\...\WinGet\Packages\astral-sh.uv_...\uv.exe"
 
         @($rows | Where-Object { $_.Id -eq 'New.New' }).Listed | Should-BeFalse
         @($rows | Where-Object { $_.Id -eq 'Cisco.CiscoWebexMeetings' }).Listed | Should-BeTrue
+    }
+
+    # An attempted install can fail without the file-in-use signature. A reason
+    # is still owed, and it stays generic rather than guessing at a diagnosis.
+    It 'still gives an undiagnosed failure a reason' {
+        $output = $script:Output -replace 'Access is denied', 'error 0x80070001'
+        $uv = @(Get-WingetLeftover -Before $script:Before -After $script:Before -Output $output) |
+            Where-Object { $_.Id -eq 'astral-sh.uv' }
+        $uv.Reason | Should-Be 'the install failed'
     }
 }
 


### PR DESCRIPTION
A one-off Pester coverage run over `src` (not wired into `test.ps1`, which stays without coverage on purpose) mapped which branches the suite executes. Nine files with real logic had gaps; two stood out: a public cmdlet and code new in #91.

- **Unregister-UpdateEverythingTask** had never been executed by a test. Now: removal, the quiet no-task case, name/folder passthrough, and `-WhatIf`.
- **Format-SelfVersionStatus**'s advice for a behind copy installed nowhere — added in #91 — shipped untested. Now pinned.
- **New-UpdateEverythingResult**: derived counts, the handed-in FailedCount override, the explicit-zero boundary, the type name.
- **Install-DeveloperTool** execution paths under a shadowed `winget` function (Mock cannot intercept a native executable): exact id, non-interactive flags, pinned installer type, failure counting, missing-winget warning, and consent declined meaning winget is never reached.
- **Register-UpdateEverythingTask**'s two refusal throws and its notify-nobody warning; **New-TaskFromPrompt**'s registration catch; **Get-UpdateTaskArgument** tag/exclusion quoting; **Get-WingetLeftover**'s undiagnosed-failure reason; **Get-UpdateToolInventory**'s unstartable-version-command record.

24 new tests. 760 tests, 0 failures, 92s (the docs-test speedup from #92 absorbed the additions). src coverage 51.0% → 54.5%; the remainder is Update-Everything.ps1 itself (static-tested by design), the interactive wizard shells, and the console seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
