### PR TITLE
Move a machine from the Store PowerShell 7 to the MSI, in one script

### DIFF
--- a/Convert-PowerShell7ToMsi.ps1
+++ b/Convert-PowerShell7ToMsi.ps1
@@ -1,0 +1,356 @@
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Moves this machine's PowerShell 7 from the Store (MSIX) package to the MSI
+    install, from Windows PowerShell.
+
+.DESCRIPTION
+    The Store package is the install everything else has to work around: a
+    packaged pwsh cannot run elevated at all, its install path carries the
+    version and stops existing at the next update, and its execution alias is
+    a zero-byte reparse point Task Scheduler cannot launch. The MSI has none
+    of those problems, and winget has defaulted new PowerShell installs to the
+    MSIX package since 7.6, so machines arrive in this state without anyone
+    choosing it.
+
+    Run it from Windows PowerShell, which is never packaged:
+
+        $mover = Join-Path $env:TEMP 'Convert-PowerShell7ToMsi.ps1'
+        Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Convert-PowerShell7ToMsi.ps1 -OutFile $mover -UseBasicParsing
+        Unblock-File $mover
+        powershell -NoProfile -ExecutionPolicy Bypass -File $mover
+
+    What it does, in order:
+
+      1. Installs the current MSI release straight from
+         github.com/PowerShell/PowerShell when no MSI install is present --
+         not through winget, whose Microsoft.PowerShell package is the MSIX
+         being removed -- and verifies the installed pwsh answers.
+      2. Removes the Store package, and its provisioning where one exists, so
+         Windows does not hand the package back to the next new user. This
+         happens only after the MSI answered.
+      3. Points the Windows Terminal default profile at the MSI install's
+         profile when the previous default is about to disappear with the
+         package. A default that was already Windows PowerShell, cmd, or a
+         profile that survives is left alone.
+      4. Reports what carries over on its own: profiles, per-user modules and
+         PSReadLine history live under Documents\PowerShell and APPDATA, which
+         both installs share, so there is nothing to move. The one thing that
+         cannot carry is an all-users profile inside the package, which the
+         package's read-only install directory prevented anyone from writing.
+      5. Lists scheduled tasks whose actions run a WindowsApps pwsh. They break
+         whenever the Store package updates or leaves, so they need
+         re-registering against the MSI path -- listed, never edited.
+
+    Everything destructive happens after one summary and one question.
+    -ReportOnly stops before it; -Force skips the question.
+
+.PARAMETER ReportOnly
+    Discover and report, change nothing. Needs no elevation.
+
+.PARAMETER Force
+    Skip the confirmation question. The summary still prints.
+
+.PARAMETER SkipTerminalDefault
+    Leave Windows Terminal's settings.json untouched whatever the default
+    profile points at.
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\Convert-PowerShell7ToMsi.ps1 -ReportOnly
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\Convert-PowerShell7ToMsi.ps1
+
+.OUTPUTS
+    Progress and a report. Exits 1 when a step it committed to fails.
+#>
+
+[CmdletBinding()]
+param(
+    [switch] $ReportOnly,
+    [switch] $Force,
+    [switch] $SkipTerminalDefault
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Well-known Windows Terminal profile GUIDs: the V5 UUIDs its generators assign.
+# MsiPwsh is the profile for a %ProgramFiles%\PowerShell install; the other two
+# are defaults a person may have chosen on purpose, which removal cannot break.
+$script:MsiPwshProfile   = '{574e775e-4f2a-5b96-ac1e-a2962a402336}'
+$script:SurvivingDefault = @(
+    $script:MsiPwshProfile
+    '{61c54bbd-c2c6-5271-96e7-009a87ff44bf}'   # Windows PowerShell
+    '{0caa0dad-35be-5f56-a8ff-afceeeaa6101}'   # cmd
+)
+
+function Test-PackagedHost {
+    # The Store package cannot remove the process it is hosting, and a packaged
+    # pwsh cannot elevate. Windows PowerShell is never packaged, so it is the
+    # host this script asks for.
+    $processPath = (Get-Process -Id $PID).Path
+    if (-not $processPath) { return $false }
+    foreach ($root in @("$env:ProgramFiles\WindowsApps", "$env:LOCALAPPDATA\Microsoft\WindowsApps")) {
+        if ($processPath -like (Join-Path $root '*')) { return $true }
+    }
+    $false
+}
+
+function Get-MsiPwsh {
+    $path = Join-Path $env:ProgramFiles 'PowerShell\7\pwsh.exe'
+    if (Test-Path -LiteralPath $path) { return $path }
+    $null
+}
+
+function Get-StorePackage {
+    # Stable only. The Preview package is a deliberate side-by-side install and
+    # is reported, not migrated.
+    @(Get-AppxPackage -Name 'Microsoft.PowerShell' -ErrorAction SilentlyContinue)
+}
+
+function Get-WindowsAppsTask {
+    # Read-only: a task that runs a WindowsApps pwsh breaks when the package
+    # moves or leaves, and the fix is re-registering it, not editing XML behind
+    # Task Scheduler's back.
+    $found = @()
+    try {
+        foreach ($task in @(Get-ScheduledTask -ErrorAction Stop)) {
+            foreach ($action in @($task.Actions)) {
+                $command = "$($action.Execute) $($action.Arguments)"
+                if ($command -match 'WindowsApps\\.*pwsh' -or $command -match 'WindowsApps\\Microsoft\.PowerShell') {
+                    $found += ('{0}{1}' -f $task.TaskPath, $task.TaskName)
+                    break
+                }
+            }
+        }
+    } catch {
+        Write-Verbose "Could not enumerate scheduled tasks: $($_.Exception.Message)"
+    }
+    $found
+}
+
+function Install-MsiPwsh {
+    # Straight from the PowerShell release, not winget: winget's
+    # Microsoft.PowerShell has installed the MSIX package by default since 7.6,
+    # which is the install this script exists to remove.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+    $arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+        'ARM64' { 'arm64' }
+        'x86'   { 'x86' }
+        default { 'x64' }
+    }
+
+    Write-Host "Asking github.com/PowerShell/PowerShell for the current release..."
+    $release = Invoke-RestMethod -Uri 'https://api.github.com/repos/PowerShell/PowerShell/releases/latest' -UseBasicParsing
+    $asset = @($release.assets | Where-Object { $_.name -like "PowerShell-*-win-$arch.msi" })[0]
+    if (-not $asset) {
+        throw "The current release ($($release.tag_name)) carries no win-$arch MSI."
+    }
+
+    $msi = Join-Path $env:TEMP $asset.name
+    Write-Host "Downloading $($asset.name)..."
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $msi -UseBasicParsing
+
+    try {
+        Write-Host 'Installing (msiexec, quiet)...'
+        $process = Start-Process msiexec.exe -ArgumentList '/i', "`"$msi`"", '/qn', '/norestart' -Wait -PassThru
+        # 3010 is success with a reboot pending, which the MSI can report when a
+        # file it carries was in use.
+        if ($process.ExitCode -notin 0, 3010) {
+            throw "msiexec exited with $($process.ExitCode)."
+        }
+        if ($process.ExitCode -eq 3010) {
+            Write-Host 'The installer asked for a restart to finish replacing a file in use.' -ForegroundColor DarkYellow
+        }
+    } finally {
+        Remove-Item -LiteralPath $msi -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Set-TerminalDefaultToMsi {
+    # The same care Set-PwshAsWindowsTerminalDefault in the UpdateEverything
+    # module takes, reduced to this one edit: back the file up, make exactly
+    # one defaultProfile change, refuse anything surprising.
+    $settingsPath = Join-Path $env:LOCALAPPDATA 'Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json'
+    if (-not (Test-Path -LiteralPath $settingsPath)) {
+        Write-Host 'Windows Terminal settings.json not found; nothing to point at the MSI profile.'
+        return
+    }
+
+    $raw = Get-Content -Raw -LiteralPath $settingsPath
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        Write-Warning 'settings.json is empty; leaving it alone.'
+        return
+    }
+
+    $current = ''
+    if ($raw -match '"defaultProfile"\s*:\s*"([^"]*)"') { $current = $Matches[1] }
+
+    if ($script:SurvivingDefault -contains $current) {
+        Write-Host "Windows Terminal default profile survives the migration ($current); leaving it."
+        return
+    }
+    # A default declared with its own block in the file is a profile the person
+    # made or pinned. If its command line is not a WindowsApps pwsh it survives
+    # too, and the choice stands.
+    if ($current -and $raw -match ('"guid"\s*:\s*"' + [regex]::Escape($current) + '"') -and
+        $raw -notmatch 'WindowsApps[^"]*pwsh') {
+        Write-Host "Windows Terminal default profile is one declared in settings.json ($current); leaving it."
+        return
+    }
+
+    if (Get-Process -Name 'WindowsTerminal', 'WindowsTerminalPreview' -ErrorAction SilentlyContinue) {
+        Write-Warning 'Windows Terminal is running. It rewrites settings.json on exit and may revert this change; close it and re-run if the default does not stick.'
+    }
+
+    $backup = Join-Path $env:TEMP ("WindowsTerminal-settings-{0:yyyyMMdd-HHmmss}.json.bak" -f (Get-Date))
+    Copy-Item -LiteralPath $settingsPath -Destination $backup -Force
+    Write-Host "Backed up settings.json -> $backup"
+
+    $newKv = '"defaultProfile": "' + $script:MsiPwshProfile + '"'
+    $pattern = '"defaultProfile"\s*:\s*"[^"]*"'
+    if ($raw -match $pattern) {
+        $updated = [regex]::Replace($raw, $pattern, [System.Text.RegularExpressions.MatchEvaluator]{ param($m) $newKv })
+    } else {
+        $updated = [regex]::Replace($raw, '\A(\s*\{)', [System.Text.RegularExpressions.MatchEvaluator]{ param($m) $m.Groups[1].Value + "`r`n    $newKv," })
+    }
+
+    $keyCount = ([regex]::Matches($updated, '"defaultProfile"\s*:')).Count
+    if ($keyCount -ne 1) {
+        Write-Warning "The edit would leave $keyCount defaultProfile keys; leaving settings.json alone. The backup is at $backup."
+        return
+    }
+
+    [System.IO.File]::WriteAllText($settingsPath, $updated, [System.Text.UTF8Encoding]::new($false))
+    Write-Host "Windows Terminal default profile now names the MSI install ($script:MsiPwshProfile)."
+}
+
+try {
+    if ($PSVersionTable.PSEdition -ne 'Desktop' -or (Test-PackagedHost)) {
+        throw ('Run this from Windows PowerShell (powershell.exe), which is never packaged: ' +
+            'a packaged host cannot elevate, and the Store pwsh cannot remove the package running it.')
+    }
+
+    # ------------------------------------------------------------------ state
+    $msiPwsh  = Get-MsiPwsh
+    $store    = Get-StorePackage
+    $preview  = @(Get-AppxPackage -Name 'Microsoft.PowerShellPreview' -ErrorAction SilentlyContinue)
+    $tasks    = Get-WindowsAppsTask
+    $profiles = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'PowerShell'
+
+    Write-Host ''
+    Write-Host 'PowerShell 7: Store package -> MSI install' -ForegroundColor Cyan
+    Write-Host ''
+    if ($msiPwsh) {
+        $msiVersion = & $msiPwsh -NoProfile -NoLogo -Command '$PSVersionTable.PSVersion.ToString()'
+        Write-Host "  MSI install       : present, $msiVersion ($msiPwsh)"
+    } else {
+        Write-Host '  MSI install       : absent -- will be installed from the PowerShell release'
+    }
+    if ($store.Count) {
+        Write-Host "  Store package     : $($store[0].Version) -- will be removed"
+    } else {
+        Write-Host '  Store package     : absent'
+    }
+    if ($preview.Count) {
+        Write-Host "  Preview package   : $($preview[0].Version) -- a side-by-side install; left alone" -ForegroundColor DarkYellow
+    }
+    if (Test-Path -LiteralPath $profiles) {
+        Write-Host "  Profiles, modules : $profiles -- shared by both installs; nothing to move"
+    } else {
+        Write-Host '  Profiles, modules : none found under Documents\PowerShell; nothing to move'
+    }
+    Write-Host '  Command history   : APPDATA\Microsoft\Windows\PowerShell\PSReadLine -- shared; nothing to move'
+    if ($tasks.Count) {
+        Write-Host ''
+        Write-Host '  Scheduled tasks running a WindowsApps pwsh (re-register these against the MSI path):' -ForegroundColor Yellow
+        foreach ($task in $tasks) { Write-Host "    $task" }
+    }
+    Write-Host ''
+
+    if (-not $msiPwsh -and -not $store.Count) {
+        Write-Host 'No PowerShell 7 found at all. Install the MSI with this script or from aka.ms/powershell; there is nothing to migrate.'
+        return
+    }
+    if ($msiPwsh -and -not $store.Count) {
+        Write-Host 'Already on the MSI install with no Store package. Nothing to do.' -ForegroundColor Green
+        return
+    }
+
+    if ($ReportOnly) {
+        Write-Host 'Report only; nothing was changed.' -ForegroundColor DarkGray
+        return
+    }
+
+    # ------------------------------------------------------------- elevation
+    $identity = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+    if (-not $identity.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        Write-Host 'Elevation is needed to install the MSI and remove the package provisioning. Asking...' -ForegroundColor DarkGray
+        $forward = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$PSCommandPath`"")
+        if ($Force)               { $forward += '-Force' }
+        if ($SkipTerminalDefault) { $forward += '-SkipTerminalDefault' }
+        $child = Start-Process powershell.exe -Verb RunAs -ArgumentList $forward -Wait -PassThru
+        exit $child.ExitCode
+    }
+
+    if (-not $Force) {
+        $answer = (Read-Host 'Proceed? [y/N]').Trim()
+        if ($answer -notmatch '^(y|yes)$') {
+            Write-Host 'Nothing was changed.'
+            return
+        }
+    }
+
+    # ------------------------------------------------------------------ MSI
+    if (-not $msiPwsh) {
+        Install-MsiPwsh
+        $msiPwsh = Get-MsiPwsh
+        if (-not $msiPwsh) { throw 'The MSI installed without error but pwsh.exe is not at the expected path.' }
+    }
+
+    # The verification the removal waits for: the MSI pwsh answers.
+    $msiVersion = & $msiPwsh -NoProfile -NoLogo -Command '$PSVersionTable.PSVersion.ToString()'
+    if ($LASTEXITCODE -ne 0 -or -not $msiVersion) {
+        throw 'The MSI pwsh did not answer; the Store package stays until it does.'
+    }
+    Write-Host "MSI PowerShell $msiVersion answers." -ForegroundColor Green
+
+    # ---------------------------------------------------------- Store removal
+    if ($store.Count) {
+        Write-Host 'Removing the Store package...'
+        $store | Remove-AppxPackage
+        try {
+            $provisioned = @(Get-AppxProvisionedPackage -Online -ErrorAction Stop |
+                Where-Object { $_.DisplayName -eq 'Microsoft.PowerShell' })
+            foreach ($package in $provisioned) {
+                $null = Remove-AppxProvisionedPackage -Online -PackageName $package.PackageName -ErrorAction Stop
+                Write-Host 'Removed the provisioning too, so new user accounts do not get the package back.'
+            }
+        } catch {
+            Write-Verbose "Provisioning check: $($_.Exception.Message)"
+        }
+        if (@(Get-StorePackage).Count) {
+            throw 'The Store package is still present after removal.'
+        }
+        Write-Host 'Store package removed.' -ForegroundColor Green
+    }
+
+    # ------------------------------------------------------ Terminal default
+    if (-not $SkipTerminalDefault) {
+        Set-TerminalDefaultToMsi
+    }
+
+    Write-Host ''
+    Write-Host 'Done. Open a new console for PATH to pick up the MSI install;' -ForegroundColor Green
+    Write-Host 'profiles, modules and history are where both installs read them.' -ForegroundColor Green
+    if ($tasks.Count) {
+        Write-Host "Re-register the $($tasks.Count) scheduled task(s) listed above against $msiPwsh." -ForegroundColor Yellow
+    }
+} catch {
+    # An explicit exit code, because what an uncaught throw returns under -File
+    # has differed between hosts.
+    Write-Error -ErrorAction Continue -Message "$_"
+    exit 1
+}

--- a/README.md
+++ b/README.md
@@ -493,6 +493,38 @@ Update, Defender signatures, the PowerShell 7 install, the Azure CLI) are
 reported as skipped
 rather than failing on permissions.
 
+## Moving off the Store PowerShell 7
+
+winget has installed PowerShell as a Store (MSIX) package by default since
+7.6, and that package is the install everything else works around: a packaged
+pwsh cannot run elevated at all, its install path carries the version and
+stops existing at the next update, and its execution alias is a zero-byte
+reparse point Task Scheduler cannot launch.
+
+`Convert-PowerShell7ToMsi.ps1` moves a machine to the MSI install in one
+attended run, from Windows PowerShell:
+
+```powershell
+$mover = Join-Path $env:TEMP 'Convert-PowerShell7ToMsi.ps1'
+Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Convert-PowerShell7ToMsi.ps1 -OutFile $mover -UseBasicParsing
+Unblock-File $mover
+powershell -NoProfile -ExecutionPolicy Bypass -File $mover
+```
+
+It installs the current MSI release straight from the PowerShell project --
+not through winget, which would hand back the package being removed --
+verifies the installed pwsh answers, and only then removes the Store package
+and its provisioning. Windows Terminal's default profile is pointed at the
+MSI install when the old default would disappear with the package, with the
+settings.json backup and validation this module's Terminal step uses.
+
+Nothing needs moving by hand: profiles, per-user modules and command history
+live under `Documents\PowerShell` and `%APPDATA%`, which both installs read.
+Scheduled tasks that run a `WindowsApps` pwsh are listed for re-registration
+against the MSI path rather than edited. `-ReportOnly` shows all of this and
+changes nothing; the real run asks once before acting, and `-Force` skips
+the question.
+
 ## Logs
 
 The module writes logs to the first writable location among `%USERPROFILE%`,
@@ -689,6 +721,7 @@ src/UpdateEverything.psm1     loader, dot-sources Public and Private
 src/Public/                   the five exported functions, one per file
 src/Private/                  internal helpers, one per file
 Install.ps1                   installs the module from a clone
+Convert-PowerShell7ToMsi.ps1  moves a machine from the Store PowerShell 7 to the MSI
 Publish.ps1                   validates and publishes to the PowerShell Gallery
 test.ps1                      test runner, used locally and by CI
 tests/                        Pester 6 suite

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -63,6 +63,7 @@ BeforeDiscovery {
     $LintTargets += (Join-Path $ModuleRoot 'UpdateEverything.psm1')
     $LintTargets += (Join-Path $RepoRoot 'test.ps1')
     $LintTargets += (Join-Path $RepoRoot 'Install.ps1')
+    $LintTargets += (Join-Path $RepoRoot 'Convert-PowerShell7ToMsi.ps1')
 
     # Everything under tests\: the test files, and the fresh-machine and
     # elevation harnesses. Pester runs *.Tests.ps1 and nothing runs the
@@ -811,6 +812,59 @@ Describe 'Nothing shows a parameter the command does not have' -Tag 'Docs' {
     # "how do I just run it", had no answer on screen.
     It 'tells a new user how to run everything' {
         ($printed -join "`n") | Should-MatchString '(?m)^\s*Update-Everything\s*$'
+    }
+}
+
+Describe 'The Store-to-MSI mover' -Tag 'Static' {
+
+    BeforeAll {
+        $script:MoverSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'Convert-PowerShell7ToMsi.ps1') -Raw
+    }
+
+    # The Store package cannot remove the process it is hosting, and a packaged
+    # pwsh cannot elevate.
+    It 'refuses to run from a packaged host' {
+        $script:MoverSource | Should-MatchString 'Test-PackagedHost'
+        $script:MoverSource | Should-MatchString ([regex]::Escape("PSEdition -ne 'Desktop'"))
+    }
+
+    # winget's Microsoft.PowerShell has installed the MSIX package by default
+    # since 7.6. Installing through it would hand back the thing being removed.
+    It 'installs from the PowerShell release, never through winget' {
+        $script:MoverSource | Should-MatchString 'repos/PowerShell/PowerShell/releases'
+        $script:MoverSource | Should-NotMatchString 'winget install'
+    }
+
+    It 'verifies the MSI answers before the package is removed' {
+        $verified = $script:MoverSource.IndexOf('did not answer; the Store package stays')
+        $removed  = $script:MoverSource.IndexOf('Remove-AppxPackage')
+
+        $verified | Should-BeGreaterThan -1
+        $removed  | Should-BeGreaterThan $verified
+    }
+
+    # 5.1 does not offer TLS 1.2 to every endpoint by default, and the GitHub
+    # API requires it.
+    It 'speaks TLS 1.2 before asking the release API' {
+        $script:MoverSource | Should-MatchString 'Tls12'
+    }
+
+    It 'backs settings.json up before pointing the default at the MSI profile' {
+        $backupAt = $script:MoverSource.IndexOf('Copy-Item -LiteralPath $settingsPath')
+        $writeAt  = $script:MoverSource.IndexOf('WriteAllText($settingsPath')
+
+        $backupAt | Should-BeGreaterThan -1
+        $writeAt  | Should-BeGreaterThan $backupAt
+    }
+
+    It 'reports scheduled tasks rather than editing them' {
+        $script:MoverSource | Should-NotMatchString 'Set-ScheduledTask'
+        $script:MoverSource | Should-NotMatchString 'Register-ScheduledTask'
+    }
+
+    It 'is documented in the README' {
+        $script:Readme | Should-MatchString 'Convert-PowerShell7ToMsi'
     }
 }
 


### PR DESCRIPTION
Closes #102. Requested directly: one attended script, run from Windows PowerShell 5.1, that does the whole migration.

- **Refuses packaged hosts**: the Store package cannot remove the process it is hosting, and a packaged pwsh cannot elevate — so it runs from `powershell.exe`, self-elevating once.
- **Installs the MSI from the PowerShell project's releases, never winget** — winget's `Microsoft.PowerShell` has installed the MSIX package by default since 7.6, which is the install being removed. Arch-matched, TLS 1.2 for 5.1, `msiexec /qn`, 3010 handled.
- **Verifies before removing**: the Store package (and its provisioning, so new users don't get it back) goes only after the MSI pwsh answers.
- **Customizations**: profiles, per-user modules and PSReadLine history are shared paths (`Documents\PowerShell`, `%APPDATA%`) — reported as carried, nothing copied. Windows Terminal's default is pointed at the MSI profile only when the old default would die with the package (known-surviving defaults and declared custom profiles are left alone), with backup and a one-key-only guard. Scheduled tasks running a `WindowsApps` pwsh are listed for re-registration, never edited.
- `-ReportOnly` changes nothing; the real run asks once; `-Force` skips the question; already-migrated machines exit clean.

Verified on the development machine: parses clean under 5.1.26100, analyzer clean, and `-ReportOnly` correctly reads its real mixed state (MSI 7.6.5 present, Store 7.6.5.0 present, profiles under a OneDrive-redirected Documents). Seven static tests pin the ordering and refusal invariants; the script joins the lint targets. README gains the section and the download-then-run command.

799 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
