### PR TITLE
Name the two tests that run the real countdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,7 +385,10 @@ Tests reach private functions by dot-sourcing `src/Private/*.ps1` and
 `src/Public/*.ps1` individually rather than importing the module. File work goes
 to `TestDrive`. Anything that reads the keyboard or waits on a clock is mocked —
 `Read-TimedChoice` above all, because a test that waits on a countdown is a test
-that hangs.
+that hangs. The two exceptions are deliberate and bounded: the tests whose
+subject is the countdown itself run the real one, with two- and three-second
+timeouts, because a mocked clock would prove nothing about the redraw and the
+timeout they exist to pin.
 
 Run the suite the way CI does, so green locally means green in the pipeline:
 


### PR DESCRIPTION
CONTRIBUTING said anything that waits on a clock is mocked, `Read-TimedChoice` above all. Two tests deliberately run the real countdown — the redraw test, which pins a formatting bug that only manifests when the countdown draws, and the timeout test, whose subject is the timeout being honoured at all. A mocked clock would prove nothing about either. The convention now names the exception instead of overstating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)