### PR TITLE
Drive the setup wizard shells from tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -414,6 +414,29 @@ A test that registers a real task should register it once and assert several
 times, in a `Context` with the registration in `BeforeAll`. Two tests that each
 register the same cadence pay the full 6.6s twice for the same task.
 
+### Measuring coverage
+
+There is no coverage gate, and `test.ps1` never measures it: `Update-Everything`
+itself is tested statically, so its commands can never execute under the suite,
+and a percentage target would either fail forever or pressure a test into
+running code that elevates, installs and reboots.
+
+The map is still worth drawing when hunting for untested branches:
+
+```powershell
+$config = New-PesterConfiguration
+$config.Run.Path             = '.\tests'
+$config.CodeCoverage.Enabled = $true
+$config.CodeCoverage.Path    = '.\src'
+Invoke-Pester -Configuration $config
+```
+
+Read the per-file numbers, not the total. Dark on purpose: `Update-Everything.ps1`
+(static-tested), `Request-InstallConsent` and `Read-TimedChoice`'s wait loop
+(both need a real console host), `Invoke-SelfElevation`'s relaunch (the attended
+elevation harness exercises it live), and the psm1's platform guards. A gap
+anywhere else is a finding — #93 and #94 each came from exactly this reading.
+
 ### Ways a test here has passed while the code was broken
 
 Each of these produced a green suite over a real defect. Worth knowing before

--- a/README.md
+++ b/README.md
@@ -746,8 +746,11 @@ in the module, since that would end the session of whoever called it.
 The behavioural checks dot-source the module's files individually and call the
 private helpers directly. File work goes to `TestDrive`, `LOCALAPPDATA` is
 redirected there while the Windows Terminal tests run, and registry probes are
-mocked. There is no coverage metric, since measuring it means executing the code
-under test.
+mocked. There is no coverage gate: the entry point is tested statically, so
+its lines never execute under the suite, and a percentage target would push a
+test into running code that elevates, installs and reboots. Coverage is still
+measured as a one-off map when hunting untested branches; CONTRIBUTING shows
+how.
 
 `Set-StrictMode` is left out on purpose. It makes reading a missing property
 fatal, and the module has to probe for optional keys in Windows Terminal's

--- a/test.ps1
+++ b/test.ps1
@@ -65,7 +65,9 @@ if ($CI) {
     $config.TestResult.OutputPath = Join-Path $PSScriptRoot 'testResults.xml'
 }
 
-# No CodeCoverage: measuring it means executing the code under test, and the
-# code under test elevates, installs software and can reboot the machine.
+# No CodeCoverage in the runner: the entry point is tested statically, so a
+# coverage gate would either fail forever or pressure a test into executing
+# code that elevates, installs software and reboots. CONTRIBUTING shows the
+# one-off measurement used to map untested branches.
 
 Invoke-Pester -Configuration $config

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -475,6 +475,15 @@ Describe 'Format-LastRunResult' -Tag 'Unit' {
 
 Describe 'Get-PowerShellHostPath' -Tag 'Unit' {
 
+    # When the MSI path is absent and no unpackaged host resolves, the task
+    # gets the process running this script rather than nothing.
+    It 'falls back to the process running these tests when nothing resolves' {
+        Mock Test-Path { $false }
+        Mock Get-Command { }
+
+        Get-PowerShellHostPath | Should-Be (Get-Process -Id $PID).Path
+    }
+
     # This path is baked into a scheduled task, so it has to still exist months
     # later. A packaged pwsh resolves to
     # ...\WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__8wekyb3d8bbwe\pwsh.exe,

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -381,6 +381,15 @@ Describe 'Test-PendingReboot' -Tag 'Unit' {
         (Test-PendingReboot).IsPending | Should-BeFalse
     }
 
+    # Reading the rename keys can be denied. That is not a pending rename, and
+    # it must not fail the probe.
+    It 'treats unreadable rename keys as no rename, not a fault' {
+        Mock Get-ItemProperty { throw 'Requested registry access is not allowed.' } `
+            -ParameterFilter { $LiteralPath -like '*ComputerName*' }
+
+        (Test-PendingReboot).IsPending | Should-BeFalse
+    }
+
     It 'collects every reason when several are pending' {
         Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*Component Based Servicing\RebootPending' }
         Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*WindowsUpdate\Auto Update\RebootRequired' }
@@ -2277,6 +2286,209 @@ Describe 'The setup menu loop' -Tag 'Unit' {
         Initialize-UpdateEverything
 
         Should-Invoke Invoke-SetupChoice -ParameterFilter { $Key -eq 'ScheduledTask' }
+    }
+}
+
+Describe 'Invoke-SetupChoice' -Tag 'Unit' {
+
+    BeforeEach {
+        Mock Write-Host { }
+    }
+
+    # The menu is the confirmation for reaching an option, not for installing
+    # anything: no option hands the run an -AllowInstall.
+    It 'runs the prerequisite steps under their tags, with installs still gated' {
+        Mock Update-Everything { }
+
+        Invoke-SetupChoice -Key Prerequisites
+
+        Should-Invoke Update-Everything -Times 1 -Exactly -ParameterFilter {
+            $Tag -contains 'PowerShell' -and $Tag -contains 'PackageManager' -and
+            $Notify -and $IncludePowerShellModules -eq $false -and -not $AllowInstall
+        }
+    }
+
+    It 'hands the scheduled-task option to the submenu' {
+        Mock Invoke-TaskSetup { }
+
+        Invoke-SetupChoice -Key ScheduledTask
+
+        Should-Invoke Invoke-TaskSetup -Times 1 -Exactly
+    }
+
+    It 'runs the ordinary run for the first-run option' {
+        Mock Update-Everything { }
+
+        Invoke-SetupChoice -Key FirstRun
+
+        Should-Invoke Update-Everything -Times 1 -Exactly -ParameterFilter {
+            -not $Tag -and -not $AllowInstall
+        }
+    }
+
+    Context 'The developer-tools menu' {
+
+        BeforeEach {
+            Mock Get-DeveloperToolCatalogue {
+                [pscustomobject]@{ Name = 'Git';    Id = 'Git.Git'; Present = $true;  Description = 'version control' }
+                [pscustomobject]@{ Name = 'Node';   Id = 'N.N';     Present = $false; Description = 'a runtime' }
+                [pscustomobject]@{ Name = 'VSCode'; Id = 'M.V';     Present = $false; Description = 'an editor' }
+            }
+            Mock Install-DeveloperTool {
+                [pscustomobject]@{ Installed = 1; Skipped = 0; Failed = 0 }
+            }
+        }
+
+        It 'installs nothing on a blank answer' {
+            Mock Read-Host { '' }
+
+            Invoke-SetupChoice -Key DeveloperTools
+
+            Should-NotInvoke Install-DeveloperTool
+        }
+
+        It 'turns picked numbers into catalogue names' {
+            Mock Read-Host { '1, 3' }
+
+            Invoke-SetupChoice -Key DeveloperTools
+
+            Should-Invoke Install-DeveloperTool -Times 1 -Exactly -ParameterFilter {
+                $Name -contains 'Git' -and $Name -contains 'VSCode' -and @($Name).Count -eq 2
+            }
+        }
+
+        It 'refuses a number that is not on the menu' {
+            Mock Read-Host { '99' }
+
+            $null = Invoke-SetupChoice -Key DeveloperTools 3>$null
+
+            Should-NotInvoke Install-DeveloperTool
+        }
+
+        It 'keeps the valid picks when one is a typo' {
+            Mock Read-Host { '2, x' }
+
+            $null = Invoke-SetupChoice -Key DeveloperTools 3>$null
+
+            Should-Invoke Install-DeveloperTool -Times 1 -Exactly -ParameterFilter {
+                @($Name).Count -eq 1 -and $Name -contains 'Node'
+            }
+        }
+    }
+}
+
+Describe 'Invoke-TaskSetup' -Tag 'Unit' {
+
+    BeforeEach {
+        Mock Write-Host { }
+        Mock New-TaskFromPrompt { }
+        Mock Register-UpdateEverythingTask { }
+        Mock Unregister-UpdateEverythingTask { }
+    }
+
+    Context 'No task registered yet' {
+
+        BeforeEach { Mock Get-UpdateEverythingTask { @() } }
+
+        It 'registers the weekly default' {
+            Invoke-TaskSetup
+
+            Should-Invoke Register-UpdateEverythingTask -Times 1 -Exactly -ParameterFilter {
+                $Cadence -eq 'Weekly' -and $Notify
+            }
+        }
+
+        It 'turns a refused registration into a warning, not a stack trace' {
+            Mock Register-UpdateEverythingTask { throw 'requires an elevated session' }
+
+            $warnings = @(Invoke-TaskSetup 3>&1)
+
+            "$($warnings -join ' ')" | Should-MatchString 'Could not register the task'
+        }
+    }
+
+    Context 'Tasks already registered' {
+
+        BeforeEach {
+            $script:TwoTasks = @(
+                [pscustomobject]@{ TaskName = 'Update-Everything';        TaskPath = '\'; State = 'Ready'; NextRun = $null }
+                [pscustomobject]@{ TaskName = 'Update-Everything-Python'; TaskPath = '\'; State = 'Ready'; NextRun = $null }
+            )
+            Mock Get-UpdateEverythingTask { $script:TwoTasks }
+        }
+
+        It 'adds another task through the wizard' {
+            Mock Read-Host { '1' }
+
+            Invoke-TaskSetup
+
+            Should-Invoke New-TaskFromPrompt -Times 1 -Exactly
+        }
+
+        It 'replaces the chosen task, keeping its name' {
+            Mock Read-Host { '2' }
+            Mock Select-TaskFromList { $script:TwoTasks[1] }
+
+            Invoke-TaskSetup
+
+            Should-Invoke New-TaskFromPrompt -Times 1 -Exactly -ParameterFilter {
+                $DefaultName -eq 'Update-Everything-Python' -and $Replace
+            }
+        }
+
+        It 'does nothing when the replace pick is abandoned' {
+            Mock Read-Host { '2' }
+            Mock Select-TaskFromList { }
+
+            Invoke-TaskSetup
+
+            Should-NotInvoke New-TaskFromPrompt
+        }
+
+        It 'removes only after a spelled-out yes' {
+            $script:answers = @('3', 'y')
+            $script:next = 0
+            Mock Read-Host { $script:answers[$script:next++] }
+            Mock Select-TaskFromList { $script:TwoTasks[0] }
+
+            Invoke-TaskSetup
+
+            Should-Invoke Unregister-UpdateEverythingTask -Times 1 -Exactly -ParameterFilter {
+                $TaskName -eq 'Update-Everything'
+            }
+        }
+
+        It 'leaves the task alone when the answer is not yes' {
+            $script:answers = @('3', '')
+            $script:next = 0
+            Mock Read-Host { $script:answers[$script:next++] }
+            Mock Select-TaskFromList { $script:TwoTasks[0] }
+
+            Invoke-TaskSetup
+
+            Should-NotInvoke Unregister-UpdateEverythingTask
+        }
+
+        It 'turns a failed removal into a warning' {
+            $script:answers = @('3', 'yes')
+            $script:next = 0
+            Mock Read-Host { $script:answers[$script:next++] }
+            Mock Select-TaskFromList { $script:TwoTasks[0] }
+            Mock Unregister-UpdateEverythingTask { throw 'access denied' }
+
+            $warnings = @(Invoke-TaskSetup 3>&1)
+
+            "$($warnings -join ' ')" | Should-MatchString 'Could not remove the task'
+        }
+
+        It 'goes back without touching anything' {
+            Mock Read-Host { '4' }
+
+            Invoke-TaskSetup
+
+            Should-NotInvoke New-TaskFromPrompt
+            Should-NotInvoke Unregister-UpdateEverythingTask
+        }
     }
 }
 


### PR DESCRIPTION
The coverage map from #93 left two pockets of real logic dark: `Invoke-SetupChoice` and `Invoke-TaskSetup`, the menu shells behind `Initialize-UpdateEverything`. The menu loop above them was tested by mocking them; nothing drove the shells themselves. Eighteen tests now do, one layer down, with every mutator mocked.

- **Prerequisites** runs Update-Everything under the PowerShell/PackageManager tags with `-Notify` and no `-AllowInstall` — reaching an option is not consent to install, so each install still asks. **FirstRun** runs the plain command.
- **Developer tools**: picked numbers become catalogue names; a blank answer installs nothing; numbers off the menu are refused; valid picks survive beside a typo.
- **Task submenu**: registers the weekly default when nothing is registered, adds through the wizard, replaces keeping the chosen name, removes only after a spelled-out yes, and turns refused registrations and failed removals into warnings instead of stack traces out of a menu.
- Also: `Test-PendingReboot` treats unreadable rename keys as no rename rather than a fault; `Get-PowerShellHostPath` falls back to the running process when no host resolves.

778 tests, 0 failures. src coverage 54.5% → 58.8%; what stays dark is Update-Everything.ps1 (static-tested by design) and the console seams that need a real host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
