### PR TITLE
Let the elevation harness choose which edition hands off

### DIFF
--- a/tests/Elevation/Invoke-ElevationTest.ps1
+++ b/tests/Elevation/Invoke-ElevationTest.ps1
@@ -38,6 +38,14 @@ param(
     [ValidateRange(1, 60)]
     [int] $TimeoutMinutes = 10,
 
+    # Which PowerShell hosts the unelevated payload. Invoke-SelfElevation
+    # prefers the same host when it relaunches elevated, so this chooses which
+    # edition's handoff the click exercises. powershell.exe is the default
+    # because it is always present; pwsh.exe covers the Windows Terminal case
+    # on a machine whose PowerShell 7 is the MSI install.
+    [ValidateSet('powershell.exe', 'pwsh.exe')]
+    [string] $HostExecutable = 'powershell.exe',
+
     [switch] $KeepOutput
 )
 
@@ -118,7 +126,7 @@ try {
         $usedTask = $true
         Write-Host '  this session is elevated, so dropping privileges through a scheduled task...' -ForegroundColor DarkGray
 
-        $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
+        $action = New-ScheduledTaskAction -Execute $HostExecutable `
             -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$payload`" -ResultPath `"$resultFile`""
         $principal = New-ScheduledTaskPrincipal `
             -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) `
@@ -129,7 +137,7 @@ try {
         Start-ScheduledTask -TaskName $taskName
     } else {
         Write-Host '  this session is not elevated, so running here directly...' -ForegroundColor DarkGray
-        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $payload -ResultPath $resultFile
+        & $HostExecutable -NoProfile -ExecutionPolicy Bypass -File $payload -ResultPath $resultFile
     }
 
     $deadline = (Get-Date).AddMinutes($TimeoutMinutes)


### PR DESCRIPTION
Closes #108.

`Invoke-ElevationTest.ps1` hardcoded `powershell.exe` as the unelevated payload host. `Invoke-SelfElevation` prefers the same host when it relaunches, so the one click always exercised the Windows PowerShell handoff and never the pwsh one — the everyday Windows Terminal case, and newly possible on a machine that moved off the MSIX package, where the elevated pwsh target did not exist.

`-HostExecutable` chooses: `powershell.exe` stays the default (always present); `pwsh.exe` covers the other edition.

Both handoffs verified attended on this machine today, each with every check passing and none not-covered: powershell.exe parent → elevated 5.1 child, and pwsh parent → elevated pwsh 7.6.5 child from the MSI install, confirmed by both transcripts' host lines.

811 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
