### PR TITLE
Fix what the two-axis review of v1.5.0..HEAD confirmed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,9 +354,11 @@ uninteresting: a cleanup that may find nothing, a probe of a key that may not
 exist. An empty `catch {}` is not. Every catch says what it swallowed via
 `Write-Verbose`, so `-Verbose` shows what was ignored.
 
-The standalone scripts — `Install.ps1`, `Publish.ps1`, `test.ps1` — do set
-`$ErrorActionPreference = 'Stop'` at the top. They own their session; the module
-does not.
+The standalone scripts — `Install.ps1`, `Publish.ps1`, `test.ps1`, and the
+shipped `src\Convert-PowerShell7ToMsi.ps1` — do set
+`$ErrorActionPreference = 'Stop'` at the top. Each owns its session: the mover
+runs only in its own process via `-File`, never dot-sourced by the loader. The
+module itself does not set it.
 
 Logging is the exception to all of it. A failure to write a log must never be
 the thing that kills a run, so `Write-StepLog` degrades to a warning rather than
@@ -515,8 +517,9 @@ longer exists. Assert both ways.
   trigger object's properties passed, because nothing handed that object to
   `Register-ScheduledTask`. Reach for this only when the failure is provably
   invisible from either side, and leave the test able to skip when it cannot run.
-- No new `exit` in `src`, no `$ErrorActionPreference` in `src`, no empty
-  `catch`.
+- No new `exit` and no `$ErrorActionPreference` in anything the loader
+  dot-sources. The shipped mover script sets and owns both, in its own
+  process. No empty `catch`.
 - Comments state facts about the code, not its history. The story of the change
   belongs in the commit message and the pull request, where it stays accurate.
 - Commit messages say what changed and why, in the imperative, with the evidence

--- a/src/Private/Format-SelfVersionStatus.ps1
+++ b/src/Private/Format-SelfVersionStatus.ps1
@@ -49,7 +49,14 @@ function Format-SelfVersionStatus {
         $how = if (-not $Status.Installed) {
             'This copy is running from outside a module path, so use "Install-Module UpdateEverything -Force" to install the gallery copy.'
         } elseif (-not $Status.Updatable) {
-            'This copy did not come from the gallery, so use "Install-Module UpdateEverything -Force", or -UpdateSelf -UpdateSelfSource Main to track the branch it came from.'
+            # The reinstall command should be the one this machine's receipts
+            # answer to; a PSResourceGet lineage reinstalls through
+            # Install-PSResource.
+            if ($Status.ReceiptedBy -eq 'PSResourceGet') {
+                'This copy is not the one the gallery receipts cover, so use "Install-PSResource UpdateEverything -Reinstall", or -UpdateSelf -UpdateSelfSource Main to track the branch it came from.'
+            } else {
+                'This copy did not come from the gallery, so use "Install-Module UpdateEverything -Force", or -UpdateSelf -UpdateSelfSource Main to track the branch it came from.'
+            }
         } else {
             'Run with -UpdateSelf to update it.'
         }

--- a/src/Private/Get-GalleryModuleStatus.ps1
+++ b/src/Private/Get-GalleryModuleStatus.ps1
@@ -5,8 +5,11 @@ function Get-GalleryModuleStatus {
         the PowerShell Gallery.
 
         .DESCRIPTION
-        Returns Name, Installed, Available, Receipted, Updatable, Mover,
-        MoverScope and NeedsUpdate. MoverScope is the installation scope of the
+        Returns Name, Installed, Available, Receipted, ReceiptedBy, Updatable,
+        Mover, MoverScope and NeedsUpdate. ReceiptedBy names the client whose
+        receipts exist -- PSResourceGet or PowerShellGet -- whether or not one
+        of them covers the newest copy, so advice can name the reinstall
+        command that lineage answers to. MoverScope is the installation scope of the
         covering receipt -- CurrentUser or AllUsers -- because Update-PSResource
         must be told when the copy to move is the machine-wide one.
 
@@ -69,13 +72,14 @@ function Get-GalleryModuleStatus {
     # as its own, so its answer exists more often, and Update-PSResource is
     # then the client that moves the copy.
     $receipted = $false
+    $receiptedBy = $null
     $updatable = $false
     $mover = $null
     $moverScope = $null
     if ($present.Count) {
         foreach ($client in @(
-                @{ Reader = 'Get-InstalledPSResource'; Mover = 'Update-PSResource' }
-                @{ Reader = 'Get-InstalledModule';     Mover = 'Update-Module' }
+                @{ Reader = 'Get-InstalledPSResource'; Mover = 'Update-PSResource'; Client = 'PSResourceGet' }
+                @{ Reader = 'Get-InstalledModule';     Mover = 'Update-Module';     Client = 'PowerShellGet' }
             )) {
             if (-not (Get-Command $client.Reader -ErrorAction SilentlyContinue)) { continue }
 
@@ -90,6 +94,7 @@ function Get-GalleryModuleStatus {
             }
             if (-not $receipts.Count) { continue }
             $receipted = $true
+            if (-not $receiptedBy) { $receiptedBy = $client.Client }
 
             foreach ($receipt in $receipts) {
                 $raw = "$($receipt.Version)" -replace '-.*$', ''
@@ -147,6 +152,7 @@ function Get-GalleryModuleStatus {
         Installed   = $installed
         Available   = $available
         Receipted   = $receipted
+        ReceiptedBy = $receiptedBy
         Updatable   = $updatable
         Mover       = $mover
         MoverScope  = $moverScope

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -527,7 +527,7 @@
                             }
                             # A per-user lineage moves without elevation: -Scope
                             # defaults to CurrentUser by documented design.
-                            $moveArgs = @{ Name = 'UpdateEverything'; TrustRepository = $true; Confirm = $false; ErrorAction = 'Stop' }
+                            $moveArgs = @{ Name = 'UpdateEverything'; TrustRepository = $true; AcceptLicense = $true; Confirm = $false; ErrorAction = 'Stop' }
                             if ($status.MoverScope -eq 'AllUsers') { $moveArgs.Scope = 'AllUsers' }
                             Update-PSResource @moveArgs
                         } else {
@@ -933,7 +933,7 @@
             if ($status.Installed -and $status.Updatable) {
                 Write-Output "$name $($status.Installed) -> $($status.Available)..."
                 if (Get-Command Update-PSResource -ErrorAction SilentlyContinue) {
-                    Update-PSResource -Name $name -TrustRepository -Confirm:$false -ErrorAction Stop
+                    Update-PSResource -Name $name -TrustRepository -AcceptLicense -Confirm:$false -ErrorAction Stop
                 } else {
                     Update-Module -Name $name -Force -Confirm:$false -ErrorAction Stop
                 }
@@ -1075,6 +1075,7 @@
                 $null = & py help install 2>&1
                 $isManager = ($LASTEXITCODE -eq 0)
             } catch {
+                Write-Verbose "py resolved but could not start: $($_.Exception.Message)"
                 $isManager = $false
             } finally {
                 Pop-Location

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1433,9 +1433,8 @@ Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
     }
 
     # PSResourceGet ships in the box with PowerShell 7.4 and its receipts are
-    # invisible to Get-InstalledModule -- measured on a real machine, 16
-    # receipts against 2. A copy installed with Install-PSResource counts as a
-    # gallery install, moved by Update-PSResource.
+    # invisible to Get-InstalledModule. A copy installed with Install-PSResource
+    # counts as a gallery install, moved by Update-PSResource.
     It 'reads a PSResourceGet receipt that PowerShellGet cannot see' {
         Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
         Mock Get-InstalledPSResource { [pscustomobject]@{ Name = 'Pester'; Version = $script:PesterVersion } }
@@ -1486,9 +1485,21 @@ Describe 'Get-GalleryModuleStatus' -Tag 'Unit' {
         (Get-GalleryModuleStatus -Name Pester).Mover | Should-BeNull
     }
 
+    # Even a receipt that covers nothing names its client, so advice can say
+    # which reinstall command this machine answers to.
+    It 'names the client holding the receipts even when none covers' {
+        Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Mock Get-InstalledPSResource { [pscustomobject]@{ Name = 'Pester'; Version = [version] '0.0.1' } }
+        Mock Get-InstalledModule { }
+
+        $status = Get-GalleryModuleStatus -Name Pester
+        $status.ReceiptedBy | Should-Be 'PSResourceGet'
+        $status.Mover       | Should-BeNull
+    }
+
     # Get-InstalledPSResource without -Scope reads only the per-user paths, so
-    # the machine scope is asked separately. Measured on a real machine: an
-    # AllUsers install had a receipt on disk and the bare call returned nothing.
+    # an AllUsers receipt stays invisible until the machine scope is asked
+    # separately.
     It 'sees an AllUsers receipt the bare call misses' {
         Mock Find-Module { [pscustomobject]@{ Version = '9.9.9' } }
         Mock Get-InstalledPSResource { }
@@ -2781,12 +2792,13 @@ Describe 'Format-SelfVersionStatus' -Tag 'Unit' {
 
     BeforeAll {
         $script:StatusOf = {
-            param($Installed, $Available, $Updatable = $true)
+            param($Installed, $Available, $Updatable = $true, $ReceiptedBy = $null)
             [pscustomobject]@{
                 Name        = 'UpdateEverything'
                 Installed   = if ($Installed) { [version] $Installed } else { $null }
                 Available   = if ($Available) { [version] $Available } else { $null }
                 Updatable   = $Updatable
+                ReceiptedBy = $ReceiptedBy
                 NeedsUpdate = [bool] ($Installed -and $Available -and ([version]$Available -gt [version]$Installed))
             }
         }
@@ -2846,6 +2858,20 @@ Describe 'Format-SelfVersionStatus' -Tag 'Unit' {
     It 'sends a behind copy that is installed nowhere to Install-Module' {
         $line = Format-SelfVersionStatus -Running '1.0.0' -Status (& $script:StatusOf $null '1.2.0' $false)
         $line | Should-MatchString 'outside a module path'
+        $line | Should-MatchString ([regex]::Escape('Install-Module UpdateEverything -Force'))
+    }
+
+    # The reinstall command should be the one this machine's receipts answer
+    # to: a PSResourceGet lineage reinstalls through Install-PSResource, a
+    # PowerShellGet one through Install-Module.
+    It 'names Install-PSResource on a PSResourceGet lineage the gallery cannot move' {
+        $line = Format-SelfVersionStatus -Running '1.1.0' -Status (& $script:StatusOf '1.1.0' '1.2.0' $false 'PSResourceGet')
+        $line | Should-MatchString ([regex]::Escape('Install-PSResource UpdateEverything -Reinstall'))
+        $line | Should-NotMatchString ([regex]::Escape('Install-Module UpdateEverything -Force'))
+    }
+
+    It 'still names Install-Module on a PowerShellGet lineage' {
+        $line = Format-SelfVersionStatus -Running '1.1.0' -Status (& $script:StatusOf '1.1.0' '1.2.0' $false 'PowerShellGet')
         $line | Should-MatchString ([regex]::Escape('Install-Module UpdateEverything -Force'))
     }
 }


### PR DESCRIPTION
**Standards**: the py probe's catch says what it swallowed (error-boundary rule); CONTRIBUTING's EAP exception list and pre-PR checklist now name the shipped mover script (it owns `exit` and the preference in its own process); two test comments lose their one-machine measurements, which stay in the commit messages that recorded them.

**Spec (#97)**: the status gains `ReceiptedBy`, and `Format-SelfVersionStatus` points a PSResourceGet lineage the gallery cannot move at `Install-PSResource UpdateEverything -Reinstall` instead of `Install-Module -Force`. Both `Update-PSResource` calls pass `-AcceptLicense`.

**Refuted with live evidence**: `winget show Microsoft.PowerShell --source winget` reports `Installer Type: msix` (PowerShell-7.6.5.msixbundle), so the mover's GitHub-MSI-only path and its premise stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)