### PR TITLE
Notify by default, and hold the window with -Attended

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ thing that crosses a process boundary.
 | `-PromptBeforeRun` | off | Pause before starting and offer: run now, skip, or wait. Takes the default after `-PromptTimeoutSeconds`. |
 | `-PromptTimeoutSeconds` | `60` | How long that prompt waits before starting anyway. |
 | `-DelayMinutes` | `60` | How long the "wait, then run" answer waits. |
-| `-Notify` | off | Show a toast when the run finishes, plus an urgent one if a restart is needed. Intended for scheduled runs. |
+| `-Notify` | on | Show a toast when the run finishes, plus an urgent one if a restart is needed. Needs BurntToast; without it the summary says so in one line. `-Notify:$false` turns it off. |
+| `-Attended` | off | Hold the window open after the summary until a key is pressed, for a run started from a shortcut. Closes on its own after `-PromptTimeoutSeconds` when given, otherwise ten minutes. |
 | `-AllowInstall` | *(none)* | Which missing components may be installed: `All`, or any of `PowerShell7`, `PSWindowsUpdate`, `NuGetProvider`, `BurntToast`, `PowerShellGet`, `PSResourceGet`. |
 | `-Tag` | *(all)* | Run only the steps carrying one of these tags. Everything else is reported as skipped. |
 | `-ExcludeTag` | *(none)* | Run everything except the steps carrying one of these tags. Exclusion wins when both are given. |
@@ -617,12 +618,13 @@ skips its step rather than failing it, so it stays out of `FailedCount`.
 
 ## Notifications
 
-`-Notify` raises two Windows toasts, a summary when the run finishes and a
-restart notice marked *urgent* when Windows is waiting on a reboot. Urgent
-notifications break through Focus Assist; ordinary ones do not.
+Every run raises two Windows toasts when it can: a summary when the run
+finishes, and a restart notice marked *urgent* when Windows is waiting on a
+reboot. Urgent notifications break through Focus Assist; ordinary ones do not.
+Turn them off with:
 
 ```powershell
-Update-Everything -Notify
+Update-Everything -Notify:$false
 ```
 
 Notifications need the [BurntToast](https://github.com/Windos/BurntToast) module:
@@ -631,13 +633,29 @@ Notifications need the [BurntToast](https://github.com/Windos/BurntToast) module
 Install-Module BurntToast -Scope CurrentUser
 ```
 
-It is an optional dependency. If the module is missing, or the run has no
-interactive desktop session, the update proceeds as normal and you are told in
-three places: when registering the scheduled task, at the start of the run, and
-again in the closing summary.
+It is an optional dependency. Without it, or without an interactive desktop
+session, the update proceeds as normal. A run that did not ask for `-Notify`
+says so in one line of the closing summary and offers nothing for install. A
+run that passed `-Notify` is told at the start, again in the summary, and
+offered the install; a task registered with notifications is told at
+registration.
 
 Toasts are drawn into an interactive desktop session, so a task running as
 `SYSTEM` cannot show one. This is why the scheduled task runs as you.
+
+## Attended runs
+
+A run started from a shortcut or a Start-menu pin closes its window as soon as
+it finishes, before anything can be read. `-Attended` holds it:
+
+```powershell
+Update-Everything -Attended
+```
+
+After the summary the window waits for a key, and closes on its own after
+`-PromptTimeoutSeconds` when that is given, otherwise ten minutes. The default
+is unattended: a scheduled task never passes `-Attended`, and one that carries
+it in `-ExtraArgument` is warned at registration.
 
 ## Pausing before a run
 

--- a/src/Private/Get-UpdateTaskArgument.ps1
+++ b/src/Private/Get-UpdateTaskArgument.ps1
@@ -37,7 +37,8 @@ function Get-UpdateTaskArgument {
     )
 
     $call = 'Update-Everything'
-    if ($Notify) { $call += ' -Notify' }
+    # Update-Everything notifies by default, so turning it off has to be said.
+    if ($Notify) { $call += ' -Notify' } else { $call += ' -Notify:$false' }
     if ($PromptBeforeRun) { $call += " -PromptBeforeRun -PromptTimeoutSeconds $PromptTimeoutSeconds" }
     if ($AllowInstall) {
         $call += ' -AllowInstall ' + (($AllowInstall | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }) -join ',')

--- a/src/Private/Initialize-NotificationSupport.ps1
+++ b/src/Private/Initialize-NotificationSupport.ps1
@@ -13,7 +13,12 @@
     param(
         # The caller's -AllowInstall list, consulted before BurntToast is pulled
         # from the PowerShell Gallery.
-        [string[]] $Approved = @()
+        [string[]] $Approved = @(),
+
+        # Notifications are on by default rather than asked for. A missing
+        # prerequisite is then a note for the summary, not a warning, and no
+        # install is offered unless -AllowInstall names it.
+        [switch] $Implied
     )
 
     # A toast is drawn by the shell in an interactive desktop session. From a
@@ -21,11 +26,16 @@
     # and the call either fails or posts a notification nobody can see.
     if (-not (Test-InteractiveSession)) {
         $reason = 'this is not an interactive session, so a toast has no desktop to appear on. Schedule the task to run as your own user while logged on.'
-        Write-Warning "Notifications requested, but $reason"
+        if ($Implied) { Write-Verbose "Notifications are on by default, but $reason" }
+        else          { Write-Warning "Notifications requested, but $reason" }
         return [pscustomobject]@{ Available = $false; Reason = $reason }
     }
 
     if (-not (Get-Module BurntToast -ListAvailable)) {
+        if ($Implied -and -not ($Approved -contains 'All' -or $Approved -contains 'BurntToast')) {
+            $reason = 'the BurntToast module is not installed. "Install-Module BurntToast -Scope CurrentUser" adds a toast when a run finishes.'
+            return [pscustomobject]@{ Available = $false; Reason = $reason }
+        }
         if (-not (Approve-Install -Component 'BurntToast' -Approved $Approved `
                 -Description 'Notifications were requested with -Notify, but the BurntToast module is not installed. This would install it from the PowerShell Gallery for the current user only.')) {
             $reason = 'the BurntToast module is not installed, and installing it was not approved. Install it with "Install-Module BurntToast -Scope CurrentUser", or re-run with -AllowInstall BurntToast.'

--- a/src/Private/Wait-AttendedExit.ps1
+++ b/src/Private/Wait-AttendedExit.ps1
@@ -1,0 +1,47 @@
+﻿function Wait-AttendedExit {
+    # Holds the window after an -Attended run so the summary can be read. Ends on
+    # any key, or when the timeout runs out, so a hold nobody is watching cannot
+    # last until a task's execution time limit.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'The hold is drawn for a person to read. Sending it down the pipeline would make it the return value instead.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateRange(1, 86400)]
+        [int] $TimeoutSeconds
+    )
+
+    if (-not (Test-CanPrompt)) {
+        Write-Warning '-Attended was requested, but this run cannot prompt (no interactive console, or input is redirected), so the window is not held.'
+        return
+    }
+
+    $length = if ($TimeoutSeconds -ge 120) { "$([int][Math]::Round($TimeoutSeconds / 60)) minutes" } else { "$TimeoutSeconds seconds" }
+    Write-Host ''
+    Write-Host "Attended run: press any key to close. The window closes on its own in $length." -ForegroundColor Cyan
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastShown = -1
+    try {
+        while ((Get-Date) -lt $deadline) {
+            $remaining = [int][Math]::Ceiling(($deadline - (Get-Date)).TotalSeconds)
+            if ($remaining -ne $lastShown) {
+                # [Console]::Write, not Write-Host: the countdown redraws in place
+                # without a line per second in the transcript. See Read-TimedChoice.
+                [Console]::Write(("`rClosing in {0,5}s -- press any key. " -f $remaining))
+                $lastShown = $remaining
+            }
+            if ($Host.UI.RawUI.KeyAvailable) {
+                $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+                [Console]::Write("`r" + (' ' * 50) + "`r")
+                return
+            }
+            Start-Sleep -Milliseconds 200
+        }
+    } catch {
+        Write-Host ''
+        Write-Warning "Could not read a keypress ($($_.Exception.Message)); closing."
+        return
+    }
+    [Console]::Write("`r" + (' ' * 50) + "`r")
+    Write-Host "No key in $length; closing." -ForegroundColor DarkGray
+}

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -181,6 +181,12 @@
         -AllowInstall $AllowInstall -Tag $Tag -ExcludeTag $ExcludeTag `
         -ExtraArgument $ExtraArgument
 
+    # A task has nobody at the window, so an -Attended run would hold every
+    # window open until the hold timed out.
+    if (@($ExtraArgument | Where-Object { $_ -match '^-Attended(:|$)' }).Count) {
+        Write-Warning 'The task passes -Attended, and a scheduled run has nobody at the window. Each run will hold its window open until the hold times out.'
+    }
+
     $action = New-ScheduledTaskAction -Execute (Get-PowerShellHostPath) -Argument $arguments
 
     $trigger = New-UpdateTaskTrigger -Cadence $Cadence -DayOfWeek $DayOfWeek -At $At `

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -124,17 +124,28 @@
     .PARAMETER DelayMinutes
         How long the "wait, then run" answer waits. Default: 60.
 
+    .PARAMETER Attended
+        Hold the window open after the summary until a key is pressed, for a run
+        started from a shortcut or a Start-menu pin, where the window would
+        otherwise close before anything could be read. Off by default, and a
+        scheduled task never passes it. The hold ends on its own after
+        -PromptTimeoutSeconds when that is given, otherwise after ten minutes, so
+        an -Attended left in a task cannot hold it open until its time limit.
+
     .PARAMETER Notify
         Show Windows toast notifications when the run finishes: a summary, and a
-        separate urgent notification when a restart is required. Off by default,
-        because an interactive run already prints everything to the console. Meant
-        for scheduled runs, where the summary would otherwise go unseen.
+        separate urgent notification when a restart is required. On unless
+        -Notify:$false is passed; a bare -Notify, as older scheduled tasks pass
+        it, means what it always did.
 
         Requires the BurntToast module (https://github.com/Windos/BurntToast) and an
         interactive desktop session. Either being absent degrades to no
-        notifications; it never fails the run.
+        notifications; it never fails the run. When -Notify was not passed and
+        BurntToast is not installed, the closing summary says so in one line and
+        no install is offered; pass -Notify, or -AllowInstall BurntToast, to be
+        asked.
 
-        That check happens before the first update step, not at the end, so the
+        That check happens before the first update step, not at the end, so a
         warning lands at the top of the transcript rather than after a long run.
         The reason is repeated in the closing summary, because by then the original
         warning has scrolled well out of sight.
@@ -243,6 +254,7 @@
         [ValidateRange(1, 1440)]
         [int]    $DelayMinutes            = 60,
         [switch] $Notify,
+        [switch] $Attended,
         [ValidateSet('All', 'PowerShell7', 'PSWindowsUpdate', 'NuGetProvider', 'BurntToast', 'PowerShellGet', 'PSResourceGet')]
         [string[]] $AllowInstall = @(),
         [ValidateSet('Windows', 'Microsoft', 'PowerShell', 'PackageManager', 'Python', 'Node', 'DotNet', 'Rust', 'Go', 'Cloud', 'Git', 'Editor', 'TeX', 'Self', 'Inventory')]
@@ -402,10 +414,14 @@
 
     # Resolved before any work starts, so a missing prerequisite is reported at the
     # top of the transcript and BurntToast is installed before it is needed.
+    # On by default: a run that did not pass -Notify is told about a missing
+    # prerequisite in one line and is not offered an install for it.
     $script:NotificationsAvailable = $false
     $notificationStatus = $null
+    $notifyImplied = -not $PSBoundParameters.ContainsKey('Notify')
+    if ($notifyImplied) { $Notify = $true }
     if ($Notify) {
-        $notificationStatus = Initialize-NotificationSupport -Approved $AllowInstall
+        $notificationStatus = Initialize-NotificationSupport -Approved $AllowInstall -Implied:$notifyImplied
         $script:NotificationsAvailable = $notificationStatus.Available
     }
 
@@ -1693,16 +1709,16 @@
 
     # Repeated here because the warning at startup is thousands of lines back by now.
     if ($Notify -and -not $script:NotificationsAvailable) {
-        Write-Host ''
-        Write-Host '[!] Notifications were requested but could not be sent.' -ForegroundColor Yellow
-        Write-Host "    Reason: $($notificationStatus.Reason)" -ForegroundColor Yellow
-        Write-Host '    The update run itself was unaffected.' -ForegroundColor Yellow
-    } elseif (-not $Notify) {
-        # State that nothing was asked for. Without this the run says nothing at
-        # all about notifications, which reads as a broken feature rather than an
-        # unrequested one.
-        Write-Host ''
-        Write-Host 'Notifications: not requested. Pass -Notify for a toast when the run finishes.' -ForegroundColor DarkGray
+        if ($notifyImplied) {
+            # Nothing was asked for, so a missing prerequisite is a note, not a fault.
+            Write-Host ''
+            Write-Host "Notifications: none sent; $($notificationStatus.Reason)" -ForegroundColor DarkGray
+        } else {
+            Write-Host ''
+            Write-Host '[!] Notifications were requested but could not be sent.' -ForegroundColor Yellow
+            Write-Host "    Reason: $($notificationStatus.Reason)" -ForegroundColor Yellow
+            Write-Host '    The update run itself was unaffected.' -ForegroundColor Yellow
+        }
     }
 
     # Said at the end rather than at the start: by here the run has shown what
@@ -1718,6 +1734,15 @@
     Write-Host "Finished $(Get-Date). Detailed logs saved to: $logDir" -ForegroundColor Green
     if ($failedSteps.Count) {
         Write-Host "$($failedSteps.Count) step(s) failed." -ForegroundColor Red
+    }
+
+    # After the summary and before the transcript closes, so the hold is on
+    # record. -PromptTimeoutSeconds bounds it when given; otherwise ten minutes,
+    # long enough to read and short enough that an -Attended left in a task
+    # cannot hold it open until the task's time limit.
+    if ($Attended) {
+        $holdSeconds = if ($PSBoundParameters.ContainsKey('PromptTimeoutSeconds')) { $PromptTimeoutSeconds } else { 600 }
+        Wait-AttendedExit -TimeoutSeconds $holdSeconds
     }
 
     if ($transcriptRunning) { try { Stop-Transcript | Out-Null } catch { Write-Verbose "Transcript already stopped." } }

--- a/src/en-us/about_UpdateEverything.help.txt
+++ b/src/en-us/about_UpdateEverything.help.txt
@@ -49,10 +49,15 @@ INSTALLING VERSUS UPDATING
     NuGetProvider and BurntToast.
 
 NOTIFICATIONS
-    -Notify raises a toast when the run finishes, and a separate urgent one
-    when a restart is pending. It needs the BurntToast module and an
-    interactive desktop session. Neither is required: without them the run
-    proceeds and says so.
+    A run raises a toast when it finishes, and a separate urgent one when a
+    restart is pending. -Notify:$false turns them off. They need the
+    BurntToast module and an interactive desktop session. Neither is
+    required: without them the run proceeds and says so, in one line when
+    -Notify was not asked for.
+
+    -Attended holds the window open after the summary until a key is
+    pressed, for a run started from a shortcut. It closes on its own after
+    -PromptTimeoutSeconds when given, otherwise ten minutes.
 
     A task running as SYSTEM cannot show a notification, which is why
     Register-UpdateEverythingTask registers the task to run as you.

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -26,6 +26,7 @@ BeforeDiscovery {
         @{ Name = 'UpdateGlobalNpm';           TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'SkipElevation';             TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'Notify';                    TypeName = 'switch';   Type = [switch];   Default = $null }
+        @{ Name = 'Attended';                  TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'AllowInstall';              TypeName = 'string[]'; Type = [string[]]; Default = '@()' }
         @{ Name = 'Tag';                       TypeName = 'string[]'; Type = [string[]]; Default = '@()' }
         @{ Name = 'ExcludeTag';                TypeName = 'string[]'; Type = [string[]]; Default = '@()' }
@@ -37,11 +38,11 @@ BeforeDiscovery {
         @{ Name = 'UpdateSelfSource';          TypeName = 'string';   Type = [string];   Default = "'Gallery'" }
     )
 
-    # Each of these either reboots the machine, moves pinned toolchains, or
-    # reaches out to the gallery, so turning one on has to be deliberate.
+    # Each of these either reboots the machine, moves pinned toolchains, reaches
+    # out to the gallery, or holds a window, so turning one on has to be deliberate.
     $DefaultOffSwitches = @(
         'AutoReboot', 'IncludePrerelease', 'UpdateGlobalNpm', 'SkipElevation',
-        'Notify', 'PromptBeforeRun', 'UpdateSelf'
+        'PromptBeforeRun', 'UpdateSelf', 'Attended'
     )
 
     # Steps that cannot work unelevated, and so must carry -RequiresAdmin.
@@ -492,7 +493,7 @@ Describe 'Update-Everything' -Tag 'Static' {
 
         It 'declares no parameters beyond the documented contract' {
             $script:DeclaredParameters.Name.VariablePath.UserPath |
-                Should-BeCollection -Count 18 -Because 'a new parameter needs docs and a test'
+                Should-BeCollection -Count 19 -Because 'a new parameter needs docs and a test'
         }
 
         It 'bounds -LogRetentionDays with ValidateRange' {

--- a/tests/Notification.Tests.ps1
+++ b/tests/Notification.Tests.ps1
@@ -140,6 +140,58 @@ Describe 'Initialize-NotificationSupport' -Tag 'Unit','Notification' {
     }
 }
 
+Describe 'Initialize-NotificationSupport when notifications are implied' -Tag 'Unit','Notification' {
+
+    # Update-Everything notifies by default. A default that warned, or offered
+    # an install, on every run of a machine without BurntToast would be a nag,
+    # so the implied path reports quietly and installs only when -AllowInstall
+    # names the module.
+
+    Context 'No interactive session' {
+
+        BeforeEach { Mock Test-InteractiveSession { $false } }
+
+        It 'reports unavailable without a warning' {
+            $warnings = @()
+            $result = Initialize-NotificationSupport -Implied -WarningVariable warnings
+
+            $result.Available | Should-BeFalse
+            @($warnings) | Should-BeCollection -Count 0
+        }
+    }
+
+    Context 'BurntToast missing' {
+
+        BeforeEach {
+            Mock Test-InteractiveSession { $true }
+            Mock Get-Module { } -ParameterFilter { $Name -eq 'BurntToast' }
+            Mock Test-CanPrompt { $true }
+            Mock Request-InstallConsent { $true }
+            Mock Install-Module { }
+        }
+
+        It 'does not ask, and does not install' {
+            $result = Initialize-NotificationSupport -Implied
+
+            $result.Available | Should-BeFalse
+            Should-NotInvoke Request-InstallConsent
+            Should-NotInvoke Install-Module
+        }
+
+        It 'returns a reason that says how to get a toast' {
+            (Initialize-NotificationSupport -Implied).Reason | Should-MatchString 'Install-Module BurntToast'
+        }
+
+        It 'still installs when -AllowInstall names the module' {
+            Mock Import-Module { } -ParameterFilter { $Name -eq 'BurntToast' }
+
+            $null = Initialize-NotificationSupport -Implied -Approved @('BurntToast') 6>$null
+
+            Should-Invoke Install-Module -Times 1 -Exactly -ParameterFilter { $Name -eq 'BurntToast' }
+        }
+    }
+}
+
 Describe 'Send-UpdateNotification' -Tag 'Unit','Notification' {
 
     BeforeEach {

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -277,8 +277,10 @@ Describe 'Get-UpdateTaskArgument' -Tag 'Unit' {
         Get-UpdateTaskArgument -ModuleRoot 'C:\x' | Should-MatchString '-Notify'
     }
 
-    It 'omits notifications when they are turned off' {
-        Get-UpdateTaskArgument -ModuleRoot 'C:\x' -Notify $false | Should-NotMatchString '-Notify'
+    # Update-Everything notifies by default, so leaving -Notify out would turn
+    # them back on.
+    It 'says notifications are off when they are turned off' {
+        Get-UpdateTaskArgument -ModuleRoot 'C:\x' -Notify $false | Should-MatchString ([regex]::Escape('-Notify:$false'))
     }
 
     It 'quotes each approval so the child parses them as a list' {
@@ -398,6 +400,18 @@ Describe 'Registration refusals' -Tag 'Unit' {
         $everything = @(Register-UpdateEverythingTask 3>&1)
 
         "$($everything -join ' ')" | Should-MatchString 'notify nobody'
+    }
+
+    # A task has nobody at the window, so -Attended in -ExtraArgument would hold
+    # every run open until the hold timed out.
+    It 'warns when the task would hold the window for nobody' {
+        Mock Test-IsAdministrator { $true }
+        Mock Test-NotificationModuleAvailable { $true }
+        Mock Register-ScheduledTask { [pscustomobject]@{ TaskName = $TaskName } }
+
+        $everything = @(Register-UpdateEverythingTask -ExtraArgument '-Attended' 3>&1)
+
+        "$($everything -join ' ')" | Should-MatchString 'nobody at the window'
     }
 }
 

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -1006,29 +1006,87 @@ Describe 'The PowerShellGet upgrade offer' -Tag 'Static' {
     }
 }
 
-Describe 'The summary says notifications were not requested' -Tag 'Static' {
+Describe 'Notifications are on by default' -Tag 'Static' {
 
-    # -Notify defaults to off, so a run that does not pass it never reaches
-    # Initialize-NotificationSupport and never offers to install BurntToast.
-    # That is correct, but the run said nothing at all about it, which reads as
-    # a broken feature rather than an unrequested one, and sends people looking
-    # for a consent prompt that was never going to appear.
+    # A run that did not pass -Notify still notifies when it can. When it
+    # cannot, the summary says so in one quiet line and offers no install: a
+    # default must not nag. A run that asked for -Notify keeps the warning.
 
-    It 'reports the unrequested case rather than staying silent' {
-        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw |
-            Should-MatchString 'Notifications: not requested'
+    BeforeAll {
+        $script:Source = Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
     }
 
-    It 'names the switch that turns them on' {
-        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw |
-            Should-MatchString 'Notifications: not requested[^\r\n]*-Notify'
+    # Still a switch, so the bare -Notify that every task registered by 1.7.x
+    # passes keeps working; only "not passed at all" changed meaning.
+    It 'keeps -Notify a switch and turns it on when it was not passed' {
+        $script:Source | Should-MatchString ([regex]::Escape('[switch] $Notify,'))
+        $script:Source | Should-MatchString ([regex]::Escape('if ($notifyImplied) { $Notify = $true }'))
     }
 
-    # The existing branch reports notifications that were asked for and could not
-    # be sent. This must not swallow it.
-    It 'still reports notifications that were requested but unavailable' {
-        Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw |
-            Should-MatchString 'Notifications were requested but could not be sent'
+    It 'tells the notification setup whether -Notify was implied' {
+        $script:Source | Should-MatchString ([regex]::Escape('$notifyImplied = -not $PSBoundParameters.ContainsKey(''Notify'')'))
+        $script:Source | Should-MatchString ([regex]::Escape('Initialize-NotificationSupport -Approved $AllowInstall -Implied:$notifyImplied'))
+    }
+
+    It 'notes, quietly, when the default could not notify' {
+        $script:Source | Should-MatchString 'Notifications: none sent;'
+    }
+
+    It 'still warns when notifications were asked for and could not be sent' {
+        $script:Source | Should-MatchString 'Notifications were requested but could not be sent'
+    }
+
+    It 'no longer tells a run that turned them off to turn them on' {
+        $script:Source | Should-NotMatchString 'Notifications: not requested'
+    }
+}
+
+Describe 'Wait-AttendedExit' -Tag 'Unit' {
+
+    It 'does not hold a session that cannot prompt, and says so' {
+        Mock Test-CanPrompt { $false }
+
+        $warnings = @(Wait-AttendedExit -TimeoutSeconds 60 3>&1)
+
+        "$($warnings -join ' ')" | Should-MatchString 'cannot prompt'
+    }
+
+    # With a keyboard the host cannot read, the hold falls out through its catch
+    # or its timeout. Either way it returns, which is the property that matters:
+    # nothing here may hang a run.
+    It 'returns within its timeout' {
+        Mock Test-CanPrompt { $true }
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+        Wait-AttendedExit -TimeoutSeconds 1 3>$null 6>$null
+
+        $sw.Elapsed.TotalSeconds | Should-BeLessThan 10
+    }
+}
+
+Describe 'The attended hold' -Tag 'Static' {
+
+    BeforeAll {
+        $script:Source = Get-Content (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    # After the summary so there is something to read; before the transcript
+    # closes so the hold is on record.
+    It 'sits after the Finished line and before the transcript closes' {
+        $hold     = $script:Source.IndexOf('Wait-AttendedExit -TimeoutSeconds $holdSeconds')
+        $finished = $script:Source.IndexOf('Write-Host "Finished $(Get-Date)')
+        $close    = $script:Source.LastIndexOf('Stop-Transcript')
+
+        $hold | Should-BeGreaterThan $finished
+        $hold | Should-BeLessThan $close
+    }
+
+    It 'is bounded by -PromptTimeoutSeconds when given, and ten minutes otherwise' {
+        $script:Source | Should-MatchString ([regex]::Escape("if (`$PSBoundParameters.ContainsKey('PromptTimeoutSeconds')) { `$PromptTimeoutSeconds } else { 600 }"))
+    }
+
+    It 'only holds when -Attended was passed' {
+        $script:Source | Should-MatchString ([regex]::Escape('if ($Attended) {'))
     }
 }
 


### PR DESCRIPTION
-Attended holds the window after the summary until a key is pressed, bounded by -PromptTimeoutSeconds or ten minutes; a task carrying it in -ExtraArgument is warned at registration. -Notify stays a switch (existing tasks pass it bare) but not passing it now means on; -Notify:$false turns it off. A default that finds no BurntToast notes it in one line and offers no install, so it cannot nag. Suite: 857 passed, 0 failed. Closes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)