### PR TITLE
Prepare 1.7.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -589,7 +589,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.6.0 -m "1.6.0" && git push origin v1.6.0
+git tag -a v1.7.0 -m "1.7.0" && git push origin v1.7.0
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -281,13 +281,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.6.0
+UpdateEverything 1.7.0
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.6.0 is running, which is the newest published version.
+UpdateEverything 1.7.0 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.6.0'
+    ModuleVersion     = '1.7.0'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -33,59 +33,36 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.6.0
+            ReleaseNotes = '# 1.7.0
 
-Both gallery clients are read, two new steps arrive under two new tags, and
-the fixes that shipped on GitHub as 1.5.1.
+The Store-to-MSI migration ships in the box.
 
-## The self-update reads both gallery clients
+## Convert-PowerShell7ToMsi
 
-PSResourceGet ships in the box with PowerShell 7.4 and its receipts are
-invisible to Get-InstalledModule, so a copy installed with Install-PSResource
-was told it did not come from the gallery, and -UpdateSelf ran Update-Module,
-which cannot move it. The status now consults both clients and runs the one
-whose receipt covers the installed copy -- Update-PSResource, whose
-CurrentUser default keeps the no-elevation promise, or Update-Module as
-before. An all-users copy is reported as needing an elevated session, with
-the command that matches, and no UAC prompt is raised either way.
+The Store (MSIX) PowerShell 7 cannot run elevated, its versioned install
+path breaks anything that recorded it whenever it updates, and winget has
+installed it by default since 7.6 -- so machines arrive in that state
+without anyone choosing it.
 
--Tag Self now selects the self step; in 1.5.0 the tag alone ran nothing. A
-machine holding a receipted older version beside a newer copy without a
-receipt is told about the mixed lineage and the way out, rather than being
-called a copy that shipped with the host.
+The module now ships Convert-PowerShell7ToMsi.ps1 beside its manifest: a
+standalone script, run under Windows PowerShell 5.1 with one command,
+because a packaged pwsh can neither elevate nor remove the package hosting
+it. It installs the current MSI release straight from the PowerShell
+project -- not through winget, which would hand back the package being
+removed -- verifies the installed pwsh answers, and only then removes the
+Store package and its provisioning. Windows Terminal is pointed at the MSI
+profile when its old default would disappear with the package. Profiles,
+per-user modules and command history already live in paths both installs
+share, and the report says so instead of moving anything.
 
-## Two new steps
+The exported Convert-PowerShell7ToMsi command launches the script from any
+session, with -ReportOnly to see the plan and change nothing. A maintenance
+run that finds the Store package on the machine now ends by recommending
+the migration, with the full path to the shipped script.
 
-VS Code extensions runs "code --update-extensions" under the new Editor tag.
-The editor itself moves through winget; its extensions only auto-update
-while the editor is open to see them, so the step earns its keep on the
-editor that is rarely opened or has auto-update off.
-
-MiKTeX packages updates installed TeX packages under the new TeX tag,
-through the modern miktex CLI. MiKTeX warns when per-user and all-users
-updates mix, so the step runs exactly one mode, chosen by where the
-executable lives. An all-users install updates only from an elevated
-session, and is skipped with that reason otherwise.
-
-The inventory covers 26 tools.
-
-## The 1.5.1 fixes, new to the gallery
-
-Duplicate-tool detection compares directories case-insensitively again. The
-Python launcher probe runs from the system directory inside a try/catch, so
-a file named help in the working directory can no longer be executed by it.
-conda sits under the Python banner with the same ownership check as uv and
-pipx. A step whose tool is absent reports the absent tool rather than a need
-for Administrator when both are true, and skipped steps record their log
-path. The task wizard reads its tag list from the command it drives. A copy
-running from outside every module path is pointed at Install-Module.
-
-## Also in the repository
-
-Convert-PowerShell7ToMsi.ps1 moves a machine from the Store (MSIX)
-PowerShell 7 -- which cannot run elevated, and breaks anything that recorded
-its versioned path whenever it updates -- to the MSI install, in one
-attended run from Windows PowerShell. The README shows the command.
+Both self-elevation handoffs -- Windows PowerShell to an elevated 5.1, and
+pwsh to an elevated MSI pwsh -- were verified attended on a real machine
+with UAC on before this version shipped.
 '
 
         }


### PR DESCRIPTION
Release notes written against published 1.6.0: the Store-to-MSI migration ships in the box — the script beside the manifest, the exported `Convert-PowerShell7ToMsi` launcher, and the run-ending recommendation with the full path when the Store package is present. Both self-elevation handoffs verified attended before shipping. README samples and the CONTRIBUTING tag example move to 1.7.0.

811 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)