### PR TITLE
Read both gallery clients' receipts, and run the one that answers

### DIFF
--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -5,7 +5,7 @@ function Get-GalleryModuleStatus {
         the PowerShell Gallery.
 
         .DESCRIPTION
-        Returns Name, Installed, Available, Receipted, Updatable and
+        Returns Name, Installed, Available, Receipted, Updatable, Mover and
         NeedsUpdate.
 
         Installed is $null when the module is absent. Absent means any install
@@ -17,16 +17,21 @@ function Get-GalleryModuleStatus {
         a reason to reinstall. An update is never reported for a module that is
         not installed.
 
-        Updatable reports whether Update-Module can move this copy forward. It
-        refuses anything it did not install, answering "Module 'X' was not
-        installed by using Install-Module, so it cannot be updated" -- which
-        covers every module that shipped with the host, and any copy whose
-        receipt names an older version than the newest one installed, since
-        Update-Module moves only the receipted lineage. Windows PowerShell
-        ships PowerShellGet 1.0.0.1
-        under Program Files rather than $PSHOME, so the path is not the test;
-        whether PowerShellGet recorded the install is. Moving a shipped copy
-        forward is a side-by-side install, and so an install decision.
+        Updatable reports whether an installed gallery client can move this
+        copy forward, and Mover names the command that can -- Update-PSResource
+        or Update-Module -- or is $null. Both clients refuse anything they did
+        not install, which covers every module that shipped with the host, and
+        any copy whose receipt names an older version than the newest one
+        installed, since each client moves only its receipted lineage. Windows
+        PowerShell ships PowerShellGet 1.0.0.1 under Program Files rather than
+        $PSHOME, so the path is not the test; whether a client recorded the
+        install is. Moving a shipped copy forward is a side-by-side install,
+        and so an install decision.
+
+        Receipts come from both clients. PSResourceGet ships in the box with
+        PowerShell 7.4 and its receipts are invisible to Get-InstalledModule,
+        so a machine can hold a gallery-installed module that PowerShellGet
+        has never heard of.
 
         .PARAMETER Name
         The module to look up, on this machine and on the gallery.
@@ -49,28 +54,43 @@ function Get-GalleryModuleStatus {
         Sort-Object Version -Descending)
     $installed = if ($present.Count) { [version] $present[0].Version } else { $null }
 
-    # Ask PowerShellGet what it installed, rather than inferring it from the
-    # path. Get-InstalledModule reports only what came through Install-Module,
-    # which is exactly the set Update-Module will act on -- and the receipt has
-    # to cover the newest installed copy, the one Installed names. A machine can
-    # carry a receipted older version beside a GitHub-installed newer one, and
-    # Update-Module moves only the receipted lineage.
-    # Receipted is whether a PowerShellGet receipt exists at all; Updatable is
-    # the stricter test that the receipt covers the newest installed copy, the
-    # one Installed names. A machine can carry a receipted older version beside
-    # an unreceipted newer one, and Update-Module moves only the receipted
-    # lineage -- so a caller distinguishes "no gallery lineage" (not Receipted)
-    # from "gallery lineage, but behind the copy running" (Receipted, not
-    # Updatable).
+    # Ask the gallery clients what they installed, rather than inferring it
+    # from the path. Each reader reports only what its client installed, which
+    # is exactly the set its Update-* command will act on -- and a receipt has
+    # to cover the newest installed copy, the one Installed names. A machine
+    # can carry a receipted older version beside a GitHub-installed newer one,
+    # and each client moves only its receipted lineage -- so a caller
+    # distinguishes "no gallery lineage" (not Receipted) from "gallery
+    # lineage, but behind the copy running" (Receipted, not Updatable).
+    #
+    # PSResourceGet is asked first: it reads PowerShellGet's receipts as well
+    # as its own, so its answer exists more often, and Update-PSResource is
+    # then the client that moves the copy.
     $receipted = $false
     $updatable = $false
-    if ($present.Count -and (Get-Command Get-InstalledModule -ErrorAction SilentlyContinue)) {
-        $receipt = Get-InstalledModule -Name $Name -ErrorAction SilentlyContinue
-        if ($receipt) {
+    $mover = $null
+    if ($present.Count) {
+        foreach ($client in @(
+                @{ Reader = 'Get-InstalledPSResource'; Mover = 'Update-PSResource' }
+                @{ Reader = 'Get-InstalledModule';     Mover = 'Update-Module' }
+            )) {
+            if (-not (Get-Command $client.Reader -ErrorAction SilentlyContinue)) { continue }
+
+            # PSResourceGet lists every installed version, not just the newest.
+            $receipts = @(& $client.Reader -Name $Name -ErrorAction SilentlyContinue)
+            if (-not $receipts.Count) { continue }
             $receipted = $true
-            $raw = "$($receipt.Version)" -replace '-.*$', ''
-            $parsed = $null
-            $updatable = [bool] ($raw -and [version]::TryParse($raw, [ref] $parsed) -and $parsed -eq $installed)
+
+            foreach ($receipt in $receipts) {
+                $raw = "$($receipt.Version)" -replace '-.*$', ''
+                $parsed = $null
+                if ($raw -and [version]::TryParse($raw, [ref] $parsed) -and $parsed -eq $installed) {
+                    $updatable = $true
+                    $mover = $client.Mover
+                    break
+                }
+            }
+            if ($mover) { break }
         }
     }
 
@@ -111,6 +131,7 @@ function Get-GalleryModuleStatus {
         Available   = $available
         Receipted   = $receipted
         Updatable   = $updatable
+        Mover       = $mover
         NeedsUpdate = [bool] ($installed -and $available -and $available -gt $installed)
     }
 }

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -497,30 +497,41 @@
                 $status = Get-GalleryModuleStatus -Name 'UpdateEverything'
 
                 if (-not $status.Installed) {
-                    Write-Output "UpdateEverything is running from a copy that is not under a module path, so Update-Module has nothing to move. Install-Module UpdateEverything -Force installs the gallery copy."
+                    Write-Output "UpdateEverything is running from a copy that is not under a module path, so an update command has nothing to move. Install-Module UpdateEverything -Force installs the gallery copy."
                 } elseif (-not $status.Available) {
                     Write-Output "UpdateEverything $($status.Installed) is installed; the gallery could not be asked about it."
                 } elseif ($status.Receipted -and -not $status.Updatable) {
                     # A gallery-installed copy is present but older than the copy
-                    # running now, which the gallery did not install. Update-Module
-                    # would move the older lineage, not this one.
+                    # running now, which the gallery did not install. The receipted
+                    # update would move the older lineage, not this one.
                     Write-Output "UpdateEverything $($status.Installed) is running from a copy the gallery did not install; the gallery-installed copy beside it is older. Use -UpdateSelfSource Main, or Install-Module UpdateEverything -Force to move to the gallery copy."
                 } elseif (-not $status.Updatable) {
                     # No PowerShellGet receipt at all -- the GitHub installer put it
                     # there, so Update-Module refuses it. -UpdateSelfSource Main is
                     # the matching path.
-                    Write-Output "UpdateEverything $($status.Installed) was not installed from the gallery, so Update-Module cannot move it. The published version is $($status.Available)."
+                    Write-Output "UpdateEverything $($status.Installed) was not installed from the gallery, so no update command can move it. The published version is $($status.Available)."
                     Write-Output 'Use -UpdateSelfSource Main to track the branch it came from, or Install-Module UpdateEverything -Force to switch to the gallery copy.'
                 } elseif (-not $status.NeedsUpdate) {
                     Write-Output "UpdateEverything $($status.Installed) is the newest published release."
                 } else {
                     Write-Output "UpdateEverything $($status.Installed) -> $($status.Available)..."
                     try {
-                        Update-Module -Name 'UpdateEverything' -Force -Confirm:$false -ErrorAction Stop
+                        if ($status.Mover -eq 'Update-PSResource') {
+                            # -Scope defaults to CurrentUser by documented design,
+                            # so a per-user lineage moves without elevation.
+                            Update-PSResource -Name 'UpdateEverything' -TrustRepository -Confirm:$false -ErrorAction Stop
+                        } else {
+                            Update-Module -Name 'UpdateEverything' -Force -Confirm:$false -ErrorAction Stop
+                        }
                         Write-Output 'Updated. The new version loads on the next run; this one continues on the code already in memory.'
                     } catch {
-                        if ("$_" -match 'Administrator rights|elevated') {
-                            Write-Output 'UpdateEverything is installed for all users, so updating it needs Administrator rights. Run "Update-Module UpdateEverything -Force" from an elevated PowerShell.'
+                        if ("$_" -match 'Administrator rights|elevated|is denied') {
+                            $how = if ($status.Mover -eq 'Update-PSResource') {
+                                'Update-PSResource UpdateEverything -Scope AllUsers'
+                            } else {
+                                'Update-Module UpdateEverything -Force'
+                            }
+                            Write-Output "UpdateEverything is installed for all users, so updating it needs Administrator rights. Run `"$how`" from an elevated PowerShell."
                         } else {
                             throw
                         }
@@ -933,7 +944,7 @@
             }
 
             $what = if ($status.Receipted) {
-                "$name $($status.Installed) has a gallery receipt for an older version, so Update-Module would move that older copy rather than the one running. Installing $($status.Available) fresh is the way forward"
+                "$name $($status.Installed) has a gallery receipt for an older version, so the receipted update would move that older copy rather than the one running. Installing $($status.Available) fresh is the way forward"
             } elseif ($status.Installed) {
                 "$name $($status.Installed) is the copy this PowerShell shipped with, which cannot be updated in place. Installing $($status.Available) alongside it is the only way forward"
             } else {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1392,9 +1392,12 @@ Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
     # through Install-Module is not something a test should depend on.
     It 'reports Updatable when the receipt covers the newest installed copy' {
         Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { }
         Mock Get-InstalledModule { [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion } }
 
-        (Get-GalleryModuleStatus -Name Pester).Updatable | Should-BeTrue
+        $status = Get-GalleryModuleStatus -Name Pester
+        $status.Updatable | Should-BeTrue
+        $status.Mover     | Should-Be 'Update-Module'
     }
 
     # A receipt can name an older version than the newest copy on disk: a
@@ -1402,6 +1405,7 @@ Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
     # newest copy is then not the one Update-Module moves.
     It 'does not call the newest copy updatable on an older receipt' {
         Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { }
         Mock Get-InstalledModule { [pscustomobject]@{ Name = 'Pester'; Version = [version] '0.0.1' } }
 
         (Get-GalleryModuleStatus -Name Pester).Updatable | Should-BeFalse
@@ -1409,6 +1413,7 @@ Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
 
     It 'reports a copy the host shipped as not updatable' {
         Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { }
         Mock Get-InstalledModule { }
 
         (Get-GalleryModuleStatus -Name Pester).Updatable | Should-BeFalse
@@ -1419,11 +1424,66 @@ Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
     # a shipped PowerShellGet 1.0.0.1 and failed the step.
     It 'still reports NeedsUpdate for a shipped copy the gallery is ahead of' {
         Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { }
         Mock Get-InstalledModule { }
 
         $status = Get-GalleryModuleStatus -Name Pester
         $status.NeedsUpdate | Should-BeTrue
         $status.Updatable   | Should-BeFalse
+    }
+
+    # PSResourceGet ships in the box with PowerShell 7.4 and its receipts are
+    # invisible to Get-InstalledModule -- measured on a real machine, 16
+    # receipts against 2. A copy installed with Install-PSResource counts as a
+    # gallery install, moved by Update-PSResource.
+    It 'reads a PSResourceGet receipt that PowerShellGet cannot see' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion } }
+        Mock Get-InstalledModule { }
+
+        $status = Get-GalleryModuleStatus -Name Pester
+        $status.Receipted | Should-BeTrue
+        $status.Updatable | Should-BeTrue
+        $status.Mover     | Should-Be 'Update-PSResource'
+    }
+
+    # Get-InstalledPSResource lists every installed version. Any of them
+    # covering the newest copy is enough, whatever order they arrive in.
+    It 'accepts any receipted version that covers the newest copy' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource {
+            [pscustomobject]@{ Name = 'Pester'; Version = [version] '0.0.1' }
+            [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion }
+        }
+        Mock Get-InstalledModule { }
+
+        (Get-GalleryModuleStatus -Name Pester).Updatable | Should-BeTrue
+    }
+
+    It 'falls back to the PowerShellGet receipt when only it covers the newest copy' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { [pscustomobject]@{ Name = 'Pester'; Version = [version] '0.0.1' } }
+        Mock Get-InstalledModule { [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion } }
+
+        $status = Get-GalleryModuleStatus -Name Pester
+        $status.Updatable | Should-BeTrue
+        $status.Mover     | Should-Be 'Update-Module'
+    }
+
+    It 'prefers the PSResourceGet client when both receipts cover' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion } }
+        Mock Get-InstalledModule { [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion } }
+
+        (Get-GalleryModuleStatus -Name Pester).Mover | Should-Be 'Update-PSResource'
+    }
+
+    It 'names no mover for a copy nothing receipted' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { }
+        Mock Get-InstalledModule { }
+
+        (Get-GalleryModuleStatus -Name Pester).Mover | Should-BeNull
     }
 
     It 'reports a module that is not installed as not updatable' {
@@ -2008,6 +2068,18 @@ Describe 'Updating the module itself' -Tag 'Static' {
     It 'says an update lands on the next run, on both paths' {
         $onNextRun = [regex]::Matches($script:SelfSource, 'loads on the next run')
         $onNextRun.Count | Should-BeGreaterThanOrEqual 2
+    }
+
+    # A copy installed with Install-PSResource has no PowerShellGet receipt,
+    # and Update-Module refuses it. The status names the client whose receipt
+    # covers the copy, and the step runs that one.
+    It 'runs the client whose receipt covers the copy' {
+        $script:SelfSource | Should-MatchString "if \(\`$status\.Mover -eq 'Update-PSResource'\)"
+        $script:SelfSource | Should-MatchString "Update-PSResource -Name 'UpdateEverything'"
+    }
+
+    It 'names the elevated command for the client that refused' {
+        $script:SelfSource | Should-MatchString ([regex]::Escape('Update-PSResource UpdateEverything -Scope AllUsers'))
     }
 }
 


### PR DESCRIPTION
Closes #97.

`Get-GalleryModuleStatus` answered Receipted and Updatable from `Get-InstalledModule` alone. PSResourceGet ships in the box with PowerShell 7.4, its documentation leads with `Install-PSResource`, and its receipts are invisible to `Get-InstalledModule` — measured on the development machine, 16 receipts against 2. A copy installed with the current gallery client was told it did not come from the gallery, and `-UpdateSelf` ran `Update-Module`, which cannot move it.

- The status consults both clients, PSResourceGet first (it reads PowerShellGet's receipts as well as its own), and gains **Mover**: the `Update-*` command whose receipt covers the newest installed copy.
- The self step runs that client — `Update-PSResource -TrustRepository` (CurrentUser default scope keeps the no-elevation promise) or `Update-Module` as before — and the elevation refusal names the matching command (`-Scope AllUsers` for PSResourceGet).
- Messages that said Update-Module by name now say what is true of either client.
- Existing receipt tests mock both readers, since the real `Get-InstalledPSResource` answers for Pester on any machine that installed it; seven new tests pin the two-store semantics.

Verified live on the mixed machine this was found on: Installed 1.4.1 (GitHub), receipts to 1.4.0 (gallery) → Receipted, not Updatable, no mover — routing to the mixed-lineage guidance exactly as before.

791 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
