### PR TITLE
Prepare 1.7.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -530,15 +530,18 @@ Maintainers only, and not casually: the PowerShell Gallery has no delete, only
 unlist, which hides a version from search while leaving it installable by anyone
 who names it.
 
-### Only x.y.0 reaches the gallery
+### Minor versions reach the gallery; a patch only when it earns it
 
-Minor versions are published. Patch versions are not, and live on `main` for
-whoever wants them:
+Minor versions are published. Patch versions usually are not, and live on
+`main` for whoever wants them. The exception is a patch that changes what an
+installed copy does on its next run -- 1.7.1, whose fix decides where a
+self-update lands, set the precedent:
 
 | Version | Where |
 |---|---|
 | 1.2.0, 1.3.0, 1.4.0 | PowerShell Gallery, and GitHub |
 | 1.2.1, 1.2.2 | GitHub only |
+| 1.7.1 | PowerShell Gallery, and GitHub |
 
 Every gallery version is permanent -- unlist hides it from search and leaves it
 installable -- so each one is a commitment, and fewer of them means fewer to
@@ -589,7 +592,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.7.0 -m "1.7.0" && git push origin v1.7.0
+git tag -a v1.7.1 -m "1.7.1" && git push origin v1.7.1
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Requires PowerShell 5.1 or later on Windows 10 or a matching Server release.
 
 ### Install from GitHub
 
-**The gallery carries minor versions only** -- 1.2.0, 1.3.0, 1.4.0. A patch
-release such as 1.2.1 is published here and nowhere else, so this is the
-supported way to get a fix that has landed but is not in a minor release yet.
+**The gallery carries minor versions, and the occasional patch that earns
+it.** Most patch releases, such as 1.2.1, are published here and nowhere
+else, so this is the supported way to get a fix that has landed but is not
+in a gallery release yet.
 
 `main` also carries whatever is being worked on. Nothing but the URL is
 needed:
@@ -281,13 +282,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.7.0
+UpdateEverything 1.7.1
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.7.0 is running, which is the newest published version.
+UpdateEverything 1.7.1 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.7.0'
+    ModuleVersion     = '1.7.1'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -33,36 +33,27 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.7.0
+            ReleaseNotes = '# 1.7.1
 
-The Store-to-MSI migration ships in the box.
+One fix, for machines that install the module for all users.
 
-## Convert-PowerShell7ToMsi
+## The self-update sees the machine-wide receipt
 
-The Store (MSIX) PowerShell 7 cannot run elevated, its versioned install
-path breaks anything that recorded it whenever it updates, and winget has
-installed it by default since 7.6 -- so machines arrive in that state
-without anyone choosing it.
+Get-InstalledPSResource without -Scope reads only the per-user paths, so a
+copy installed with Install-PSResource -Scope AllUsers -- receipt on disk,
+returned by the AllUsers query -- reported no gallery lineage at all. Once
+the gallery moved ahead, the self step would have called it a copy the
+gallery did not install.
 
-The module now ships Convert-PowerShell7ToMsi.ps1 beside its manifest: a
-standalone script, run under Windows PowerShell 5.1 with one command,
-because a packaged pwsh can neither elevate nor remove the package hosting
-it. It installs the current MSI release straight from the PowerShell
-project -- not through winget, which would hand back the package being
-removed -- verifies the installed pwsh answers, and only then removes the
-Store package and its provisioning. Windows Terminal is pointed at the MSI
-profile when its old default would disappear with the package. Profiles,
-per-user modules and command history already live in paths both installs
-share, and the report says so instead of moving anything.
+The status now asks PSResourceGet both ways and carries the scope of the
+covering receipt. The self step targets that scope: elevated,
+Update-PSResource runs with -Scope AllUsers; unelevated, the step reports
+the elevation need up front instead of calling at all, because
+Update-PSResource would not refuse -- its CurrentUser default would quietly
+install the new version per-user beside the all-users copy.
 
-The exported Convert-PowerShell7ToMsi command launches the script from any
-session, with -ReportOnly to see the plan and change nothing. A maintenance
-run that finds the Store package on the machine now ends by recommending
-the migration, with the full path to the shipped script.
-
-Both self-elevation handoffs -- Windows PowerShell to an elevated 5.1, and
-pwsh to an elevated MSI pwsh -- were verified attended on a real machine
-with UAC on before this version shipped.
+A per-user receipt wins when both scopes cover: that copy shadows the
+machine one in PSModulePath order, and moving it needs no elevation.
 '
 
         }


### PR DESCRIPTION
Release notes written against published 1.7.0, for the one fix on main: the self-update now sees an AllUsers receipt and targets the scope that holds it. This patch changes what an installed copy does on its next self-update, which is why it goes to the gallery — the first patch to. The release policy in CONTRIBUTING and the README now say a patch can earn that, with 1.7.1 as the precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)