### PR TITLE
Exercise the 5.1 run path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,15 @@ jobs:
         with:
           name: test-results
           path: testResults.xml
+
+  # Pester 6 requires PowerShell 7, so the suite above never executes the run
+  # path under the module's other supported host. This job does: import under
+  # powershell.exe and take the read-only inventory pass end to end.
+  windows-powershell:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Smoke test under Windows PowerShell 5.1
+        shell: powershell
+        run: .\tests\WindowsPowerShell\Invoke-WindowsPowerShellSmoke.ps1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,8 +325,12 @@ uses colour to separate failures from noise.
 because they all ran under 7 where a separate code path masked it.
 
 Because of this, the suite shells out to both `powershell.exe` and `pwsh.exe`
-and imports the module in each. If you change the loader, the manifest, or
-anything touching encoding, run the suite on both editions before opening a PR.
+and imports the module in each, and CI runs a second job that takes the
+read-only inventory pass end to end under 5.1
+(`tests/WindowsPowerShell/Invoke-WindowsPowerShellSmoke.ps1`, runnable locally
+with `powershell -File`). If you change the loader, the manifest, or anything
+touching encoding, run that smoke test as well as the suite before opening a
+PR -- the suite itself cannot run under 5.1, because Pester 6 requires 7.
 
 ## ErrorAction
 

--- a/tests/WindowsPowerShell/Invoke-WindowsPowerShellSmoke.ps1
+++ b/tests/WindowsPowerShell/Invoke-WindowsPowerShellSmoke.ps1
@@ -1,0 +1,74 @@
+#Requires -Version 5.1
+
+<#
+    .SYNOPSIS
+    Imports the module under Windows PowerShell 5.1 and runs the read-only
+    inventory pass end to end.
+
+    .DESCRIPTION
+    The Pester suite runs under PowerShell 7, because Pester 6 requires it. Two
+    of its tests shell out to powershell.exe -- one imports the module, one
+    writes a step log -- which catches parse errors and the encoding split, but
+    nothing executes the run path under 5.1: the step runner, the transcript,
+    the inventory formatting, and PowerShellGet 1.0.0.1 answering the
+    self-version lookup.
+
+    This does. It runs the one tag that changes nothing on the machine, then
+    checks the result object. CI runs it as its own job under shell:
+    powershell; locally:
+
+        powershell -NoProfile -ExecutionPolicy Bypass -File .\tests\WindowsPowerShell\Invoke-WindowsPowerShellSmoke.ps1
+
+    .OUTPUTS
+    Progress lines. Exits 1 on the first failed check, so a pipeline fails.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+try {
+    # Running this under 7 would pass while proving nothing about 5.1.
+    if ($PSVersionTable.PSEdition -ne 'Desktop') {
+        throw ("This smoke test exists to exercise Windows PowerShell and is running under " +
+            "$($PSVersionTable.PSVersion) ($($PSVersionTable.PSEdition)). Run it with powershell.exe.")
+    }
+
+    $repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $manifest = Join-Path $repoRoot 'src\UpdateEverything.psd1'
+
+    Import-Module $manifest -Force -ErrorAction Stop
+    Write-Output "Imported under Windows PowerShell $($PSVersionTable.PSVersion)."
+
+    $missing = @(
+        (Import-PowerShellDataFile $manifest).FunctionsToExport |
+            Where-Object { -not (Get-Command $_ -Module UpdateEverything -ErrorAction SilentlyContinue) })
+    if ($missing.Count) {
+        throw "Exported commands that do not resolve under 5.1: $($missing -join ', ')"
+    }
+    Write-Output 'Every command the manifest exports resolves.'
+
+    $result = Update-Everything -Tag Inventory -SkipElevation -LogRetentionDays 0 6>$null
+
+    $problems = @(
+        if (-not $result) { 'no result object came back' }
+        elseif (-not $result.Ran) { "the run did not start: $($result.Reason)" }
+        else {
+            if ($result.FailedCount -ne 0) { "FailedCount=$($result.FailedCount)" }
+            if (@($result.Steps).Count -lt 25) { "only $(@($result.Steps).Count) step records came back" }
+            if (@($result.Steps | Where-Object { $_.Step -eq 'Inventory' -and $_.Status -eq 'OK' }).Count -ne 1) {
+                'the Inventory step did not report OK'
+            }
+        })
+    if ($problems.Count) {
+        throw ('The inventory pass failed under 5.1: ' + ($problems -join '; '))
+    }
+
+    Write-Output "Inventory pass OK under 5.1: $(@($result.Steps).Count) steps, 0 failed."
+} catch {
+    # An explicit exit code, because what an uncaught throw returns under -File
+    # has differed between hosts.
+    Write-Error -ErrorAction Continue -Message "$_"
+    exit 1
+}


### PR DESCRIPTION
The suite runs under PowerShell 7 because Pester 6 requires it, and its two `powershell.exe` child tests cover import and the encoding split — but nothing executed the run path under the module's other supported host: the step runner, the transcript, the inventory formatting, PowerShellGet 1.0.0.1 answering the self-version lookup. CONTRIBUTING even told people to run the suite on both editions, which Pester 6 makes impossible.

`tests/WindowsPowerShell/Invoke-WindowsPowerShellSmoke.ps1` imports the module under `powershell.exe`, checks every exported command resolves, and takes the read-only inventory pass end to end, asserting on the result object. It refuses to run under 7 (where passing would prove nothing) and exits 1 explicitly, because what an uncaught throw returns under `-File` has differed between hosts. CI runs it as a second job in parallel with the suite; CONTRIBUTING now points at it instead of the impossible advice.

Verified locally: exit 0 under 5.1.26100 (33 steps, 0 failed), exit 1 under 7 with the wrong-host message. 783 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
