### PR TITLE
Prepare 1.7.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -544,7 +544,7 @@ self-update lands, set the precedent:
 |---|---|
 | 1.2.0, 1.3.0, 1.4.0 | PowerShell Gallery, and GitHub |
 | 1.2.1, 1.2.2 | GitHub only |
-| 1.7.1 | PowerShell Gallery, and GitHub |
+| 1.7.1, 1.7.2 | PowerShell Gallery, and GitHub |
 
 Every gallery version is permanent -- unlist hides it from search and leaves it
 installable -- so each one is a commitment, and fewer of them means fewer to
@@ -595,7 +595,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.7.1 -m "1.7.1" && git push origin v1.7.1
+git tag -a v1.7.2 -m "1.7.2" && git push origin v1.7.2
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -282,13 +282,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.7.1
+UpdateEverything 1.7.2
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.7.1 is running, which is the newest published version.
+UpdateEverything 1.7.2 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.7.1'
+    ModuleVersion     = '1.7.2'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -33,27 +33,24 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.7.1
+            ReleaseNotes = '# 1.7.2
 
-One fix, for machines that install the module for all users.
+Fixes from a standards-and-spec review of everything since 1.5.0.
 
-## The self-update sees the machine-wide receipt
+## The advice matches the receipts
 
-Get-InstalledPSResource without -Scope reads only the per-user paths, so a
-copy installed with Install-PSResource -Scope AllUsers -- receipt on disk,
-returned by the AllUsers query -- reported no gallery lineage at all. Once
-the gallery moved ahead, the self step would have called it a copy the
-gallery did not install.
+The status behind the version banner reports which gallery client holds the
+receipts on this machine, and the advice follows it: a PSResourceGet lineage
+the gallery cannot move is pointed at "Install-PSResource UpdateEverything
+-Reinstall" rather than at Install-Module, which answers a different
+lineage.
 
-The status now asks PSResourceGet both ways and carries the scope of the
-covering receipt. The self step targets that scope: elevated,
-Update-PSResource runs with -Scope AllUsers; unelevated, the step reports
-the elevation need up front instead of calling at all, because
-Update-PSResource would not refuse -- its CurrentUser default would quietly
-install the new version per-user beside the all-users copy.
+## Robustness
 
-A per-user receipt wins when both scopes cover: that copy shadows the
-machine one in PSModulePath order, and moving it needs no elevation.
+Both Update-PSResource calls pass -AcceptLicense, so a module that requires
+accepting a license cannot stall an unattended run. The Python launcher
+probe says through Write-Verbose what it swallowed when a py that resolves
+cannot start.
 '
 
         }


### PR DESCRIPTION
Release notes written against published 1.7.1, for the review fixes on main: the receipt-aware reinstall advice, `-AcceptLicense` on both `Update-PSResource` calls, and the py probe saying what it swallowed. Samples, the tag example and the policy table move to 1.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)