### PR TITLE
Ship the Store-to-MSI mover inside the module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,11 +80,16 @@ weeks later. `Get-PowerShellHostPath` resolves a stable host instead.
 pre-run prompt is enabled, and says why. A prompt nobody can answer is a
 scheduled task that hangs until its execution time limit kills it.
 
-### Nothing in `src` calls `exit`
+### Nothing the loader dot-sources calls `exit`
 
 The module returns a result object. `exit` would end the session of whoever
-called it. A test walks the AST of every file and fails on any
-`ExitStatementAst`.
+called it. A test walks the AST of every file under `Public` and `Private`
+and fails on any `ExitStatementAst`.
+
+The one file in `src` outside those folders, `Convert-PowerShell7ToMsi.ps1`,
+does call `exit`, on purpose: it is a standalone script the module ships but
+never dot-sources, run only in its own process via `-File`, where an explicit
+exit code is the contract.
 
 Only the scheduled task turns that result into an exit code, because a process
 boundary is the one place where a number is all that can cross.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ other runs. Check with `Get-ExecutionPolicy -List`.
 | `Get-UpdateEverythingTask` | Reports every task that runs this module, or nothing if there are none |
 | `Unregister-UpdateEverythingTask` | Removes the task |
 | `Test-PendingReboot` | Reports whether Windows is waiting on a restart, and why |
+| `Convert-PowerShell7ToMsi` | Launches the shipped Store-to-MSI migration script under Windows PowerShell |
 
 `Update-All` is an alias for `Update-Everything`.
 
@@ -504,11 +505,15 @@ stops existing at the next update, and its execution alias is a zero-byte
 reparse point Task Scheduler cannot launch.
 
 `Convert-PowerShell7ToMsi.ps1` moves a machine to the MSI install in one
-attended run, from Windows PowerShell:
+attended run, from Windows PowerShell. It ships inside the module -- beside
+the manifest, in the versioned module folder -- so an installed module always
+has it on disk, `Convert-PowerShell7ToMsi` launches it from any session, and
+a run that finds the Store package prints the script's full path. On a
+machine without the module, fetch it straight from the repository:
 
 ```powershell
 $mover = Join-Path $env:TEMP 'Convert-PowerShell7ToMsi.ps1'
-Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/Convert-PowerShell7ToMsi.ps1 -OutFile $mover -UseBasicParsing
+Invoke-WebRequest https://raw.githubusercontent.com/briankronberg/UpdateEverything/main/src/Convert-PowerShell7ToMsi.ps1 -OutFile $mover -UseBasicParsing
 Unblock-File $mover
 powershell -NoProfile -ExecutionPolicy Bypass -File $mover
 ```
@@ -720,10 +725,10 @@ while the machine was off happens shortly after your next logon.
 ```
 src/UpdateEverything.psd1     module manifest
 src/UpdateEverything.psm1     loader, dot-sources Public and Private
-src/Public/                   the five exported functions, one per file
+src/Public/                   the exported functions, one per file
 src/Private/                  internal helpers, one per file
+src/Convert-PowerShell7ToMsi.ps1  the Store-to-MSI mover, shipped with the module
 Install.ps1                   installs the module from a clone
-Convert-PowerShell7ToMsi.ps1  moves a machine from the Store PowerShell 7 to the MSI
 Publish.ps1                   validates and publishes to the PowerShell Gallery
 test.ps1                      test runner, used locally and by CI
 tests/                        Pester 6 suite

--- a/src/Convert-PowerShell7ToMsi.ps1
+++ b/src/Convert-PowerShell7ToMsi.ps1
@@ -66,6 +66,9 @@
     Progress and a report. Exits 1 when a step it committed to fails.
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Host is the user interface of an attended console migration. Its output is a plan and a report a person reads and answers, not data a caller consumes.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'The script prints its plan and asks once before changing anything; -ReportOnly is the dry run, and the internal functions run only after that gate.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'False positive on the [MatchEvaluator] { param($m) ... } delegate, whose signature requires the parameter whether or not it is read.')]
 [CmdletBinding()]
 param(
     [switch] $ReportOnly,

--- a/src/Public/Convert-PowerShell7ToMsi.ps1
+++ b/src/Public/Convert-PowerShell7ToMsi.ps1
@@ -1,0 +1,55 @@
+﻿function Convert-PowerShell7ToMsi {
+    <#
+        .SYNOPSIS
+        Moves this machine's PowerShell 7 from the Store (MSIX) package to the
+        MSI install, by running the migration script the module ships.
+
+        .DESCRIPTION
+        The work lives in Convert-PowerShell7ToMsi.ps1 beside the module
+        manifest: a standalone script designed to run under Windows PowerShell
+        5.1, because a packaged pwsh can neither elevate nor remove the package
+        hosting it. This function is only the launcher -- it starts the script
+        under powershell.exe from whichever session called it and passes the
+        switches through. The script prints its plan, asks once before changing
+        anything, and elevates itself when the run needs it.
+
+        .PARAMETER ReportOnly
+        Discover and report, change nothing.
+
+        .PARAMETER Force
+        Skip the script's confirmation question. The plan still prints.
+
+        .PARAMETER SkipTerminalDefault
+        Leave Windows Terminal's settings.json untouched whatever the default
+        profile points at.
+
+        .EXAMPLE
+        Convert-PowerShell7ToMsi -ReportOnly
+
+        .EXAMPLE
+        Convert-PowerShell7ToMsi
+    #>
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [switch] $ReportOnly,
+        [switch] $Force,
+        [switch] $SkipTerminalDefault
+    )
+
+    $mover = Join-Path $script:ModuleRoot 'Convert-PowerShell7ToMsi.ps1'
+    if (-not (Test-Path -LiteralPath $mover)) {
+        throw "The migration script is not at $mover. Reinstall the module, or fetch the script from the repository README."
+    }
+
+    $arguments = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $mover)
+    if ($ReportOnly)          { $arguments += '-ReportOnly' }
+    if ($Force)               { $arguments += '-Force' }
+    if ($SkipTerminalDefault) { $arguments += '-SkipTerminalDefault' }
+
+    & powershell.exe @arguments
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "The migration script exited with code $LASTEXITCODE."
+        $global:LASTEXITCODE = 0
+    }
+}

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -1629,6 +1629,19 @@
         Write-Host "`n[OK] No pending reboots detected." -ForegroundColor Green
     }
 
+    # The Store package cannot run elevated, and anything that recorded its
+    # versioned path breaks when it updates. Moving off it is a one-time,
+    # attended migration, so the run recommends the shipped script rather than
+    # performing it. The package family alias directory is the cheap test: it
+    # exists per user exactly when the Store package is installed.
+    $storeAlias = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps\Microsoft.PowerShell_8wekyb3d8bbwe\pwsh.exe'
+    $mover = Join-Path $script:ModuleRoot 'Convert-PowerShell7ToMsi.ps1'
+    if ((Test-Path -LiteralPath $storeAlias) -and (Test-Path -LiteralPath $mover)) {
+        Write-Host "`n[!] PowerShell 7 here includes the Store package, which cannot run elevated and" -ForegroundColor Yellow
+        Write-Host '    breaks scheduled tasks when it updates. Move it to the MSI install with:' -ForegroundColor Yellow
+        Write-Host "      powershell -NoProfile -ExecutionPolicy Bypass -File `"$mover`"" -ForegroundColor Yellow
+    }
+
     if ($Notify) {
         $okCount      = @($Results | Where-Object { $_.Status -eq 'OK' }).Count
         $skippedCount = @($Results | Where-Object { $_.Status -eq 'Skipped' }).Count

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -22,6 +22,7 @@
         'Unregister-UpdateEverythingTask'
         'Get-UpdateEverythingTask'
         'Test-PendingReboot'
+        'Convert-PowerShell7ToMsi'
     )
     CmdletsToExport   = @()
     VariablesToExport = @()

--- a/tests/Gallery/Invoke-GalleryValidation.ps1
+++ b/tests/Gallery/Invoke-GalleryValidation.ps1
@@ -74,7 +74,7 @@ try {
 
     $manifest = Test-ModuleManifest -Path $manifestPath -ErrorAction SilentlyContinue
     Add-Check 'the manifest validates' ($null -ne $manifest) "version $($manifest.Version)"
-    Add-Check 'the manifest carries the six exports' ($manifest.ExportedFunctions.Count -eq 6) `
+    Add-Check 'the manifest carries the seven exports' ($manifest.ExportedFunctions.Count -eq 7) `
         "$($manifest.ExportedFunctions.Count) exported"
 
     Get-Module -Name UpdateEverything | Remove-Module -Force -ErrorAction SilentlyContinue

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -54,6 +54,7 @@ BeforeDiscovery {
         'Unregister-UpdateEverythingTask'
         'Get-UpdateEverythingTask'
         'Test-PendingReboot'
+        'Convert-PowerShell7ToMsi'
     )
 
     $HasAnalyzer = [bool] (Get-Module PSScriptAnalyzer -ListAvailable)
@@ -63,7 +64,7 @@ BeforeDiscovery {
     $LintTargets += (Join-Path $ModuleRoot 'UpdateEverything.psm1')
     $LintTargets += (Join-Path $RepoRoot 'test.ps1')
     $LintTargets += (Join-Path $RepoRoot 'Install.ps1')
-    $LintTargets += (Join-Path $RepoRoot 'Convert-PowerShell7ToMsi.ps1')
+    $LintTargets += (Join-Path $ModuleRoot 'Convert-PowerShell7ToMsi.ps1')
 
     # Everything under tests\: the test files, and the fresh-machine and
     # elevation harnesses. Pester runs *.Tests.ps1 and nothing runs the
@@ -819,7 +820,7 @@ Describe 'The Store-to-MSI mover' -Tag 'Static' {
 
     BeforeAll {
         $script:MoverSource = Get-Content `
-            (Join-Path (Split-Path $PSScriptRoot -Parent) 'Convert-PowerShell7ToMsi.ps1') -Raw
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Convert-PowerShell7ToMsi.ps1') -Raw
     }
 
     # The Store package cannot remove the process it is hosting, and a packaged
@@ -865,6 +866,27 @@ Describe 'The Store-to-MSI mover' -Tag 'Static' {
 
     It 'is documented in the README' {
         $script:Readme | Should-MatchString 'Convert-PowerShell7ToMsi'
+    }
+
+    # The script ships inside the module folder, so every install has it at a
+    # knowable path, and the run points at that path when the Store package is
+    # on the machine.
+    It 'is recommended by the run, with the full path, when the Store package is present' {
+        $main = Get-Content $script:MainPath -Raw
+
+        $main | Should-MatchString 'Microsoft\.PowerShell_8wekyb3d8bbwe'
+        $main | Should-MatchString ([regex]::Escape("Join-Path `$script:ModuleRoot 'Convert-PowerShell7ToMsi.ps1'"))
+        $main | Should-MatchString ([regex]::Escape('-File `"$mover`"'))
+    }
+
+    # The rule that nothing in the function folders calls exit stands; the
+    # script is not a function, is never dot-sourced by the loader, and runs
+    # only in its own process via -File, where the exit code is the contract.
+    It 'stays out of the folders the loader dot-sources' {
+        Test-Path (Join-Path $script:ModuleRoot 'Public\Convert-PowerShell7ToMsi.ps1') | Should-BeTrue
+        Test-Path (Join-Path $script:ModuleRoot 'Convert-PowerShell7ToMsi.ps1') | Should-BeTrue
+        $wrapper = Get-Content (Join-Path $script:ModuleRoot 'Public\Convert-PowerShell7ToMsi.ps1') -Raw
+        $wrapper | Should-NotMatchString 'Remove-AppxPackage'
     }
 }
 

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2083,6 +2083,39 @@ Describe 'Updating the module itself' -Tag 'Static' {
     }
 }
 
+Describe 'Convert-PowerShell7ToMsi (the launcher)' -Tag 'Unit' {
+
+    # The work lives in the shipped script, which must run under Windows
+    # PowerShell; the exported function only launches it. powershell.exe is a
+    # native executable, so a function of the same name intercepts the call.
+
+    It 'launches the shipped script under Windows PowerShell, switches forwarded' {
+        function powershell.exe { $script:MoverArgs = $args; $global:LASTEXITCODE = 0 }
+
+        Convert-PowerShell7ToMsi -ReportOnly -SkipTerminalDefault
+
+        "$script:MoverArgs" | Should-MatchString 'Convert-PowerShell7ToMsi\.ps1'
+        "$script:MoverArgs" | Should-MatchString '-ReportOnly'
+        "$script:MoverArgs" | Should-MatchString '-SkipTerminalDefault'
+        "$script:MoverArgs" | Should-NotMatchString '-Force'
+    }
+
+    It 'reports a nonzero exit as an error naming the code' {
+        function powershell.exe { $global:LASTEXITCODE = 7 }
+
+        $failures = @()
+        Convert-PowerShell7ToMsi -ReportOnly -ErrorAction SilentlyContinue -ErrorVariable failures
+
+        "$($failures -join ' ')" | Should-MatchString 'exited with code 7'
+    }
+
+    It 'throws when the shipped script is missing, naming the expected path' {
+        Mock Test-Path { $false }
+
+        { Convert-PowerShell7ToMsi } | Should-Throw -ExceptionMessage '*migration script is not at*'
+    }
+}
+
 Describe 'The MiKTeX step' -Tag 'Static' {
 
     BeforeAll {


### PR DESCRIPTION
Closes #106. Requested directly: ship the script with the module, keep it a separate 5.1-run `.ps1`, and have the run recommend it with the full path when the Store package is present.

- The script moves to `src\Convert-PowerShell7ToMsi.ps1`, so the gallery package and `Install.ps1` both carry it — every install has it on disk in the versioned module folder. It stays standalone: it must run under Windows PowerShell 5.1, while the module usually runs in 7.
- New exported **`Convert-PowerShell7ToMsi`** is only the launcher: it starts the shipped script under `powershell.exe`, forwarding `-ReportOnly`/`-Force`/`-SkipTerminalDefault`. Seven exports now; the gallery harness expects that.
- A run that finds the Store package (cheap per-user test: the package family alias directory) ends by recommending the migration with the script's **full on-disk path**.
- The no-exit rule now names its scope (the loader's `Public`/`Private`, exactly what the AST test walks) and the mover as the deliberate exception — it runs only in its own process via `-File`, where the exit code is the contract. The gallery-readiness default-rules pass required the same three suppressions the module files already carry, with the same justifications.

Verified live: `Convert-PowerShell7ToMsi -ReportOnly` runs the shipped script from a 7 session, and an inventory run on this machine ends with the recommendation and full path. 811 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
