### PR TITLE
Probe wsl with WSL_UTF8 set, for the one call

### DIFF
--- a/src/Private/Get-UpdateToolInventory.ps1
+++ b/src/Private/Get-UpdateToolInventory.ps1
@@ -30,8 +30,7 @@ function Get-UpdateToolInventory {
         The tools to look for. Defaults to the ones this module drives; a test
         passes its own. Each entry names the Command, the VersionArgument that
         makes it print its version (null to record presence only), and
-        optionally the OutputEncoding the tool writes when it is not the
-        console's, as a name Encoding.GetEncoding accepts.
+        optionally Environment, a hashtable of variables set for that one call.
 
         .EXAMPLE
         Get-UpdateToolInventory | Where-Object Present
@@ -71,8 +70,9 @@ function Get-UpdateToolInventory {
             @{ Name = 'Google Cloud CLI'; Command = 'gcloud'; VersionArgument = $null }
             @{ Name = 'VS Code';         Command = 'code';    VersionArgument = $null }
             @{ Name = 'MiKTeX';          Command = 'miktex';  VersionArgument = '--version' }
-            # wsl.exe writes UTF-16 to stdout.
-            @{ Name = 'WSL';             Command = 'wsl';     VersionArgument = '--version'; OutputEncoding = 'utf-16' }
+            # wsl.exe writes UTF-16 or single-byte text depending on where it
+            # runs; WSL_UTF8=1 makes it write UTF-8 everywhere.
+            @{ Name = 'WSL';             Command = 'wsl';     VersionArgument = '--version'; Environment = @{ WSL_UTF8 = '1' } }
         )
     }
 
@@ -107,12 +107,15 @@ function Get-UpdateToolInventory {
         # value, and none of these are worth the wait.
         $version = $null
         if ($tool.VersionArgument) {
-            # Native output is decoded with the console's output encoding, so a
-            # tool that writes another one is read with that one, briefly.
-            $consoleEncoding = [Console]::OutputEncoding
+            # A tool that needs a variable to answer plainly gets it for this
+            # call only; whatever the variable held before comes back after.
+            $previousEnvironment = @{}
             try {
-                if ($tool.OutputEncoding) {
-                    [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding($tool.OutputEncoding)
+                if ($tool.Environment) {
+                    foreach ($name in @($tool.Environment.Keys)) {
+                        $previousEnvironment[$name] = [Environment]::GetEnvironmentVariable($name)
+                        [Environment]::SetEnvironmentVariable($name, [string]$tool.Environment[$name])
+                    }
                 }
                 $raw = & $tool.Command $tool.VersionArgument 2>&1
                 $global:LASTEXITCODE = 0
@@ -123,7 +126,9 @@ function Get-UpdateToolInventory {
                 Write-Verbose "$($tool.Command) $($tool.VersionArgument) failed: $($_.Exception.Message)"
                 $global:LASTEXITCODE = 0
             } finally {
-                if ($tool.OutputEncoding) { [Console]::OutputEncoding = $consoleEncoding }
+                foreach ($name in @($previousEnvironment.Keys)) {
+                    [Environment]::SetEnvironmentVariable($name, $previousEnvironment[$name])
+                }
             }
         }
 

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1919,40 +1919,59 @@ Describe 'Get-UpdateToolInventory' -Tag 'Unit' {
         $LASTEXITCODE | Should-Be 0
     }
 
-    # wsl.exe writes UTF-16 to stdout. Decoded as the console's encoding, the
-    # text arrives with a NUL between every character and the version is lost.
-    # A catalogue entry can say what its tool writes.
-    Context 'A tool that writes an encoding the console does not expect' {
+    # Most entries name no Environment at all, and the probe must still read
+    # their version; an entry with none is the common case, not an edge.
+    It 'reads the version of a tool that names no environment' {
+        $plain = @{ Name = 'Plain'; Command = 'powershell'
+                    VersionArgument = @('-NoProfile', '-Command', '"Plain version: 7.8.9"') }
+
+        (Get-UpdateToolInventory -Catalogue @($plain)).Version | Should-Be 'Plain version: 7.8.9'
+    }
+
+    # wsl.exe writes UTF-16 in one context and single-byte text in another,
+    # and WSL_UTF8=1 makes it write UTF-8 in both. A catalogue entry can name
+    # variables its tool needs, and they are set for the one call.
+    Context 'A tool that needs an environment variable to answer plainly' {
 
         BeforeAll {
-            $script:WideTool = @{
-                Name            = 'Wide'
+            $script:EnvTool = @{
+                Name            = 'Env'
                 Command         = 'powershell'
-                VersionArgument = @('-NoProfile', '-Command',
-                    '[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; ''Wide version: 1.2.3''')
-                OutputEncoding  = 'utf-16'
+                VersionArgument = @('-NoProfile', '-Command', '"Env version: $env:UE_PROBE_VARIABLE"')
+                Environment     = @{ UE_PROBE_VARIABLE = '4.5.6' }
             }
         }
 
-        It 'reads the version through the encoding the catalogue names' {
-            (Get-UpdateToolInventory -Catalogue @($script:WideTool)).Version | Should-Be 'Wide version: 1.2.3'
+        AfterEach {
+            [Environment]::SetEnvironmentVariable('UE_PROBE_VARIABLE', $null)
         }
 
-        It 'puts the console encoding back afterwards' {
-            $before = [Console]::OutputEncoding
-            $null = Get-UpdateToolInventory -Catalogue @($script:WideTool)
-
-            [Console]::OutputEncoding.WebName | Should-Be $before.WebName
+        It 'the tool sees the variable' {
+            (Get-UpdateToolInventory -Catalogue @($script:EnvTool)).Version | Should-Be 'Env version: 4.5.6'
         }
 
-        It 'puts it back when the tool cannot start' {
+        It 'the variable is gone afterwards when it was not set before' {
+            $null = Get-UpdateToolInventory -Catalogue @($script:EnvTool)
+
+            # A removed variable reads back as an empty string on this side.
+            [string][Environment]::GetEnvironmentVariable('UE_PROBE_VARIABLE') | Should-Be ''
+        }
+
+        It 'a value that was set before comes back' {
+            [Environment]::SetEnvironmentVariable('UE_PROBE_VARIABLE', 'mine')
+            $null = Get-UpdateToolInventory -Catalogue @($script:EnvTool)
+
+            [Environment]::GetEnvironmentVariable('UE_PROBE_VARIABLE') | Should-Be 'mine'
+        }
+
+        It 'comes back when the tool cannot start' {
             Mock Get-Command { [pscustomobject]@{ Source = 'C:\shims\ue-broken-shim.exe' } }
-            $before = [Console]::OutputEncoding
 
             $null = Get-UpdateToolInventory -Catalogue @(
-                @{ Name = 'Broken'; Command = 'ue-broken-shim-2b9d'; VersionArgument = '--version'; OutputEncoding = 'utf-16' })
+                @{ Name = 'Broken'; Command = 'ue-broken-shim-2b9d'; VersionArgument = '--version'; Environment = @{ UE_PROBE_VARIABLE = 'x' } })
 
-            [Console]::OutputEncoding.WebName | Should-Be $before.WebName
+            # A removed variable reads back as an empty string on this side.
+            [string][Environment]::GetEnvironmentVariable('UE_PROBE_VARIABLE') | Should-Be ''
         }
     }
 
@@ -1963,8 +1982,8 @@ Describe 'Get-UpdateToolInventory' -Tag 'Unit' {
                 (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Get-UpdateToolInventory.ps1') -Raw
         }
 
-        It 'probes wsl as UTF-16' {
-            $script:InventorySource | Should-MatchString "Command = 'wsl';\s+VersionArgument = '--version'; OutputEncoding = 'utf-16'"
+        It 'probes wsl with WSL_UTF8 set' {
+            $script:InventorySource | Should-MatchString "Command = 'wsl';\s+VersionArgument = '--version'; Environment = @\{ WSL_UTF8 = '1' \}"
         }
 
         # pymanager --version exits 0 and prints nothing; help opens with the version.


### PR DESCRIPTION
Inside a run the Inventory step logged the WSL row as CJK garbage: the single-byte text wsl.exe writes there, read in pairs as the UTF-16 it writes from a bare shell. WSL_UTF8=1 makes wsl.exe write UTF-8 in both contexts, so a catalogue entry can now name environment variables for its probe, set for that call and restored after; the console-encoding switch is gone. A test pins that an entry with no Environment still reads its version. Suite: 830 passed, 0 failed. Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)