### PR TITLE
Cover VS Code extensions and MiKTeX packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ thing that crosses a process boundary.
 more of:
 
 `Windows` `Microsoft` `PowerShell` `PackageManager` `Python` `Node` `DotNet`
-`Rust` `Go` `Cloud` `Git` `Self` `Inventory`
+`Rust` `Go` `Cloud` `Git` `Editor` `TeX` `Self` `Inventory`
 
 ```powershell
 Update-Everything -Tag Python
@@ -299,7 +299,7 @@ called out of date.
 quickest way to see why a run skipped what it skipped:
 
 ```
-12 of 24 tools present.
+12 of 26 tools present.
 
   winget           Unknown     v1.29.290
   PowerShell 7     Unknown     PowerShell 7.6.5
@@ -420,6 +420,8 @@ choose the packages; the manager's own inventory does.
 | Azure CLI | `az` | `az upgrade --yes --only-show-errors` | The CLI and its installed extensions. Reruns the MSI, so it needs administrator rights. Tagged `Cloud`: `-ExcludeTag Cloud` drops it on a metered or offline machine. |
 | Google Cloud CLI | `gcloud`, plus an ownership check | `gcloud components update --quiet` | Every installed component of the bundled install. A Chocolatey or Scoop gcloud disables its own component manager and is left to that manager. Tagged `Cloud`. |
 | GitHub CLI | `gh`, plus a non-empty `gh extension list` | `gh extension upgrade --all` | Installed `gh` extensions. That second check matters, because the upgrade command exits non-zero when nothing is installed. |
+| VS Code extensions | `code` | `code --update-extensions` | Installed VS Code extensions. The editor itself moves through winget, and an extension only auto-updates while the editor is open to see it -- so this covers the editor that is rarely opened, or has auto-update off. Tagged `Editor`. |
+| MiKTeX | `miktex` | `miktex packages update-package-database`, then `miktex packages update` | Installed TeX packages, in the mode matching the install: an all-users MiKTeX runs with `--admin` and needs an elevated session, a per-user one does not. The step runs exactly one mode, because MiKTeX warns when the two mix. Tagged `TeX`. |
 
 ### How it decides who owns a tool
 

--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -65,6 +65,8 @@ function Get-UpdateToolInventory {
             @{ Name = 'GitHub CLI';      Command = 'gh';      VersionArgument = '--version' }
             @{ Name = 'Azure CLI';       Command = 'az';      VersionArgument = $null }
             @{ Name = 'Google Cloud CLI'; Command = 'gcloud'; VersionArgument = $null }
+            @{ Name = 'VS Code';         Command = 'code';    VersionArgument = $null }
+            @{ Name = 'MiKTeX';          Command = 'miktex';  VersionArgument = '--version' }
             @{ Name = 'WSL';             Command = 'wsl';     VersionArgument = $null }
         )
     }
@@ -94,10 +96,11 @@ function Get-UpdateToolInventory {
             continue
         }
 
-        # Scoop and WSL are left without a version argument on purpose. scoop is
-        # a PowerShell shim whose --version runs a git describe against its own
-        # repository, and wsl --version writes UTF-16 that arrives as spaced-out
-        # characters. Neither is worth the seconds or the mess.
+        # The null version arguments are on purpose. scoop is a PowerShell shim
+        # whose --version runs a git describe against its own repository; wsl
+        # --version writes UTF-16 that arrives as spaced-out characters; az,
+        # gcloud and code each take seconds to answer. Presence is most of the
+        # value, and none of these are worth the wait or the mess.
         $version = $null
         if ($tool.VersionArgument) {
             try {

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -135,10 +135,10 @@
         # Passed straight through to the run this task performs, so one machine
         # can carry a daily task that skips a toolchain and a monthly one that
         # updates only that toolchain.
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Editor', 'TeX', 'Self', 'Inventory')]
         [string[]] $Tag = @(),
 
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Editor', 'TeX', 'Self', 'Inventory')]
         [string[]] $ExcludeTag = @(),
 
         [ValidateSet('Normal', 'Minimized', 'Hidden')]

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -245,9 +245,9 @@
         [switch] $Notify,
         [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Editor', 'TeX', 'Self', 'Inventory')]
         [string[]] $Tag = @(),
-        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Self', 'Inventory')]
+        [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Editor', 'TeX', 'Self', 'Inventory')]
         [string[]] $ExcludeTag = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30,
@@ -1404,6 +1404,14 @@
         gh extension upgrade --all
     }
 
+    Invoke-Step -Name 'VS Code extensions' -RequiresCommand 'code' -Tag 'Editor' -Action {
+        # The editor itself is winget's to move; this covers its extensions.
+        # extensions.autoUpdate defaults to true, but an extension only updates
+        # while the editor is open to see it -- so this step earns its keep on
+        # the editor that is rarely opened, or has auto-update turned off.
+        code --update-extensions
+    }
+
     # ---------------------------------------------------------------------------
     # 7b. Cloud CLIs
     # ---------------------------------------------------------------------------
@@ -1441,6 +1449,37 @@
                 Write-Error "gcloud components update failed with exit code $LASTEXITCODE. gcloud's own message is in this step's log."
                 $global:LASTEXITCODE = 0
             }
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # 7c. TeX
+    # ---------------------------------------------------------------------------
+    Invoke-Step -Name 'MiKTeX packages' -RequiresCommand 'miktex' -Tag 'TeX' -Action {
+        # MiKTeX runs per-user or for all users ("admin mode"), and mixing the
+        # two draws its own warning -- so the step runs exactly one mode, chosen
+        # by where the executable lives. An all-users install updates only from
+        # an elevated session.
+        $source = @(Get-Command miktex -CommandType Application -ErrorAction SilentlyContinue)[0].Source
+        $adminArgs = @()
+        if ($source -like (Join-Path $env:ProgramFiles '*')) {
+            if (-not $script:isAdmin) {
+                Stop-StepAsSkipped -Reason 'MiKTeX is installed for all users and needs an elevated session'
+            }
+            $adminArgs = @('--admin')
+        }
+
+        miktex @adminArgs packages update-package-database
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "miktex packages update-package-database failed with exit code $LASTEXITCODE. MiKTeX's own message is in this step's log."
+            $global:LASTEXITCODE = 0
+            return
+        }
+
+        miktex @adminArgs packages update
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "miktex packages update failed with exit code $LASTEXITCODE. MiKTeX's own message is in this step's log."
+            $global:LASTEXITCODE = 0
         }
     }
 

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2083,6 +2083,40 @@ Describe 'Updating the module itself' -Tag 'Static' {
     }
 }
 
+Describe 'The MiKTeX step' -Tag 'Static' {
+
+    BeforeAll {
+        $script:MikSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+        $script:MikStep = [regex]::Match($script:MikSource,
+            "(?s)Invoke-Step -Name 'MiKTeX packages'.*?\n    \}").Value
+    }
+
+    It 'exists and is tagged TeX' {
+        $script:MikStep | Should-MatchString "-Tag 'TeX'"
+    }
+
+    # MiKTeX warns when admin-mode and user-mode updates mix, so the step must
+    # pick exactly one mode from where the executable lives.
+    It 'runs admin mode only for an all-users install' {
+        $script:MikStep | Should-MatchString ([regex]::Escape('$env:ProgramFiles'))
+        $script:MikStep | Should-MatchString ([regex]::Escape("adminArgs = @('--admin')"))
+    }
+
+    It 'skips an all-users install in an unelevated session, rather than failing' {
+        $script:MikStep | Should-MatchString 'Stop-StepAsSkipped'
+        $script:MikStep | Should-MatchString 'needs an elevated session'
+    }
+
+    It 'updates the package database before the packages' {
+        $databaseAt = $script:MikStep.IndexOf('update-package-database')
+        $packagesAt = $script:MikStep.LastIndexOf('packages update')
+
+        $databaseAt | Should-BeGreaterThan -1
+        $packagesAt | Should-BeGreaterThan $databaseAt
+    }
+}
+
 Describe 'Get-DeveloperToolCatalogue' -Tag 'Unit' {
 
     BeforeAll { $script:Catalogue = @(Get-DeveloperToolCatalogue) }


### PR DESCRIPTION
Closes #98. Closes #99. Two updaters the run was missing, under two new tags.

- **VS Code extensions** (`Editor`): `code --update-extensions` exists now — the premise #74 recorded stopped being true — and costs one line. The editor itself is winget's to move; an extension only auto-updates while the editor is open to see it, so the step earns its keep on the editor that is rarely opened or has auto-update off.
- **MiKTeX packages** (`TeX`): `miktex packages update-package-database`, then `miktex packages update` (the modern CLI; `mpm` is deprecated). MiKTeX warns when admin-mode and user-mode updates mix, so the step runs exactly one mode, chosen by where the executable lives: an all-users install gets `--admin` and, unelevated, skips with the reason rather than failing.
- Inventory covers both (26 tools); the null-version comment now names all of its entries honestly. Four static tests pin the MiKTeX mode logic; the tag tests and wizard pick up `Editor`/`TeX` from the ValidateSet on their own.

Verified live: a `-Tag Editor,TeX` run selects exactly the two steps and both skip on their absent commands. 803 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
