### PR TITLE
Say when the previous run did not finish, and print the task time limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,22 @@ The module writes logs to the first writable location among `%USERPROFILE%`,
 Many CLIs write ordinary progress to stderr, so a step earns `Warning` only when
 PowerShell itself raises an error record.
 
+### A run that did not finish
+
+A run stopped by the task's execution time limit, or by a window closed early,
+dies mid-step: its transcript has a start line and no summary. The next run
+reads the newest previous transcript and, when it ends that way, says so at the
+top:
+
+```
+WARNING: The previous run, started 09/02/2026 03:00:12, did not finish; its last
+step was 'Windows Update'. A run stopped at the task's time limit, or by a closed
+window, ends this way. See C:\Users\you\UpdateLogs\Update-Everything-20260902-030012.log
+```
+
+Registering a task prints the limit alongside the schedule, and
+`-ExecutionTimeLimitHours` changes it.
+
 ### An error appears twice in the transcript
 
 One error, two identical blocks in `Update-Everything-<timestamp>.log`. **This is
@@ -750,7 +766,7 @@ while the machine was off happens shortly after your next logon.
 | `RunOnlyIfNetworkAvailable` | on | Nothing to update without a network. |
 | Battery | won't start, stops if unplugged | A full pass is heavy. Override with `-AllowBattery`. |
 | `RandomDelay` | 15 min | Spreads the start time. Set with `-RandomDelayMinutes`. |
-| `ExecutionTimeLimit` | 2 hours | A wedged installer would otherwise hold the task open until reboot. |
+| `ExecutionTimeLimit` | 2 hours | A wedged installer would otherwise hold the task open until reboot. Set with `-ExecutionTimeLimitHours`; the next run reports a run this stopped. |
 | `MultipleInstances` | `IgnoreNew` | A second run would fight the first for the same managers and logs. |
 | `RestartCount` / `RestartInterval` | 2 / 30 min | Transient network failures are the common case. |
 | `WakeToRun` | off | `StartWhenAvailable` picks it up once the machine is awake. |

--- a/src/Private/Get-UnfinishedRunNote.ps1
+++ b/src/Private/Get-UnfinishedRunNote.ps1
@@ -1,0 +1,64 @@
+﻿function Get-UnfinishedRunNote {
+    <#
+        .SYNOPSIS
+        Says whether the previous run's transcript stops without finishing.
+
+        .DESCRIPTION
+        A run stopped by the task's execution time limit, or by a window closed
+        early, dies mid-step: its transcript has a start line and no summary, and
+        nothing else records that it happened. This reads the newest transcript
+        other than the current run's and returns a sentence when that transcript
+        started a run and never reached any of the lines a run ends on.
+
+        A parent that handed off to an elevated child ends on the hand-off line
+        and is not unfinished: its work went to the child's transcript. A run
+        that declined at the pre-run prompt, or could not elevate, ended on
+        purpose and says so.
+
+        .PARAMETER LogDirectory
+        Where the transcripts are.
+
+        .PARAMETER CurrentLog
+        This run's transcript, which is excluded.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)] [string] $LogDirectory,
+        [Parameter(Mandatory)] [string] $CurrentLog
+    )
+
+    # The stamp in the name sorts chronologically; LastWriteTime does not, once a
+    # transcript has been appended to by a re-opened parent.
+    $previous = Get-ChildItem -LiteralPath $LogDirectory -Filter 'Update-Everything-*.log' -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -ne $CurrentLog } |
+        Sort-Object Name -Descending |
+        Select-Object -First 1
+    if (-not $previous) { return }
+
+    $text = Get-Content -LiteralPath $previous.FullName -Raw -ErrorAction SilentlyContinue
+    if (-not $text) { return }
+
+    $started = [regex]::Match($text, 'Maintenance run started (?<when>[^|]+?)\s+\|')
+    if (-not $started.Success) { return }
+
+    # The lines a run ends on. Any one of them means the run reached its own end.
+    $ended = @(
+        'Finished \d'
+        'Elevated run finished'
+        'Handing off to an elevated run'
+        'Skipped at your request'
+        'Cannot run elevated'
+    )
+    foreach ($marker in $ended) {
+        if ($text -match $marker) { return }
+    }
+
+    $steps = [regex]::Matches($text, '=== STARTING: (?<step>.+?) ===')
+    $last = if ($steps.Count) { $steps[$steps.Count - 1].Groups['step'].Value } else { $null }
+
+    $note = "The previous run, started $($started.Groups['when'].Value.Trim()), did not finish"
+    $note += if ($last) { "; its last step was '$last'." } else { '; no step had started.' }
+    $note += " A run stopped at the task's time limit, or by a closed window, ends this way. See $($previous.FullName)"
+    $note
+}

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -236,6 +236,7 @@
     Write-Host "  Runs as  : $([Security.Principal.WindowsIdentity]::GetCurrent().Name), elevated, while logged on"
     $windowNote = if ($PromptBeforeRun) { ", prompting first (${PromptTimeoutSeconds}s to answer)" } else { '' }
     Write-Host "  Window   : ${effectiveWindowStyle}${windowNote}"
+    Write-Host "  Limit    : $ExecutionTimeLimitHours hour(s), after which Task Scheduler stops the run; the next run says so"
     Write-Host ''
     Write-Host '  The task runs only while you are logged on, so that it can show notifications.'
     Write-Host '  A run missed while the machine was off happens shortly after your next logon.'

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -460,6 +460,12 @@
         Write-Host "UpdateEverything $script:RunningVersion" -ForegroundColor Green
     }
 
+    # A run the task's time limit stopped, or a window closed early, left a
+    # transcript that simply stops. Said here, at the top of the next run, since
+    # nothing else records it.
+    $unfinished = Get-UnfinishedRunNote -LogDirectory $logDir -CurrentLog $mainLog
+    if ($unfinished) { Write-Warning $unfinished }
+
     # ---------------------------------------------------------------------------
     # 1a. What this machine actually has
     # ---------------------------------------------------------------------------

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -402,6 +402,22 @@ Describe 'Registration refusals' -Tag 'Unit' {
         "$($everything -join ' ')" | Should-MatchString 'notify nobody'
     }
 
+    # The limit is the one setting that ends a run by force, and the person
+    # registering the task is the one who can change it.
+    It 'prints the execution time limit alongside the schedule' {
+        Mock Test-IsAdministrator { $true }
+        Mock Test-NotificationModuleAvailable { $true }
+        Mock Register-ScheduledTask { [pscustomobject]@{ TaskName = $TaskName } }
+
+        # Write-Host is mocked away for this Describe, so capture what it was given.
+        $script:Printed = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { $script:Printed.Add("$Object") }
+
+        $null = Register-UpdateEverythingTask -ExecutionTimeLimitHours 3
+
+        ($script:Printed -join ' ') | Should-MatchString 'Limit\s*:\s*3 hour'
+    }
+
     # A task has nobody at the window, so -Attended in -ExtraArgument would hold
     # every run open until the hold timed out.
     It 'warns when the task would hold the window for nobody' {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -2153,6 +2153,115 @@ Describe 'The run refreshes PATH between steps' -Tag 'Static' {
     }
 }
 
+Describe 'Get-UnfinishedRunNote' -Tag 'Unit' {
+
+    # Transcripts are written by hand into TestDrive, so nothing here depends on
+    # the machine's real log directory.
+
+    BeforeEach {
+        $script:Logs = Join-Path $TestDrive ('logs-' + [guid]::NewGuid().ToString('N'))
+        $null = New-Item -ItemType Directory -Path $script:Logs
+        $script:Current = Join-Path $script:Logs 'Update-Everything-20260902-120000.log'
+        Set-Content -LiteralPath $script:Current -Value 'Maintenance run started 09/02/2026 12:00:00  |  Admin: True  |  Main Log: x'
+
+        $script:WriteLog = {
+            param($Stamp, $Lines)
+            Set-Content -LiteralPath (Join-Path $script:Logs "Update-Everything-$Stamp.log") -Value ($Lines -join [Environment]::NewLine)
+        }
+    }
+
+    It 'says nothing when there is no previous run' {
+        Get-UnfinishedRunNote -LogDirectory $script:Logs -CurrentLog $script:Current | Should-BeNull
+    }
+
+    It 'says nothing about a run that finished' {
+        & $script:WriteLog '20260902-110000' @(
+            'Maintenance run started 09/02/2026 11:00:00  |  Admin: True  |  Main Log: x'
+            '=== STARTING: Inventory ==='
+            'Finished 09/02/2026 11:05:00. Detailed logs saved to: x'
+        )
+
+        Get-UnfinishedRunNote -LogDirectory $script:Logs -CurrentLog $script:Current | Should-BeNull
+    }
+
+    It 'names the run and its last step when the transcript just stops' {
+        & $script:WriteLog '20260902-110000' @(
+            'Maintenance run started 09/02/2026 11:00:00  |  Admin: True  |  Main Log: x'
+            '=== STARTING: Inventory ==='
+            'COMPLETED: Inventory (5 s)'
+            '=== STARTING: winget (all sources) ==='
+            'Downloading...'
+        )
+
+        $note = Get-UnfinishedRunNote -LogDirectory $script:Logs -CurrentLog $script:Current
+
+        $note | Should-MatchString 'started 09/02/2026 11:00:00'
+        $note | Should-MatchString ([regex]::Escape("last step was 'winget (all sources)'"))
+        $note | Should-MatchString ([regex]::Escape('Update-Everything-20260902-110000.log'))
+    }
+
+    # A parent that handed off did its work in the child's transcript.
+    It 'does not blame a parent that handed off to an elevated child' {
+        & $script:WriteLog '20260902-110000' @(
+            'Maintenance run started 09/02/2026 11:00:00  |  Admin: False  |  Main Log: x'
+            'Handing off to an elevated run. Its transcript is a separate Update-Everything-*.log'
+        )
+
+        Get-UnfinishedRunNote -LogDirectory $script:Logs -CurrentLog $script:Current | Should-BeNull
+    }
+
+    It 'does not blame a run that was skipped at the prompt' {
+        & $script:WriteLog '20260902-110000' @(
+            'Maintenance run started 09/02/2026 11:00:00  |  Admin: True  |  Main Log: x'
+            'Skipped at your request. Nothing was changed.'
+        )
+
+        Get-UnfinishedRunNote -LogDirectory $script:Logs -CurrentLog $script:Current | Should-BeNull
+    }
+
+    # Only the newest previous transcript is read: an old unfinished run has
+    # already been reported by the run after it.
+    It 'reads only the newest previous transcript' {
+        & $script:WriteLog '20260902-100000' @(
+            'Maintenance run started 09/02/2026 10:00:00  |  Admin: True  |  Main Log: x'
+            '=== STARTING: Inventory ==='
+        )
+        & $script:WriteLog '20260902-110000' @(
+            'Maintenance run started 09/02/2026 11:00:00  |  Admin: True  |  Main Log: x'
+            'Finished 09/02/2026 11:05:00. Detailed logs saved to: x'
+        )
+
+        Get-UnfinishedRunNote -LogDirectory $script:Logs -CurrentLog $script:Current | Should-BeNull
+    }
+
+    It 'ignores the current run, which has not finished yet either' {
+        Get-UnfinishedRunNote -LogDirectory $script:Logs -CurrentLog $script:Current | Should-BeNull
+    }
+}
+
+Describe 'The run reports a previous run that did not finish' -Tag 'Static' {
+
+    BeforeAll {
+        $script:Source = Get-Content `
+            (Join-Path (Split-Path $PSScriptRoot -Parent) 'src\Public\Update-Everything.ps1') -Raw
+    }
+
+    # At the top of the run, after the banner and before the first step, where
+    # a person reading the transcript looks first.
+    It 'asks after the banner and before the first step' {
+        $note   = $script:Source.IndexOf('Get-UnfinishedRunNote -LogDirectory $logDir -CurrentLog $mainLog')
+        $banner = $script:Source.IndexOf('Write-Host "Maintenance run started')
+        $first  = $script:Source.IndexOf("Invoke-Step -Name 'Inventory'")
+
+        $note | Should-BeGreaterThan $banner
+        $note | Should-BeLessThan $first
+    }
+
+    It 'says it as a warning, so it stands out in the transcript' {
+        $script:Source | Should-MatchString ([regex]::Escape('if ($unfinished) { Write-Warning $unfinished }'))
+    }
+}
+
 Describe 'Step order' -Tag 'Static' {
 
     # The order is a contract, not a preference, so it is asserted rather than


### PR DESCRIPTION
Get-UnfinishedRunNote reads the newest previous transcript and warns at the top of the run when it started and never reached a line a run ends on, naming its last step and the file; hand-offs, prompt skips and refused elevations are not blamed. Registration prints the execution time limit alongside the schedule. The per-step timeout is split out as #128. Suite: 868 passed, 0 failed. Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)