### PR TITLE
Prepare 1.7.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -544,7 +544,7 @@ self-update lands, set the precedent:
 |---|---|
 | 1.2.0, 1.3.0, 1.4.0 | PowerShell Gallery, and GitHub |
 | 1.2.1, 1.2.2 | GitHub only |
-| 1.7.1, 1.7.2 | PowerShell Gallery, and GitHub |
+| 1.7.1, 1.7.2, 1.7.3 | PowerShell Gallery, and GitHub |
 
 Every gallery version is permanent -- unlist hides it from search and leaves it
 installable -- so each one is a commitment, and fewer of them means fewer to
@@ -595,7 +595,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.7.2 -m "1.7.2" && git push origin v1.7.2
+git tag -a v1.7.3 -m "1.7.3" && git push origin v1.7.3
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -282,13 +282,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.7.2
+UpdateEverything 1.7.3
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.7.2 is running, which is the newest published version.
+UpdateEverything 1.7.3 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.7.2'
+    ModuleVersion     = '1.7.3'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -33,24 +33,30 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.7.2
+            ReleaseNotes = '# 1.7.3
 
-Fixes from a standards-and-spec review of everything since 1.5.0.
+Fixes from a full run of 1.7.2 on a live machine.
 
-## The advice matches the receipts
+## The Terminal default stays where you put it
 
-The status behind the version banner reports which gallery client holds the
-receipts on this machine, and the advice follows it: a PSResourceGet lineage
-the gallery cannot move is pointed at "Install-PSResource UpdateEverything
--Reinstall" rather than at Install-Module, which answers a different
-lineage.
+Windows Terminal generates one PowerShell 7 profile per pwsh install it has
+seen, so a machine that moved from the Store package to the MSI has two. The
+Terminal-default step compared against the first one only and moved a
+default that already named the second, on every run. It now recognises any
+pwsh profile -- generated or hand-written, by GUID or by name -- and leaves
+a default that points at one alone.
 
-## Robustness
+## The inventory reports every version it can
 
-Both Update-PSResource calls pass -AcceptLicense, so a module that requires
-accepting a license cannot stall an unattended run. The Python launcher
-probe says through Write-Verbose what it swallowed when a py that resolves
-cannot start.
+The Python install manager prints its version at the head of help and
+nothing for --version, so help is what gets asked. wsl.exe writes UTF-16,
+which used to arrive unreadable; it is now read as what it is, so WSL shows
+its version too.
+
+## Windows Update says what it found
+
+When the scan offers nothing, the step says so, and names whether Microsoft
+Update was part of the scan, instead of finishing in silence.
 '
 
         }


### PR DESCRIPTION
Manifest 1.7.3 with release notes for the fixes in #119. README samples and the CONTRIBUTING tag example and policy table follow. Suite: 828 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)