### PR TITLE
Give each step a budget: -StepTimeoutMinutes stops a hung steps children

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ thing that crosses a process boundary.
 | `-Tag` | *(all)* | Run only the steps carrying one of these tags. Everything else is reported as skipped. |
 | `-ExcludeTag` | *(none)* | Run everything except the steps carrying one of these tags. Exclusion wins when both are given. |
 | `-LogRetentionDays` | `30` | Prune logs and settings.json backups older than this. `0` keeps everything. |
+| `-StepTimeoutMinutes` | `0` | Stop a step's child processes after this long and fail the step alone, so the run still reaches its summary. `0` means no per-step limit. |
 | `-UpdateSelf` | off | Update this module through `Update-Module` and run nothing else. `-Tag`/`-ExcludeTag` are ignored; no UAC prompt is raised, and an all-users copy is reported as needing an elevated session. Takes effect on the **next** run: the module is already loaded, so the files change and the running code does not. |
 | `-UpdateSelfSource` | `Gallery` | Where `-UpdateSelf` gets it from. `Gallery` is the newest published release; `Main` is the development head, fetched from GitHub. |
 
@@ -672,6 +673,26 @@ After the summary the window waits for a key, and closes on its own after
 `-PromptTimeoutSeconds` when that is given, otherwise ten minutes. The default
 is unattended: a scheduled task never passes `-Attended`, and one that carries
 it in `-ExtraArgument` is warned at registration.
+
+## Step timeouts
+
+A step that hangs -- a `winget` waiting on a dialog nobody sees -- runs until
+Task Scheduler stops the whole process at the execution time limit, with no
+summary, no toast and no reboot check. `-StepTimeoutMinutes` puts a budget on
+each step instead:
+
+```powershell
+Update-Everything -StepTimeoutMinutes 30
+Register-UpdateEverythingTask -Cadence Weekly -StepTimeoutMinutes 30
+```
+
+When a step runs past it, the processes it started are stopped, the step is
+recorded as Failed with `Exceeded the step timeout of 30 minute(s); stopped:
+winget.exe (1234)`, and the run continues. Steps run in-process, so the budget
+is enforced by a watchdog thread that stops the step's child processes; a step
+that hangs inside a cmdlet in this process, such as a Windows Update scan that
+never returns, has no child to stop and is not helped. The execution time limit
+remains the backstop for that.
 
 ## Pausing before a run
 

--- a/src/Private/Get-UpdateTaskArgument.ps1
+++ b/src/Private/Get-UpdateTaskArgument.ps1
@@ -33,6 +33,8 @@ function Get-UpdateTaskArgument {
 
         [string[]] $ExcludeTag = @(),
 
+        [int] $StepTimeoutMinutes = 0,
+
         [string[]] $ExtraArgument = @()
     )
 
@@ -48,6 +50,7 @@ function Get-UpdateTaskArgument {
             $call += " -$($set.Name) " + (($set.Value | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }) -join ',')
         }
     }
+    if ($StepTimeoutMinutes -gt 0) { $call += " -StepTimeoutMinutes $StepTimeoutMinutes" }
     if ($ExtraArgument) { $call += ' ' + ($ExtraArgument -join ' ') }
 
     # The manifest, not the folder holding it. Given a directory, Import-Module

--- a/src/Private/Invoke-Step.ps1
+++ b/src/Private/Invoke-Step.ps1
@@ -75,6 +75,13 @@
     # Non-terminating errors still reach $stepOutput and are still counted below.
     $ErrorActionPreference = 'Continue'
 
+    # Armed only when the run asked for a step budget. See Start-StepWatchdog
+    # for what it can and cannot stop.
+    $watchdog = $null
+    if ($script:StepTimeoutSeconds -gt 0) {
+        $watchdog = Start-StepWatchdog -TimeoutSeconds $script:StepTimeoutSeconds
+    }
+
     try {
         # Reset so a cmdlet-only step can't inherit a stale exit code from an earlier native command
         $global:LASTEXITCODE = 0
@@ -110,6 +117,14 @@
             Where-Object { -not (Test-ProgressRepaint -Line $_) } |
             ForEach-Object { Write-StepLog -Path $stepLog -Raw $_; $_ } |
             Out-Host
+
+        # Checked before the exit code: a child the watchdog stopped exits with
+        # whatever code a killed process reports, and the reason is the budget.
+        if ($watchdog -and $watchdog.State.Fired) {
+            $budget = if ($watchdog.Seconds % 60 -eq 0) { "$($watchdog.Seconds / 60) minute(s)" } else { "$($watchdog.Seconds) seconds" }
+            $stopped = if ($watchdog.State.Killed.Count) { "stopped: $($watchdog.State.Killed -join ', ')" } else { 'no child process was running to stop' }
+            throw "Exceeded the step timeout of $budget; $stopped"
+        }
 
         $code = $LASTEXITCODE
         if ($null -ne $code -and $code -ne 0) {
@@ -159,6 +174,8 @@
         Write-Warning ("FAILED: $Name | $_")
         Write-StepLog -Path $stepLog -Message "FAILED | $_"
         $script:Results.Add([pscustomobject]@{ Step = $Name; Status = 'Failed'; Seconds = $secs; Log = $stepLog })
+    } finally {
+        if ($watchdog) { Stop-StepWatchdog -Watchdog $watchdog }
     }
 
     # A step that installed a manager has changed the machine or user PATH, and

--- a/src/Private/Start-StepWatchdog.ps1
+++ b/src/Private/Start-StepWatchdog.ps1
@@ -1,0 +1,90 @@
+﻿function Start-StepWatchdog {
+    <#
+        .SYNOPSIS
+        Arms a timer that stops a step's child processes when the step runs long.
+
+        .DESCRIPTION
+        Steps run in this process and close over the run's variables and this
+        module's private functions, so a step cannot be moved somewhere it could
+        be stopped from outside. What can run elsewhere is a watchdog: a second
+        runspace on its own thread that sleeps for the budget and, if it wakes
+        before Stop-StepWatchdog is called, kills every process descended from
+        this one. The hung native command -- winget, msiexec, npm -- then returns,
+        and the step fails with the reason instead of the run being stopped at
+        the task's execution time limit with no summary.
+
+        A step that hangs inside a cmdlet in this process, such as a Windows
+        Update scan that never returns, has no child to kill and is not helped.
+
+        Returns an object with State (Fired, Killed), or nothing when a runspace
+        could not be created, in which case the step runs unguarded.
+
+        .PARAMETER TimeoutSeconds
+        How long the step may run before its children are stopped.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Arms a timer in this process. What it may stop later is the step the caller is already running, and the step reports it.')]
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateRange(1, 86400)]
+        [int] $TimeoutSeconds
+    )
+
+    # Synchronized, because the watchdog thread writes and the step thread reads.
+    $state = [hashtable]::Synchronized(@{
+        Fired  = $false
+        Killed = [System.Collections.ArrayList]::Synchronized([System.Collections.ArrayList]::new())
+        Error  = $null
+    })
+
+    # Process ids from CIM are UInt32 and the parent's is Int32; compared as
+    # they arrive, nothing matches and nothing is stopped.
+    $script = {
+        param($ParentPid, $TimeoutSeconds, $State)
+        try {
+            Start-Sleep -Seconds $TimeoutSeconds
+            $State.Fired = $true
+            $all = @(Get-CimInstance Win32_Process -Property ProcessId, ParentProcessId, Name -ErrorAction Stop)
+            $seen = @{}
+            $frontier = @([int] $ParentPid)
+            $targets = @()
+            while ($frontier.Count) {
+                $next = @($all | Where-Object { [int] $_.ParentProcessId -in $frontier -and -not $seen.ContainsKey([int] $_.ProcessId) })
+                foreach ($p in $next) { $seen[[int] $p.ProcessId] = $true }
+                $targets += $next
+                $frontier = @($next | ForEach-Object { [int] $_.ProcessId })
+            }
+            foreach ($t in $targets) {
+                try {
+                    Stop-Process -Id $t.ProcessId -Force -ErrorAction Stop
+                    $null = $State.Killed.Add("$($t.Name) ($($t.ProcessId))")
+                } catch {
+                    $null = $State.Killed.Add("$($t.Name) ($($t.ProcessId)) would not stop: $($_.Exception.Message)")
+                }
+            }
+        } catch {
+            $State.Error = $_.Exception.Message
+        }
+    }
+
+    try {
+        $runspace = [runspacefactory]::CreateRunspace()
+        $runspace.Open()
+        $powershell = [powershell]::Create()
+        $powershell.Runspace = $runspace
+        $null = $powershell.AddScript($script.ToString()).AddArgument($PID).AddArgument($TimeoutSeconds).AddArgument($state)
+        $handle = $powershell.BeginInvoke()
+    } catch {
+        Write-Verbose "Could not start the step watchdog: $($_.Exception.Message)"
+        return
+    }
+
+    [pscustomobject]@{
+        State      = $state
+        PowerShell = $powershell
+        Runspace   = $runspace
+        Handle     = $handle
+        Seconds    = $TimeoutSeconds
+    }
+}

--- a/src/Private/Stop-StepWatchdog.ps1
+++ b/src/Private/Stop-StepWatchdog.ps1
@@ -1,0 +1,14 @@
+﻿function Stop-StepWatchdog {
+    # Disarms the watchdog a step finished ahead of, and releases its runspace.
+    # Stop interrupts the sleep at once, so a run pays nothing for a watchdog
+    # that never fired.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Releases a timer this module armed in this process. Nothing on the machine changes.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Watchdog
+    )
+
+    try { $Watchdog.PowerShell.Stop() }    catch { Write-Verbose "Step watchdog stop: $($_.Exception.Message)" }
+    try { $Watchdog.PowerShell.Dispose() } catch { Write-Verbose "Step watchdog dispose: $($_.Exception.Message)" }
+    try { $Watchdog.Runspace.Dispose() }   catch { Write-Verbose "Step watchdog runspace: $($_.Exception.Message)" }
+}

--- a/src/Public/Register-UpdateEverythingTask.ps1
+++ b/src/Public/Register-UpdateEverythingTask.ps1
@@ -95,6 +95,12 @@
         Stop the task if it runs longer than this. Default: 2. Without a limit,
         one wedged installer leaves the task running until the machine reboots.
 
+    .PARAMETER StepTimeoutMinutes
+        Passed to the run: how long any one step may run before its child
+        processes are stopped and the step fails alone, so the run reaches its
+        summary instead of being stopped whole at the execution time limit.
+        Default: 0, no per-step limit.
+
     .PARAMETER Force
         Replace an existing task of the same name without prompting.
 
@@ -159,6 +165,9 @@
         [ValidateRange(1, 24)]
         [int] $ExecutionTimeLimitHours = 2,
 
+        [ValidateRange(0, 1440)]
+        [int] $StepTimeoutMinutes = 0,
+
         [switch] $Force
     )
 
@@ -179,7 +188,7 @@
         -WindowStyle $effectiveWindowStyle -PromptBeforeRun:$PromptBeforeRun `
         -PromptTimeoutSeconds $PromptTimeoutSeconds `
         -AllowInstall $AllowInstall -Tag $Tag -ExcludeTag $ExcludeTag `
-        -ExtraArgument $ExtraArgument
+        -StepTimeoutMinutes $StepTimeoutMinutes -ExtraArgument $ExtraArgument
 
     # A task has nobody at the window, so an -Attended run would hold every
     # window open until the hold timed out.
@@ -237,6 +246,9 @@
     $windowNote = if ($PromptBeforeRun) { ", prompting first (${PromptTimeoutSeconds}s to answer)" } else { '' }
     Write-Host "  Window   : ${effectiveWindowStyle}${windowNote}"
     Write-Host "  Limit    : $ExecutionTimeLimitHours hour(s), after which Task Scheduler stops the run; the next run says so"
+    if ($StepTimeoutMinutes -gt 0) {
+        Write-Host "  Per step : $StepTimeoutMinutes minute(s), after which a step's child processes are stopped and the step fails alone"
+    }
     Write-Host ''
     Write-Host '  The task runs only while you are logged on, so that it can show notifications.'
     Write-Host '  A run missed while the machine was off happens shortly after your next logon.'

--- a/src/Public/Update-Everything.ps1
+++ b/src/Public/Update-Everything.ps1
@@ -207,6 +207,15 @@
         Delete logs and settings.json backups in the log directory older than this
         many days. Default: 30. Set to 0 to keep everything.
 
+    .PARAMETER StepTimeoutMinutes
+        How long any one step may run before its child processes are stopped
+        and the step is recorded as Failed, so the run goes on to its summary,
+        its toast and its reboot check instead of being stopped whole at the
+        task's execution time limit. Default: 0, no limit. Stops the native
+        commands a step started -- winget, msiexec, npm -- and not a step that
+        hangs inside a cmdlet in this process, such as a Windows Update scan
+        that never returns.
+
     .OUTPUTS
         An object describing the run:
 
@@ -263,6 +272,8 @@
         [string[]] $ExcludeTag = @(),
         [ValidateRange(0, 3650)]
         [int]    $LogRetentionDays       = 30,
+        [ValidateRange(0, 1440)]
+        [int]    $StepTimeoutMinutes     = 0,
         [switch] $UpdateSelf,
         [ValidateSet('Gallery', 'Main')]
         [string] $UpdateSelfSource = 'Gallery'
@@ -433,6 +444,9 @@
     # session started.
     $null = Update-ProcessPath
     $script:RefreshPathAfterStep = $true
+
+    # Read by Invoke-Step, which arms a watchdog per step when this is set.
+    $script:StepTimeoutSeconds = $StepTimeoutMinutes * 60
 
     # Read by Invoke-Step, which decides per step. Script scope for the same reason
     # as $script:isAdmin: a step action runs inside Invoke-Step, not here.

--- a/src/en-us/about_UpdateEverything.help.txt
+++ b/src/en-us/about_UpdateEverything.help.txt
@@ -59,6 +59,10 @@ NOTIFICATIONS
     pressed, for a run started from a shortcut. It closes on its own after
     -PromptTimeoutSeconds when given, otherwise ten minutes.
 
+    -StepTimeoutMinutes stops a step's child processes after that long and
+    fails the step alone, so the run still reaches its summary. It cannot
+    stop a step hung inside a cmdlet in this process.
+
     A task running as SYSTEM cannot show a notification, which is why
     Register-UpdateEverythingTask registers the task to run as you.
 

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -34,6 +34,7 @@ BeforeDiscovery {
         @{ Name = 'PromptTimeoutSeconds';      TypeName = 'int';      Type = [int];      Default = '60' }
         @{ Name = 'DelayMinutes';              TypeName = 'int';      Type = [int];      Default = '60' }
         @{ Name = 'LogRetentionDays';          TypeName = 'int';      Type = [int];      Default = '30' }
+        @{ Name = 'StepTimeoutMinutes';        TypeName = 'int';      Type = [int];      Default = '0' }
         @{ Name = 'UpdateSelf';                TypeName = 'switch';   Type = [switch];   Default = $null }
         @{ Name = 'UpdateSelfSource';          TypeName = 'string';   Type = [string];   Default = "'Gallery'" }
     )
@@ -493,7 +494,7 @@ Describe 'Update-Everything' -Tag 'Static' {
 
         It 'declares no parameters beyond the documented contract' {
             $script:DeclaredParameters.Name.VariablePath.UserPath |
-                Should-BeCollection -Count 19 -Because 'a new parameter needs docs and a test'
+                Should-BeCollection -Count 20 -Because 'a new parameter needs docs and a test'
         }
 
         It 'bounds -LogRetentionDays with ValidateRange' {
@@ -911,7 +912,7 @@ Describe 'Variable hygiene' -Tag 'Static' {
             # Set by the module loader, and by the caller of a private helper.
             'ModuleRoot', 'Results', 'logDir', 'runStamp', 'isAdmin', 'InstallDecision',
             'NotificationsAvailable', 'WingetNothingToDo', 'TagFilter', 'ExcludeTagFilter',
-            'RefreshPathAfterStep'
+            'RefreshPathAfterStep', 'StepTimeoutSeconds'
         )
 
         $bare = { param($p) ($p -replace '^(script|global|local|private):', '') }

--- a/tests/Register-UpdateTask.Tests.ps1
+++ b/tests/Register-UpdateTask.Tests.ps1
@@ -277,6 +277,14 @@ Describe 'Get-UpdateTaskArgument' -Tag 'Unit' {
         Get-UpdateTaskArgument -ModuleRoot 'C:\x' | Should-MatchString '-Notify'
     }
 
+    It 'passes a step timeout through when one is set' {
+        Get-UpdateTaskArgument -ModuleRoot 'C:\x' -StepTimeoutMinutes 30 | Should-MatchString '-StepTimeoutMinutes 30'
+    }
+
+    It 'leaves the step timeout out when none is set' {
+        Get-UpdateTaskArgument -ModuleRoot 'C:\x' | Should-NotMatchString '-StepTimeoutMinutes'
+    }
+
     # Update-Everything notifies by default, so leaving -Notify out would turn
     # them back on.
     It 'says notifications are off when they are turned off' {

--- a/tests/Update-Everything.Functions.Tests.ps1
+++ b/tests/Update-Everything.Functions.Tests.ps1
@@ -454,6 +454,43 @@ Describe 'Invoke-Step' -Tag 'Unit' {
         }
     }
 
+    Context 'A step that outlives its budget' {
+
+        # The budget is enforced by a watchdog on another thread that stops the
+        # step's child processes, so the hung command here is a real child:
+        # cmd running ping for half a minute.
+
+        BeforeEach { $script:StepTimeoutSeconds = 2 }
+        AfterEach  { $script:StepTimeoutSeconds = 0 }
+
+        It 'stops the child, fails the step, and says why' {
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+            Invoke-Step -Name 'slow' -Action { & cmd /c 'ping -n 30 127.0.0.1 >nul' } 3>$null 6>$null
+
+            $sw.Elapsed.TotalSeconds | Should-BeLessThan 20
+            $script:Results[0].Status | Should-Be 'Failed'
+            Get-Content (Join-Path $script:logDir 'slow-teststamp.log') -Raw |
+                Should-MatchString 'Exceeded the step timeout of 2 seconds; stopped: '
+        }
+
+        It 'leaves a step that finishes in time alone' {
+            Invoke-Step -Name 'quick' -Action { 'work' } 6>$null
+
+            $script:Results[0].Status | Should-Be 'OK'
+        }
+
+        # A budget of zero is the default and means no watchdog at all.
+        It 'arms nothing when the budget is zero' {
+            $script:StepTimeoutSeconds = 0
+            Mock Start-StepWatchdog { throw 'should not be armed' }
+
+            Invoke-Step -Name 'plain' -Action { 'work' } 6>$null
+
+            $script:Results[0].Status | Should-Be 'OK'
+        }
+    }
+
     Context 'A step whose tool is missing' {
 
         It 'skips when RequiresCommand cannot be resolved' {
@@ -2259,6 +2296,41 @@ Describe 'The run reports a previous run that did not finish' -Tag 'Static' {
 
     It 'says it as a warning, so it stands out in the transcript' {
         $script:Source | Should-MatchString ([regex]::Escape('if ($unfinished) { Write-Warning $unfinished }'))
+    }
+}
+
+Describe 'Start-StepWatchdog and Stop-StepWatchdog' -Tag 'Unit' {
+
+    It 'returns a watchdog that has not fired' {
+        $w = Start-StepWatchdog -TimeoutSeconds 60
+        try {
+            $w | Should-NotBeNull
+            $w.State.Fired | Should-BeFalse
+        } finally {
+            Stop-StepWatchdog -Watchdog $w
+        }
+    }
+
+    # Stop interrupts the sleep, so a run pays nothing for a watchdog that
+    # never fired.
+    It 'stops at once when disarmed early' {
+        $w = Start-StepWatchdog -TimeoutSeconds 60
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+        Stop-StepWatchdog -Watchdog $w
+
+        $sw.Elapsed.TotalSeconds | Should-BeLessThan 5
+        $w.State.Fired | Should-BeFalse
+    }
+
+    It 'records that it fired when the budget runs out' {
+        $w = Start-StepWatchdog -TimeoutSeconds 1
+        try {
+            Start-Sleep -Seconds 4
+            $w.State.Fired | Should-BeTrue
+        } finally {
+            Stop-StepWatchdog -Watchdog $w
+        }
     }
 }
 


### PR DESCRIPTION
A watchdog runspace on its own thread sleeps for the budget and, if the step is still running, stops every process descended from this one; the native command returns and Invoke-Step fails the step with the reason, so the run reaches its summary. Disarmed at once when a step finishes. Cannot stop a step hung inside an in-process cmdlet, which the docs say. Register-UpdateEverythingTask passes -StepTimeoutMinutes through. Suite: 882 passed, 0 failed, including a step whose real child is stopped. Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)