### PR TITLE
Prepare 1.8.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -595,7 +595,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.7.3 -m "1.7.3" && git push origin v1.7.3
+git tag -a v1.8.0 -m "1.8.0" && git push origin v1.8.0
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -299,13 +299,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.7.3
+UpdateEverything 1.8.0
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.7.3 is running, which is the newest published version.
+UpdateEverything 1.8.0 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network

--- a/src/UpdateEverything.psd1
+++ b/src/UpdateEverything.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'UpdateEverything.psm1'
-    ModuleVersion     = '1.7.3'
+    ModuleVersion     = '1.8.0'
     GUID              = 'e4e1f3eb-5967-4311-94af-c650fe192e95'
     Author            = 'Brian Kronberg'
     Copyright         = '(c) 2026 Brian Kronberg. Released under the MIT License.'
@@ -33,30 +33,48 @@
             Tags         = @('Windows', 'Update', 'Maintenance', 'winget', 'WindowsUpdate', 'Chocolatey', 'Scoop', 'ScheduledTask', 'PSEdition_Desktop', 'PSEdition_Core')
             LicenseUri   = 'https://github.com/briankronberg/UpdateEverything/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/briankronberg/UpdateEverything'
-            ReleaseNotes = '# 1.7.3
+            ReleaseNotes = '# 1.8.0
 
-Fixes from a full run of 1.7.2 on a live machine.
+Three additions from comparing this module with a smaller daily-update
+script, and one fix since 1.7.3.
 
-## The Terminal default stays where you put it
+## Notifications are on by default
 
-Windows Terminal generates one PowerShell 7 profile per pwsh install it has
-seen, so a machine that moved from the Store package to the MSI has two. The
-Terminal-default step compared against the first one only and moved a
-default that already named the second, on every run. It now recognises any
-pwsh profile -- generated or hand-written, by GUID or by name -- and leaves
-a default that points at one alone.
+A run now raises its toasts without being asked. -Notify:$false turns them
+off. -Notify stays a switch, so every task registered by an earlier version
+keeps working unchanged; what changed is that not passing it means on. When
+BurntToast is not installed and -Notify was not passed, the closing summary
+says so in one line and offers nothing for install, so the default cannot
+nag. A run that passed -Notify keeps the warning and the consent prompt.
 
-## The inventory reports every version it can
+## -Attended holds the window
 
-The Python install manager prints its version at the head of help and
-nothing for --version, so help is what gets asked. wsl.exe writes UTF-16,
-which used to arrive unreadable; it is now read as what it is, so WSL shows
-its version too.
+A run started from a shortcut or a Start-menu pin closes its window before
+the summary can be read. -Attended holds it until a key is pressed, and
+closes on its own after -PromptTimeoutSeconds when given, otherwise ten
+minutes. The default stays unattended; a task carrying -Attended in
+-ExtraArgument is warned at registration.
 
-## Windows Update says what it found
+## PATH is refreshed between steps
 
-When the scan offers nothing, the step says so, and names whether Microsoft
-Update was part of the scan, instead of finishing in silence.
+A step that installs a manager changes the machine or user PATH, and the
+process used to keep the PATH it started with, so the new tool was found by
+the next run. The run now re-reads both hives after each step and says
+"PATH gained: ..." when there is anything to say. Entries this session added
+itself stay in front.
+
+## A run that did not finish is reported
+
+A run stopped by the task execution time limit, or by a closed window, left
+a transcript that simply stopped. The next run reads it and warns at the
+top, naming when it started, its last step and the file. Registering a task
+prints the time limit alongside the schedule.
+
+## Fixes
+
+The Inventory row for WSL read as garbage inside a run: wsl.exe writes
+UTF-16 from a bare shell and single-byte text inside a run. The probe now
+sets WSL_UTF8=1 for the one call, which makes it write UTF-8 in both.
 '
 
         }


### PR DESCRIPTION
Manifest 1.8.0 with release notes for #123, #124, #125 and the WSL probe fix (#121). README samples and the CONTRIBUTING tag example follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)