### PR TITLE
Refresh PATH after each step, so a manager installed this run is found this run

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ Run without elevating, reporting admin-only steps as skipped:
 Update-Everything -SkipElevation
 ```
 
+### Tools installed during a run
+
+A step that installs a package manager changes the machine or user `PATH`, and
+a process normally keeps the `PATH` it started with. The run re-reads both from
+the registry after each step, so a manager installed by one step is found by
+the steps after it rather than by the next run. Each step that gains something
+says so:
+
+```
+PATH gained: C:\ProgramData\chocolatey\bin
+```
+
+Entries this session added itself, such as an activated virtual environment,
+stay where they are, ahead of everything else. The Inventory step runs before
+any of this and stays a picture of the machine as the run found it.
+
 ### What it returns
 
 `Update-Everything` hands back an object rather than exiting. As a script it

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -160,4 +160,18 @@
         Write-StepLog -Path $stepLog -Message "FAILED | $_"
         $script:Results.Add([pscustomobject]@{ Step = $Name; Status = 'Failed'; Seconds = $secs; Log = $stepLog })
     }
+
+    # A step that installed a manager has changed the machine or user PATH, and
+    # this process still has the PATH it started with. Refreshing here lets the
+    # next step's -RequiresCommand find what this one installed. Update-Everything
+    # enables it after its own opening sync, so only what changed during the run
+    # is reported; a caller that never set it gets no registry reads.
+    if ($script:RefreshPathAfterStep) {
+        $gained = @(Update-ProcessPath)
+        if ($gained.Count) {
+            $msg = "PATH gained: $($gained -join '; ')"
+            Write-Host $msg -ForegroundColor DarkGray
+            Write-StepLog -Path $stepLog -Message $msg
+        }
+    }
 }

--- a/src/Private/Update-ProcessPath.ps1
+++ b/src/Private/Update-ProcessPath.ps1
@@ -1,0 +1,92 @@
+﻿function Update-ProcessPath {
+    <#
+        .SYNOPSIS
+        Brings this process's PATH up to date with the machine and user PATH.
+
+        .DESCRIPTION
+        A step that installs a manager writes to the machine or user PATH in the
+        registry, and a process keeps the PATH it started with. Without this, a
+        tool installed by one step is found by the next run rather than the next
+        step.
+
+        The result is the process-only entries first, in their existing order,
+        then the machine entries, then the user entries, each once. Process-only
+        entries are the ones neither hive lists: an activated virtual environment,
+        a per-session prepend. They keep their place at the front so what they
+        shadow stays shadowed.
+
+        Returns the entries that were in a hive and not in the process PATH
+        before, so the caller can say what the run gained. Returns nothing, and
+        changes nothing, when neither hive could be read.
+
+        .PARAMETER MachinePath
+        The machine PATH, unexpanded. Read from the registry when not given.
+
+        .PARAMETER UserPath
+        The user PATH, unexpanded. Read from the registry when not given.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Changes only this process''s PATH, to match what the registry already says. Nothing on the machine is touched, and the run that calls it reports every entry gained.')]
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string] $MachinePath,
+        [string] $UserPath
+    )
+
+    # DoNotExpandEnvironmentNames, then expand: Get-ItemProperty expands the
+    # REG_EXPAND_SZ value itself, but against this process's environment, which is
+    # the thing being brought up to date.
+    $read = {
+        param($Key)
+        try {
+            $item = Get-Item -LiteralPath $Key -ErrorAction Stop
+            [string] $item.GetValue('Path', '', 'DoNotExpandEnvironmentNames')
+        } catch {
+            Write-Verbose "Could not read PATH from ${Key}: $($_.Exception.Message)"
+            ''
+        }
+    }
+    if (-not $PSBoundParameters.ContainsKey('MachinePath')) {
+        $MachinePath = & $read 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+    }
+    if (-not $PSBoundParameters.ContainsKey('UserPath')) {
+        $UserPath = & $read 'HKCU:\Environment'
+    }
+    if ([string]::IsNullOrWhiteSpace($MachinePath) -and [string]::IsNullOrWhiteSpace($UserPath)) {
+        return
+    }
+
+    $split = {
+        param($Text)
+        @(([Environment]::ExpandEnvironmentVariables([string] $Text) -split ';') |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ })
+    }
+    $before = @(& $split $env:PATH)
+    $hive   = @(& $split $MachinePath) + @(& $split $UserPath)
+
+    # Trailing separators are the usual reason one directory appears as two.
+    $key = { param($Entry) $Entry.TrimEnd('\', '/') }
+    $comparer = [System.StringComparer]::OrdinalIgnoreCase
+
+    $inHive = [System.Collections.Generic.HashSet[string]]::new($comparer)
+    foreach ($entry in $hive) { $null = $inHive.Add((& $key $entry)) }
+    $inBefore = [System.Collections.Generic.HashSet[string]]::new($comparer)
+    foreach ($entry in $before) { $null = $inBefore.Add((& $key $entry)) }
+
+    $seen = [System.Collections.Generic.HashSet[string]]::new($comparer)
+    $ordered = [System.Collections.Generic.List[string]]::new()
+    foreach ($entry in $before) {
+        if (-not $inHive.Contains((& $key $entry)) -and $seen.Add((& $key $entry))) { $ordered.Add($entry) }
+    }
+    $gained = [System.Collections.Generic.List[string]]::new()
+    foreach ($entry in $hive) {
+        if ($seen.Add((& $key $entry))) {
+            $ordered.Add($entry)
+            if (-not $inBefore.Contains((& $key $entry))) { $gained.Add($entry) }
+        }
+    }
+
+    $env:PATH = $ordered -join ';'
+    $gained
+}

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -411,6 +411,13 @@
 
     $script:Results = [System.Collections.Generic.List[object]]::new()
 
+    # The process PATH is brought level with the registry once, quietly, before
+    # any step runs, so the per-step refresh in Invoke-Step reports only what
+    # this run's steps installed rather than whatever was added since this
+    # session started.
+    $null = Update-ProcessPath
+    $script:RefreshPathAfterStep = $true
+
     # Read by Invoke-Step, which decides per step. Script scope for the same reason
     # as $script:isAdmin: a step action runs inside Invoke-Step, not here.
     $script:TagFilter        = $Tag

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -909,7 +909,8 @@ Describe 'Variable hygiene' -Tag 'Static' {
             'ShellId', 'NestedPromptLevel', 'StackTrace', 'switch', 'foreach',
             # Set by the module loader, and by the caller of a private helper.
             'ModuleRoot', 'Results', 'logDir', 'runStamp', 'isAdmin', 'InstallDecision',
-            'NotificationsAvailable', 'WingetNothingToDo', 'TagFilter', 'ExcludeTagFilter'
+            'NotificationsAvailable', 'WingetNothingToDo', 'TagFilter', 'ExcludeTagFilter',
+            'RefreshPathAfterStep'
         )
 
         $bare = { param($p) ($p -replace '^(script|global|local|private):', '') }

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1993,6 +1993,108 @@ Describe 'Get-UpdateToolInventory' -Tag 'Unit' {
     }
 }
 
+Describe 'Update-ProcessPath' -Tag 'Unit' {
+
+    # The hives are passed in as strings, so nothing here reads the registry or
+    # depends on the machine. $env:PATH is the one thing it changes, and it is
+    # put back after every test.
+
+    BeforeEach {
+        $script:RealPath = $env:PATH
+    }
+
+    AfterEach {
+        $env:PATH = $script:RealPath
+    }
+
+    It 'adds hive entries the process did not have, and returns them' {
+        $env:PATH = 'C:\tools'
+
+        $gained = @(Update-ProcessPath -MachinePath 'C:\tools;C:\new' -UserPath 'C:\me')
+
+        $gained | Should-BeCollection @('C:\new', 'C:\me')
+        $env:PATH | Should-Be 'C:\tools;C:\new;C:\me'
+    }
+
+    # An activated venv or a per-session prepend is in neither hive. It stays,
+    # and it stays first, so what it shadowed is still shadowed.
+    It 'keeps process-only entries, ahead of the hives' {
+        $env:PATH = 'C:\venv\Scripts;C:\tools'
+
+        $null = Update-ProcessPath -MachinePath 'C:\tools' -UserPath ''
+
+        $env:PATH | Should-Be 'C:\venv\Scripts;C:\tools'
+    }
+
+    It 'expands %variables% the way the registry stores them' {
+        $env:PATH = 'C:\tools'
+
+        $gained = @(Update-ProcessPath -MachinePath '%SystemRoot%\ue-test' -UserPath '')
+
+        $gained | Should-BeCollection @("$env:SystemRoot\ue-test")
+    }
+
+    It 'treats casing and a trailing backslash as the same directory' {
+        $env:PATH = 'c:\tools\'
+
+        $gained = @(Update-ProcessPath -MachinePath 'C:\Tools' -UserPath '')
+
+        $gained | Should-BeCollection -Count 0
+        ($env:PATH -split ';') | Should-BeCollection -Count 1
+    }
+
+    It 'returns nothing the second time, because nothing is new' {
+        $env:PATH = 'C:\tools'
+        $null = Update-ProcessPath -MachinePath 'C:\tools;C:\new' -UserPath ''
+
+        @(Update-ProcessPath -MachinePath 'C:\tools;C:\new' -UserPath '') | Should-BeCollection -Count 0
+    }
+
+    # Unreadable hives must not turn into an empty PATH.
+    It 'leaves PATH alone when both hives are empty' {
+        $env:PATH = 'C:\tools;C:\venv'
+
+        @(Update-ProcessPath -MachinePath '' -UserPath '') | Should-BeCollection -Count 0
+        $env:PATH | Should-Be 'C:\tools;C:\venv'
+    }
+
+    # An exception here fails the test on its own; the point is that the real
+    # registry read completes on whatever machine runs the suite.
+    It 'reads the real hives when none are given, without throwing' {
+        $null = Update-ProcessPath
+    }
+}
+
+Describe 'The run refreshes PATH between steps' -Tag 'Static' {
+
+    BeforeAll {
+        $script:StepSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Private\Invoke-Step.ps1') -Raw
+        $script:RunSource = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    It 'refreshes after a step, and says what was gained' {
+        $script:StepSource | Should-MatchString ([regex]::Escape('$gained = @(Update-ProcessPath)'))
+        $script:StepSource | Should-MatchString 'PATH gained:'
+    }
+
+    # Without the opening sync, the first step would report everything added
+    # since the session started, none of which this run did.
+    It 'syncs once, quietly, before the first step' {
+        $sync  = $script:RunSource.IndexOf('$null = Update-ProcessPath')
+        $first = $script:RunSource.IndexOf("Invoke-Step -Name 'Inventory'")
+
+        $sync | Should-BeGreaterThan -1
+        $sync | Should-BeLessThan $first
+    }
+
+    It 'only refreshes when the run turned it on' {
+        $script:StepSource | Should-MatchString ([regex]::Escape('if ($script:RefreshPathAfterStep)'))
+        $script:RunSource  | Should-MatchString ([regex]::Escape('$script:RefreshPathAfterStep = $true'))
+    }
+}
+
 Describe 'Step order' -Tag 'Static' {
 
     # The order is a contract, not a preference, so it is asserted rather than


### PR DESCRIPTION
Update-ProcessPath rebuilds the process PATH from the machine and user hives after every step, keeping process-only entries in front, and reports what the run gained. Update-Everything syncs once quietly before the first step so only in-run changes are reported. Suite: 841 passed, 0 failed. Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)