### PR TITLE
Fix what a real run of 1.7.2 showed

### DIFF
--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -28,7 +28,10 @@ function Get-UpdateToolInventory {
 
         .PARAMETER Catalogue
         The tools to look for. Defaults to the ones this module drives; a test
-        passes its own.
+        passes its own. Each entry names the Command, the VersionArgument that
+        makes it print its version (null to record presence only), and
+        optionally the OutputEncoding the tool writes when it is not the
+        console's, as a name Encoding.GetEncoding accepts.
 
         .EXAMPLE
         Get-UpdateToolInventory | Where-Object Present
@@ -52,7 +55,8 @@ function Get-UpdateToolInventory {
             @{ Name = 'Bun';             Command = 'bun';     VersionArgument = '--version' }
             @{ Name = 'pnpm';            Command = 'pnpm';    VersionArgument = '--version' }
             @{ Name = 'Python launcher'; Command = 'py';      VersionArgument = '--version' }
-            @{ Name = 'Python manager';  Command = 'pymanager'; VersionArgument = '--version' }
+            # pymanager prints its version at the head of help and nothing for --version.
+            @{ Name = 'Python manager';  Command = 'pymanager'; VersionArgument = 'help' }
             @{ Name = 'uv';              Command = 'uv';      VersionArgument = '--version' }
             @{ Name = 'pip';             Command = 'pip';     VersionArgument = '--version' }
             @{ Name = 'pipx';            Command = 'pipx';    VersionArgument = '--version' }
@@ -67,7 +71,8 @@ function Get-UpdateToolInventory {
             @{ Name = 'Google Cloud CLI'; Command = 'gcloud'; VersionArgument = $null }
             @{ Name = 'VS Code';         Command = 'code';    VersionArgument = $null }
             @{ Name = 'MiKTeX';          Command = 'miktex';  VersionArgument = '--version' }
-            @{ Name = 'WSL';             Command = 'wsl';     VersionArgument = $null }
+            # wsl.exe writes UTF-16 to stdout.
+            @{ Name = 'WSL';             Command = 'wsl';     VersionArgument = '--version'; OutputEncoding = 'utf-16' }
         )
     }
 
@@ -97,13 +102,18 @@ function Get-UpdateToolInventory {
         }
 
         # The null version arguments are on purpose. scoop is a PowerShell shim
-        # whose --version runs a git describe against its own repository; wsl
-        # --version writes UTF-16 that arrives as spaced-out characters; az,
+        # whose --version runs a git describe against its own repository; az,
         # gcloud and code each take seconds to answer. Presence is most of the
-        # value, and none of these are worth the wait or the mess.
+        # value, and none of these are worth the wait.
         $version = $null
         if ($tool.VersionArgument) {
+            # Native output is decoded with the console's output encoding, so a
+            # tool that writes another one is read with that one, briefly.
+            $consoleEncoding = [Console]::OutputEncoding
             try {
+                if ($tool.OutputEncoding) {
+                    [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding($tool.OutputEncoding)
+                }
                 $raw = & $tool.Command $tool.VersionArgument 2>&1
                 $global:LASTEXITCODE = 0
                 $version = @($raw | Out-String -Stream |
@@ -112,6 +122,8 @@ function Get-UpdateToolInventory {
             } catch {
                 Write-Verbose "$($tool.Command) $($tool.VersionArgument) failed: $($_.Exception.Message)"
                 $global:LASTEXITCODE = 0
+            } finally {
+                if ($tool.OutputEncoding) { [Console]::OutputEncoding = $consoleEncoding }
             }
         }
 

--- a/src/Private/Set-PwshAsWindowsTerminalDefault.ps1
+++ b/src/Private/Set-PwshAsWindowsTerminalDefault.ps1
@@ -46,11 +46,17 @@
     # Stable V5 UUID the PowershellCore generator assigns to the primary pwsh
     # install; used as a fallback if the profile is not yet materialized in the file.
     $wellKnownPwsh = '{574e775e-4f2a-5b96-ac1e-a2962a402336}'
+    # Terminal generates one PowershellCore profile per pwsh install it finds, so
+    # a machine that has carried more than one install has more than one. Every
+    # one of them is PowerShell 7, and a default pointing at any of them stays.
+    $pwshProfiles = @()
     $ps7Guid = $null
     if ($cfg -and $cfg.profiles -and $cfg.profiles.list) {
-        $p = $cfg.profiles.list | Where-Object { $_.source -eq 'Windows.Terminal.PowershellCore' } | Select-Object -First 1
-        if (-not $p) { $p = $cfg.profiles.list | Where-Object { $_.commandline -match 'pwsh' } | Select-Object -First 1 }
-        if ($p -and $p.guid) { $ps7Guid = $p.guid }
+        $generated = @($cfg.profiles.list | Where-Object { $_.source -eq 'Windows.Terminal.PowershellCore' })
+        $handmade  = @($cfg.profiles.list | Where-Object { $_.commandline -match 'pwsh' })
+        $pwshProfiles = $generated + $handmade
+        $p = $pwshProfiles | Where-Object { $_.guid } | Select-Object -First 1
+        if ($p) { $ps7Guid = $p.guid }
     }
     if (-not $ps7Guid) {
         $ps7Guid = $wellKnownPwsh
@@ -68,8 +74,11 @@
         $current = $Matches[1]
     }
 
-    if ($current -eq $ps7Guid) {
-        Write-Output "Default profile is already PowerShell 7 ($ps7Guid). No change needed."
+    # Terminal accepts a profile name here as well as a GUID.
+    $currentIsPwsh = ($current -eq $ps7Guid) -or
+        ($current -and @($pwshProfiles | Where-Object { $_.guid -eq $current -or $_.name -eq $current }).Count)
+    if ($currentIsPwsh) {
+        Write-Output "Default profile is already PowerShell 7 ($current). No change needed."
         return
     }
     Write-Output "Current default profile: $current"

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -1606,7 +1606,15 @@
             if ($AutoReboot)         { $params.AutoReboot      = $true }
             else                     { $params.IgnoreReboot    = $true }
 
-            Get-WindowsUpdate @params
+            # Get-WindowsUpdate returns nothing at all when the scan finds
+            # nothing, and a step that ran for half a minute owes a word on it.
+            $offered = @(Get-WindowsUpdate @params)
+            if ($offered.Count) {
+                $offered
+            } else {
+                $scanned = if ($useMicrosoftUpdate) { 'Windows Update and Microsoft Update' } else { 'Windows Update' }
+                Write-Output "$scanned offered nothing to install."
+            }
         }
     } else {
         Add-SkippedStep -Name 'Windows Update'

--- a/tests/Set-PwshAsWindowsTerminalDefault.Tests.ps1
+++ b/tests/Set-PwshAsWindowsTerminalDefault.Tests.ps1
@@ -144,6 +144,78 @@ Describe 'Set-PwshAsWindowsTerminalDefault' -Tag 'Unit' {
         }
     }
 
+    Context 'A default that already names a second PowerShell 7 profile' {
+
+        # Terminal generates one PowershellCore profile per pwsh install it has
+        # seen, so two is normal on a machine that moved from the Store package
+        # to the MSI. Either is PowerShell 7.
+        BeforeEach {
+            $script:OtherPwsh = '{5fb123f1-af88-5b5c-8953-d14a8def1978}'
+            $content = '{' + [Environment]::NewLine +
+                '    "defaultProfile": "' + $script:OtherPwsh + '",' + [Environment]::NewLine +
+                '    "profiles": { "list": [' + [Environment]::NewLine +
+                '        { "guid": "' + $script:PwshGuid + '", "name": "PowerShell", "source": "Windows.Terminal.PowershellCore" },' + [Environment]::NewLine +
+                '        { "guid": "' + $script:OtherPwsh + '", "name": "PowerShell 7", "source": "Windows.Terminal.PowershellCore" }' + [Environment]::NewLine +
+                '    ] }' + [Environment]::NewLine +
+                '}'
+            Set-Content -LiteralPath $script:SettingsPath -Value $content -Encoding utf8
+        }
+
+        It 'leaves the default where the person put it' {
+            $before = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($script:SettingsPath))
+            Set-PwshAsWindowsTerminalDefault -LogDir $script:LogDir 6>$null
+            $after = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($script:SettingsPath))
+
+            $after | Should-Be $before
+            @(Get-ChildItem $script:LogDir -Filter '*.json.bak') | Should-BeCollection -Count 0
+        }
+
+        It 'says the default is already PowerShell 7' {
+            $out = @(Set-PwshAsWindowsTerminalDefault -LogDir $script:LogDir 6>$null)
+
+            "$($out -join ' ')" | Should-MatchString 'already PowerShell 7'
+        }
+    }
+
+    Context 'A default given as a profile name' {
+
+        # Terminal accepts a name in defaultProfile as well as a GUID.
+        BeforeEach {
+            $content = '{' + [Environment]::NewLine +
+                '    "defaultProfile": "PowerShell",' + [Environment]::NewLine +
+                '    "profiles": { "list": [ { "guid": "' + $script:PwshGuid + '", "name": "PowerShell", "source": "Windows.Terminal.PowershellCore" } ] }' + [Environment]::NewLine +
+                '}'
+            Set-Content -LiteralPath $script:SettingsPath -Value $content -Encoding utf8
+        }
+
+        It 'recognises the pwsh profile by its name and makes no change' {
+            Set-PwshAsWindowsTerminalDefault -LogDir $script:LogDir 6>$null
+
+            (Get-Content $script:SettingsPath -Raw | ConvertFrom-Json).defaultProfile | Should-Be 'PowerShell'
+            @(Get-ChildItem $script:LogDir -Filter '*.json.bak') | Should-BeCollection -Count 0
+        }
+    }
+
+    Context 'A hand-written pwsh profile as the default' {
+
+        BeforeEach {
+            $content = '{' + [Environment]::NewLine +
+                '    "defaultProfile": "{55555555-5555-5555-5555-555555555555}",' + [Environment]::NewLine +
+                '    "profiles": { "list": [' + [Environment]::NewLine +
+                '        { "guid": "' + $script:PwshGuid + '", "source": "Windows.Terminal.PowershellCore" },' + [Environment]::NewLine +
+                '        { "guid": "{55555555-5555-5555-5555-555555555555}", "name": "mine", "commandline": "pwsh.exe -NoLogo" }' + [Environment]::NewLine +
+                '    ] }' + [Environment]::NewLine +
+                '}'
+            Set-Content -LiteralPath $script:SettingsPath -Value $content -Encoding utf8
+        }
+
+        It 'counts a profile whose commandline runs pwsh as PowerShell 7' {
+            Set-PwshAsWindowsTerminalDefault -LogDir $script:LogDir 6>$null
+
+            (Get-Content $script:SettingsPath -Raw | ConvertFrom-Json).defaultProfile | Should-Be '{55555555-5555-5555-5555-555555555555}'
+        }
+    }
+
     Context 'A settings file carrying JSONC comments' {
 
         BeforeEach {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1918,6 +1918,60 @@ Describe 'Get-UpdateToolInventory' -Tag 'Unit' {
         $r.Version | Should-BeNull
         $LASTEXITCODE | Should-Be 0
     }
+
+    # wsl.exe writes UTF-16 to stdout. Decoded as the console's encoding, the
+    # text arrives with a NUL between every character and the version is lost.
+    # A catalogue entry can say what its tool writes.
+    Context 'A tool that writes an encoding the console does not expect' {
+
+        BeforeAll {
+            $script:WideTool = @{
+                Name            = 'Wide'
+                Command         = 'powershell'
+                VersionArgument = @('-NoProfile', '-Command',
+                    '[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; ''Wide version: 1.2.3''')
+                OutputEncoding  = 'utf-16'
+            }
+        }
+
+        It 'reads the version through the encoding the catalogue names' {
+            (Get-UpdateToolInventory -Catalogue @($script:WideTool)).Version | Should-Be 'Wide version: 1.2.3'
+        }
+
+        It 'puts the console encoding back afterwards' {
+            $before = [Console]::OutputEncoding
+            $null = Get-UpdateToolInventory -Catalogue @($script:WideTool)
+
+            [Console]::OutputEncoding.WebName | Should-Be $before.WebName
+        }
+
+        It 'puts it back when the tool cannot start' {
+            Mock Get-Command { [pscustomobject]@{ Source = 'C:\shims\ue-broken-shim.exe' } }
+            $before = [Console]::OutputEncoding
+
+            $null = Get-UpdateToolInventory -Catalogue @(
+                @{ Name = 'Broken'; Command = 'ue-broken-shim-2b9d'; VersionArgument = '--version'; OutputEncoding = 'utf-16' })
+
+            [Console]::OutputEncoding.WebName | Should-Be $before.WebName
+        }
+    }
+
+    Context 'The real catalogue' -Tag 'Static' {
+
+        BeforeAll {
+            $script:InventorySource = Get-Content `
+                (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Get-UpdateToolInventory.ps1') -Raw
+        }
+
+        It 'probes wsl as UTF-16' {
+            $script:InventorySource | Should-MatchString "Command = 'wsl';\s+VersionArgument = '--version'; OutputEncoding = 'utf-16'"
+        }
+
+        # pymanager --version exits 0 and prints nothing; help opens with the version.
+        It 'asks the Python manager for help, where its version is' {
+            $script:InventorySource | Should-MatchString "Command = 'pymanager'; VersionArgument = 'help'"
+        }
+    }
 }
 
 Describe 'Step order' -Tag 'Static' {
@@ -3274,6 +3328,25 @@ Describe 'pip is in the inventory' -Tag 'Unit' {
             (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Get-UpdateToolInventory.ps1') -Raw
 
         $source | Should-MatchString "Name = 'pip';"
+    }
+}
+
+Describe 'The Windows Update step' -Tag 'Static' {
+
+    BeforeAll {
+        $script:Source = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    # Get-WindowsUpdate returns nothing when the scan finds nothing, and the
+    # step used to say nothing with it.
+    It 'says so when nothing was offered' {
+        $script:Source | Should-MatchString ([regex]::Escape('$offered = @(Get-WindowsUpdate @params)'))
+        $script:Source | Should-MatchString 'offered nothing to install'
+    }
+
+    It 'names Microsoft Update in that line only when it was in the scan' {
+        $script:Source | Should-MatchString ([regex]::Escape("if (`$useMicrosoftUpdate) { 'Windows Update and Microsoft Update' } else { 'Windows Update' }"))
     }
 }
 


### PR DESCRIPTION
Fix what a real run of 1.7.2 showed

Three things a full run on a live machine got wrong, none of which the
suite could see.

The Windows Terminal step compared the default profile against the first
PowershellCore profile only. Terminal generates one such profile per pwsh
install it has seen, so a default that already named the second one was
"corrected" to the first on every run. The step now collects every pwsh
profile -- generated or hand-written -- and leaves a default that points
at any of them alone, whether it is given as a GUID or a name. (#116)

The Windows Update step said nothing when Get-WindowsUpdate found nothing.
It now says what was scanned and that it offered nothing. (#117)

The inventory printed a blank version for two Present tools. pymanager
prints its version at the head of help and nothing for --version, so help
is what gets asked. wsl.exe writes UTF-16, so a catalogue entry can now
name the encoding its tool writes and the console is switched to it for
the one call, then put back. (#118)

Tests: 828, up from 817.

Closes #116, closes #117, closes #118.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
