### PR TITLE
See the AllUsers receipt, and update the scope that holds it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,3 +124,17 @@ backlog. Issue #25 carries the roadmap and its dependency order.
 
 Close issues from the pull request body with `Closes #N`, so the record maintains
 itself.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked as GitHub issues on briankronberg/UpdateEverything via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five default labels, each string equal to its role name (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (this repo):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── 0002-another-decision.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -5,8 +5,10 @@ function Get-GalleryModuleStatus {
         the PowerShell Gallery.
 
         .DESCRIPTION
-        Returns Name, Installed, Available, Receipted, Updatable, Mover and
-        NeedsUpdate.
+        Returns Name, Installed, Available, Receipted, Updatable, Mover,
+        MoverScope and NeedsUpdate. MoverScope is the installation scope of the
+        covering receipt -- CurrentUser or AllUsers -- because Update-PSResource
+        must be told when the copy to move is the machine-wide one.
 
         Installed is $null when the module is absent. Absent means any install
         is a new install and needs consent; present but old means an update,
@@ -69,6 +71,7 @@ function Get-GalleryModuleStatus {
     $receipted = $false
     $updatable = $false
     $mover = $null
+    $moverScope = $null
     if ($present.Count) {
         foreach ($client in @(
                 @{ Reader = 'Get-InstalledPSResource'; Mover = 'Update-PSResource' }
@@ -76,19 +79,33 @@ function Get-GalleryModuleStatus {
             )) {
             if (-not (Get-Command $client.Reader -ErrorAction SilentlyContinue)) { continue }
 
-            # PSResourceGet lists every installed version, not just the newest.
+            # PSResourceGet lists every installed version, not just the newest
+            # -- and its bare call reads only the per-user paths, so the
+            # machine scope is asked separately or an AllUsers install reports
+            # no receipt at all. Get-InstalledModule takes no -Scope and reads
+            # every path in one call.
             $receipts = @(& $client.Reader -Name $Name -ErrorAction SilentlyContinue)
+            if ($client.Reader -eq 'Get-InstalledPSResource') {
+                $receipts += @(& $client.Reader -Name $Name -Scope AllUsers -ErrorAction SilentlyContinue)
+            }
             if (-not $receipts.Count) { continue }
             $receipted = $true
 
             foreach ($receipt in $receipts) {
                 $raw = "$($receipt.Version)" -replace '-.*$', ''
                 $parsed = $null
-                if ($raw -and [version]::TryParse($raw, [ref] $parsed) -and $parsed -eq $installed) {
-                    $updatable = $true
-                    $mover = $client.Mover
-                    break
-                }
+                if (-not ($raw -and [version]::TryParse($raw, [ref] $parsed) -and $parsed -eq $installed)) { continue }
+
+                $updatable = $true
+                $mover = $client.Mover
+
+                # The covering receipt says which scope the update must target.
+                # A per-user receipt wins when both scopes cover: that copy
+                # shadows the machine one in PSModulePath order, and moving it
+                # needs no elevation.
+                $scope = if ("$($receipt.InstalledLocation)" -like (Join-Path $env:ProgramFiles '*')) { 'AllUsers' } else { 'CurrentUser' }
+                if (-not $moverScope -or $scope -eq 'CurrentUser') { $moverScope = $scope }
+                if ($moverScope -eq 'CurrentUser') { break }
             }
             if ($mover) { break }
         }
@@ -132,6 +149,7 @@ function Get-GalleryModuleStatus {
         Receipted   = $receipted
         Updatable   = $updatable
         Mover       = $mover
+        MoverScope  = $moverScope
         NeedsUpdate = [bool] ($installed -and $available -and $available -gt $installed)
     }
 }

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -517,9 +517,19 @@
                     Write-Output "UpdateEverything $($status.Installed) -> $($status.Available)..."
                     try {
                         if ($status.Mover -eq 'Update-PSResource') {
-                            # -Scope defaults to CurrentUser by documented design,
-                            # so a per-user lineage moves without elevation.
-                            Update-PSResource -Name 'UpdateEverything' -TrustRepository -Confirm:$false -ErrorAction Stop
+                            if ($status.MoverScope -eq 'AllUsers' -and -not $script:isAdmin) {
+                                # Checked up front rather than caught, because
+                                # Update-PSResource would not refuse: its
+                                # CurrentUser default would quietly install the
+                                # new version per-user beside the all-users copy.
+                                Write-Output 'UpdateEverything is installed for all users, so updating it needs Administrator rights. Run "Update-PSResource UpdateEverything -Scope AllUsers" from an elevated PowerShell.'
+                                return
+                            }
+                            # A per-user lineage moves without elevation: -Scope
+                            # defaults to CurrentUser by documented design.
+                            $moveArgs = @{ Name = 'UpdateEverything'; TrustRepository = $true; Confirm = $false; ErrorAction = 'Stop' }
+                            if ($status.MoverScope -eq 'AllUsers') { $moveArgs.Scope = 'AllUsers' }
+                            Update-PSResource @moveArgs
                         } else {
                             Update-Module -Name 'UpdateEverything' -Force -Confirm:$false -ErrorAction Stop
                         }

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1486,6 +1486,40 @@ Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
         (Get-GalleryModuleStatus -Name Pester).Mover | Should-BeNull
     }
 
+    # Get-InstalledPSResource without -Scope reads only the per-user paths, so
+    # the machine scope is asked separately. Measured on a real machine: an
+    # AllUsers install had a receipt on disk and the bare call returned nothing.
+    It 'sees an AllUsers receipt the bare call misses' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { }
+        Mock Get-InstalledPSResource {
+            [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion; InstalledLocation = 'C:\Program Files\PowerShell\Modules' }
+        } -ParameterFilter { $Scope -eq 'AllUsers' }
+        Mock Get-InstalledModule { }
+
+        $status = Get-GalleryModuleStatus -Name Pester
+        $status.Receipted  | Should-BeTrue
+        $status.Updatable  | Should-BeTrue
+        $status.Mover      | Should-Be 'Update-PSResource'
+        $status.MoverScope | Should-Be 'AllUsers'
+    }
+
+    # A per-user copy shadows the machine one in PSModulePath order, and moving
+    # it needs no elevation -- so when receipts in both scopes cover, per-user
+    # is the scope the update targets.
+    It 'prefers the per-user scope when receipts in both scopes cover' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource {
+            [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion; InstalledLocation = 'C:\Users\someone\Documents\PowerShell\Modules' }
+        }
+        Mock Get-InstalledPSResource {
+            [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion; InstalledLocation = 'C:\Program Files\PowerShell\Modules' }
+        } -ParameterFilter { $Scope -eq 'AllUsers' }
+        Mock Get-InstalledModule { }
+
+        (Get-GalleryModuleStatus -Name Pester).MoverScope | Should-Be 'CurrentUser'
+    }
+
     It 'reports a module that is not installed as not updatable' {
         Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
 
@@ -2075,7 +2109,15 @@ Describe 'Updating the module itself' -Tag 'Static' {
     # covers the copy, and the step runs that one.
     It 'runs the client whose receipt covers the copy' {
         $script:SelfSource | Should-MatchString "if \(\`$status\.Mover -eq 'Update-PSResource'\)"
-        $script:SelfSource | Should-MatchString "Update-PSResource -Name 'UpdateEverything'"
+        $script:SelfSource | Should-MatchString ([regex]::Escape('Update-PSResource @moveArgs'))
+    }
+
+    # Update-PSResource would not refuse an unelevated call against an
+    # all-users copy -- its CurrentUser default would quietly side-install the
+    # new version per-user. The step checks up front instead.
+    It 'refuses to side-install per-user when the all-users copy needs elevation' {
+        $script:SelfSource | Should-MatchString "MoverScope -eq 'AllUsers' -and -not \`$script:isAdmin"
+        $script:SelfSource | Should-MatchString ([regex]::Escape("if (`$status.MoverScope -eq 'AllUsers') { `$moveArgs.Scope = 'AllUsers' }"))
     }
 
     It 'names the elevated command for the client that refused' {


### PR DESCRIPTION
Closes #111.

Found minutes after moving the development machine's install to `-Scope AllUsers`: the receipt was on disk and `Get-InstalledPSResource -Scope AllUsers` returned it, while the bare call `Get-GalleryModuleStatus` makes reads only the per-user paths and returned nothing. A receipted machine-wide gallery install reported `Receipted=False` — and once the gallery moved ahead, the self step would have called it a copy the gallery did not install.

- The status asks PSResourceGet both ways and reports **MoverScope**, the installation scope of the covering receipt. A per-user receipt wins when both scopes cover: that copy shadows the machine one in PSModulePath order and moves without elevation.
- The self step targets that scope: elevated, `Update-PSResource` gets `-Scope AllUsers`; unelevated, the step reports the elevation need **up front instead of calling at all** — `Update-PSResource` would not refuse, its CurrentUser default would quietly side-install the new version per-user beside the all-users copy.

Verified live on the machine it was found on: the same install that read `Receipted=False` now reads `Receipted, Updatable, Mover=Update-PSResource, MoverScope=AllUsers`. 815 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
