### PR TITLE
Prepare 1.9.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -595,7 +595,7 @@ Afterwards, tag the exact commit that was published, so the permanent version
 has something in the history pointing at it:
 
 ```bash
-git tag -a v1.8.0 -m "1.8.0" && git push origin v1.8.0
+git tag -a v1.9.0 -m "1.9.0" && git push origin v1.9.0
 ```
 
 Then cut a GitHub release at that tag, reusing the manifest's `ReleaseNotes` so

--- a/README.md
+++ b/README.md
@@ -300,13 +300,13 @@ read against the code that made it:
 
 ```
 Maintenance run started 09/01/2026 08:14  |  Admin: True  |  Main Log: ...
-UpdateEverything 1.8.0
+UpdateEverything 1.9.0
 ```
 
 The Inventory step then compares that against the gallery:
 
 ```
-UpdateEverything 1.8.0 is running, which is the newest published version.
+UpdateEverything 1.9.0 is running, which is the newest published version.
 ```
 
 The comparison lives there rather than in the banner because it costs a network


### PR DESCRIPTION
Manifest 1.9.0 with release notes for the per-step budget (#128). README samples and the CONTRIBUTING tag example follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)